### PR TITLE
Fix to indentation across page breaks

### DIFF
--- a/lib/prawn/document.rb
+++ b/lib/prawn/document.rb
@@ -570,7 +570,13 @@ module Prawn
         :width => page.dimensions[-2] - (page.margins[:left] + page.margins[:right]),
         :height => page.dimensions[-1] - (page.margins[:top] + page.margins[:bottom])
       )
-
+      
+      # This check maintains indentation settings across page breaks
+      if (old_margin_box)
+        @margin_box.add_left_padding(old_margin_box.total_left_padding)
+        @margin_box.add_right_padding(old_margin_box.total_right_padding)
+      end
+      
       # we must update bounding box if not flowing from the previous page
       #
       # FIXME: This may have a bug where the old margin is restored

--- a/lib/prawn/document/bounding_box.rb
+++ b/lib/prawn/document/bounding_box.rb
@@ -210,7 +210,9 @@ module Prawn
         @parent = parent
         @x, @y = point
         @width, @height = options[:width], options[:height]
-	      @stretched_height = nil
+        @total_left_padding = 0
+        @total_right_padding = 0
+        @stretched_height = nil
       end
 
       attr_reader :document, :parent
@@ -249,12 +251,48 @@ module Prawn
       #  end
       #
       def indent(left_padding, right_padding = 0, &block)
-        @x += left_padding
-        @width -= (left_padding + right_padding)
+        self.add_left_padding(left_padding)
+        self.add_right_padding(right_padding)
         yield
       ensure
+        self.subtract_left_padding(left_padding)
+        self.subtract_right_padding(right_padding)
+      end
+      
+      # The current indentation of the left side of the bounding box.
+      def total_left_padding
+        @total_left_padding
+      end
+      
+      # The current indentation of the right side of the bounding box.
+      def total_right_padding
+        @total_right_padding
+      end
+      
+      # Increase the left padding of the bounding box.
+      def add_left_padding(left_padding)
+        @total_left_padding += left_padding
+        @x += left_padding
+        @width -= left_padding
+      end
+      
+      # Decrease the left padding of the bounding box.
+      def subtract_left_padding(left_padding)
+        @total_left_padding -= left_padding
         @x -= left_padding
-        @width += (left_padding + right_padding)
+        @width += left_padding
+      end
+      
+      # Increase the right padding of the bounding box.
+      def add_right_padding(right_padding)
+        @total_right_padding += right_padding
+        @width -= right_padding
+      end
+      
+      # Decrease the right padding of the bounding box.
+      def subtract_right_padding(right_padding)
+        @total_right_padding -= right_padding
+        @width += right_padding
       end
       
       # Relative right x-coordinate of the bounding box. (Equal to the box width)

--- a/spec/bounding_box_spec.rb
+++ b/spec/bounding_box_spec.rb
@@ -174,6 +174,28 @@ describe "Indentation" do
       end
     end
   end
+  
+  it "should maintain left indentation across a page break" do
+    original_left = @pdf.bounds.absolute_left
+    
+    @pdf.indent(20) do
+      @pdf.bounds.absolute_left.should == original_left + 20
+      @pdf.start_new_page
+      @pdf.bounds.absolute_left.should == original_left + 20
+    end
+    
+  end
+  
+  it "should maintain right indentation across a page break" do
+    original_width = @pdf.bounds.width
+    
+    @pdf.indent(0, 20) do
+      @pdf.bounds.width.should == original_width - 20
+      @pdf.start_new_page
+      @pdf.bounds.width.should == original_width - 20
+    end
+    
+  end
 
   it "optionally allows adjustment of the right bound as well" do
     @pdf.bounding_box([100,100], :width => 200) do
@@ -196,5 +218,4 @@ describe "A canvas" do
     end
     @pdf.y.should == 450
   end
-end      
-  
+end


### PR DESCRIPTION
I ran into an issue where indentation is lost when a new page is started in a document (it looks like it has existed for a while at https://github.com/sandal/prawn/issues/#issue/86 )

Basically I added instance variables to track the left and right padding (saw that was just added), and set those variables again when a new margin box is created in the document (in generate_margin_box).
