### PR TITLE
allow :template to be a stream as well as a filename

### DIFF
--- a/lib/prawn/core/object_store.rb
+++ b/lib/prawn/core/object_store.rb
@@ -143,12 +143,12 @@ module Prawn
 
       # takes a source PDF and uses it as a template for this document.
       #
-      def load_file(filename)
-        unless File.file?(filename)
-          raise ArgumentError, "#{filename} does not exist"
+      def load_file(template)
+        unless (template.respond_to?(:seek) && template.respond_to?(:read)) || File.file?(template) 
+          raise ArgumentError, "#{template} does not exist"
         end
 
-        hash = PDF::Reader::ObjectHash.new(filename)
+        hash = PDF::Reader::ObjectHash.new(template)
         src_info = hash.trailer[:Info]
         src_root = hash.trailer[:Root]
         @min_version = hash.pdf_version.to_f

--- a/spec/object_store_spec.rb
+++ b/spec/object_store_spec.rb
@@ -157,4 +157,14 @@ describe "Prawn::ObjectStorie#object_id_for_page" do
     store = Prawn::Core::ObjectStore.new
     store.object_id_for_page(10).should == nil
   end
+  
+  it "should accept a stream instead of a filename" do
+    example = Prawn::Document.new()
+    example.text "An example doc, created in memory"
+    example.start_new_page
+    StringIO.open(example.render) do |stream|
+      @pdf = Prawn::Core::ObjectStore.new(:template => stream)
+    end
+    @pdf.page_count.should == 2
+  end
 end


### PR DESCRIPTION
Currently the :template option of Prawn::Document.new only accepts filenames.  In some cases (such as when the PDF is already in memory), it would be more convenient to pass in a stream-like object to use as a template instead.  This is an easy fix, since PDF::Reader::ObjectHash.new already accepts either a String or stream-like object.
