### PR TITLE
Support uppercase TTF file extension 

### DIFF
--- a/lib/prawn/font.rb
+++ b/lib/prawn/font.rb
@@ -240,7 +240,7 @@ module Prawn
     #
     def self.load(document,name,options={})
       case name
-      when /\.ttf$/   then TTF.new(document, name, options)
+      when /\.ttf$/, /\.TTF$/ then TTF.new(document, name, options)
       when /\.dfont$/ then DFont.new(document, name, options)
       when /\.afm$/   then AFM.new(document, name, options)
       else                 AFM.new(document, name, options)


### PR DESCRIPTION
I have several true type fonts which are abbreviated to a 8.3 filename scheme and have TTF as extension. 
I added an additional when clause in font.rb to support that. Maybe that's of use for someone else.

Regards,
Dominik.
