### PR TITLE
Ensure Windows-1252 is a known encoding

### DIFF
--- a/lib/prawn/font/afm.rb
+++ b/lib/prawn/font/afm.rb
@@ -188,13 +188,17 @@ module Prawn
             kerned << -k << [byte]
           else
             kerned.last << byte
-          end         
+          end
           last_byte = byte
         end
 
         kerned.map { |e| 
           e = (Array === e ? e.pack("C*") : e)
-          e.respond_to?(:force_encoding) ? e.force_encoding("Windows-1252") : e  
+          # Only force encoding if we know about Windows-1252:
+          # WriteExcel creates an Encoding-compatibility layer in Ruby 1.8
+          # but it doesn't know about Windows-1252, so it woulc break this
+          e.respond_to?(:force_encoding) && Encoding::Windows_1252 ? 
+            e.force_encoding("Windows-1252") : e
         }
       end
 


### PR DESCRIPTION
WriteExcel, when running in Ruby 1.8, defines an encoding-compatibility layer; however it only supports a small handful of character sets. As a result, when WriteExcel and Prawn are running together, the respond_to would pass but an exception would be raised on the unknown Windows-1252 character set. This patch enables compatibility with WriteExcel and (hopefully) any other half-assed encoding compatibility system for 1.8.
