### PR TITLE
Fixes #177

### DIFF
--- a/lib/prawn/text/formatted/box.rb
+++ b/lib/prawn/text/formatted/box.rb
@@ -192,7 +192,7 @@ module Prawn
                                     :Border => [0, 0, 0],
                                     :A => { :Type => :Action,
                                             :S => :URI,
-                                            :URI => fragment.link })
+                                            :URI => Prawn::Core::LiteralString.new(fragment.link) })
         end
 
         def draw_fragment_overlay_anchor(fragment)


### PR DESCRIPTION
Added Prawn::Core::LiteralString.new to draw_fragment_overlay_link to ensure links are literal encoded rather than PDF hex.

I ran the specs and checked examples/text/inline_format.rb to test.
