### PR TITLE
Shortcuts move

### DIFF
--- a/lib/prawn/graphics.rb
+++ b/lib/prawn/graphics.rb
@@ -327,6 +327,25 @@ module Prawn
       add_content "h"
     end
 
+    # Provides the following shortcuts:
+    #
+    #    stroke_some_method(*args) #=> some_method(*args); stroke
+    #    fill_some_method(*args) #=> some_method(*args); fill
+    #    fill_and_stroke_some_method(*args) #=> some_method(*args); fill_and_stroke
+    #
+    def method_missing(id,*args,&block)
+      case(id.to_s)
+      when /^fill_and_stroke_(.*)/
+        send($1,*args,&block); fill_and_stroke
+      when /^stroke_(.*)/
+        send($1,*args,&block); stroke
+      when /^fill_(.*)/
+        send($1,*args,&block); fill
+      else
+        super
+      end
+    end
+
     private
     
     def current_line_width

--- a/lib/prawn/graphics/color.rb
+++ b/lib/prawn/graphics/color.rb
@@ -54,25 +54,6 @@ module Prawn
 
       alias_method :stroke_color=, :stroke_color
 
-      # Provides the following shortcuts:
-      #
-      #    stroke_some_method(*args) #=> some_method(*args); stroke
-      #    fill_some_method(*args) #=> some_method(*args); fill
-      #    fill_and_stroke_some_method(*args) #=> some_method(*args); fill_and_stroke
-      #
-      def method_missing(id,*args,&block)
-        case(id.to_s)
-        when /^fill_and_stroke_(.*)/
-          send($1,*args,&block); fill_and_stroke
-        when /^stroke_(.*)/
-          send($1,*args,&block); stroke
-        when /^fill_(.*)/
-          send($1,*args,&block); fill
-        else
-          super
-        end
-      end
-
       module_function
 
       # Converts RGB value array to hex string suitable for use with fill_color


### PR DESCRIPTION
I spent some time searching for the definition of the stroke_circle, used in the first manual example. I expected it to be a generic stroke_\* method but I couldn't find where it was defined or how (probably a loop or a method_missing). I was surprised to finally find it in color.rb. I expected it to be defined near the fill and stroke methods, in graphics.rb. So, I moved it there in this commit.
