### PR TITLE
Fix ColumnBox indentation on columns 2+

### DIFF
--- a/lib/prawn/document/column_box.rb
+++ b/lib/prawn/document/column_box.rb
@@ -110,6 +110,17 @@ module Prawn
         end
       end
 
+      # BoundingBox#indent modifies @width, which doesn't work past column one.
+      # If we just modify the spacing, we get the same effect.
+      def indent(left_padding, &block)
+        @x += left_padding
+        @spacer += left_padding
+        yield
+      ensure
+        @x -= left_padding
+        @spacer -= left_padding
+      end
+
     end
   end
 end


### PR DESCRIPTION
ColumnBox#indent doesn't indent properly past the first column, which this fixes. Also I found it generally useful to be able to introspect the current column_box from the document.

I'm not sure what the appropriate way to test this is. Can something be done with pdf_reader, or is there some "done" way of testing changes like this?
