### PR TITLE
Indent_paragraphs bug with empty paragraphs producing page breaks

### DIFF
--- a/lib/prawn/text.rb
+++ b/lib/prawn/text.rb
@@ -147,6 +147,7 @@ module Prawn
 
       if @indent_paragraphs
         string.split("\n").each do |paragraph|
+          paragraph << "\n" if paragraph.empty?
           options[:skip_encoding] = false
           remaining_text = draw_indented_line(paragraph, options)
           options[:skip_encoding] = true

--- a/spec/text_spec.rb
+++ b/spec/text_spec.rb
@@ -345,5 +345,17 @@ describe "#text" do
         text.strings[4].should == ("hello " * 21).strip
       end
     end
+    describe "when a paragraphs are separated by by a new line" do
+      it "should not create multiple pages" do
+        @pdf.text("Paragraph 1\n\nParagraph 2", :indent_paragraphs => 10)
+        text = PDF::Inspector::Page.analyze(@pdf.render)
+        text.pages.size.should == 1
+      end
+      it "should separate the paragraphs by a new line" do
+        @pdf.text("Paragraph 1\n\nParagraph 2", :indent_paragraphs => 10)
+        text = PDF::Inspector::Text.analyze(@pdf.render)
+        text.strings.size.should == 3
+      end
+    end
   end
 end


### PR DESCRIPTION
This will detect empty paragraphs and replace them with newlines. Will then appropriately render empty paragraphs.
