### PR TITLE
fixed wrapping bug in text boxes with leading

### DIFF
--- a/lib/prawn/core/text/formatted/wrap.rb
+++ b/lib/prawn/core/text/formatted/wrap.rb
@@ -107,7 +107,7 @@ module Prawn
             if @baseline_y == 0
               diff = @ascender + @descender
             else
-              diff = @descender + @line_height
+              diff = @descender + @line_height + @leading
             end
             required_total_height = @baseline_y.abs + diff
             if required_total_height > @height + 0.0001

--- a/spec/text_box_spec.rb
+++ b/spec/text_box_spec.rb
@@ -522,6 +522,73 @@ describe "Text::Box with text than can fit in the box" do
   end
 end
 
+describe "Text::Box with text that fits exactly in the box" do
+  before(:each) do
+    create_pdf
+    @lines = 3
+    @interlines = @lines - 1
+    @text = (1..@lines).to_a.join("\n")
+    @options = {
+      :width => 162.0,
+      :height => @pdf.font.ascender + @pdf.font.height * @interlines + @pdf.font.descender,
+      :document => @pdf
+    }
+  end
+  
+  it "should have the expected height" do
+    expected_height = @options.delete(:height)
+    text_box = Prawn::Text::Box.new(@text, @options)
+    text_box.render
+    text_box.height.should.be.close(expected_height, 0.0001)
+  end
+
+  it "should print everything" do
+    text_box = Prawn::Text::Box.new(@text, @options)
+    text_box.render
+    text_box.text.should == @text
+  end
+
+  describe "with leading" do
+    before(:each) do
+      @options[:leading] = 15
+    end
+
+    it "should not overflow when enough height is added" do
+      @options[:height] += @options[:leading] * @interlines
+      text_box = Prawn::Text::Box.new(@text, @options)
+      text_box.render
+      text_box.text.should == @text
+    end
+
+    it "should overflow when insufficient height is added" do
+      @options[:height] += @options[:leading] * @interlines - 1
+      text_box = Prawn::Text::Box.new(@text, @options)
+      text_box.render
+      text_box.text.should.not == @text
+    end
+  end
+
+  describe "with negative leading" do
+    before(:each) do
+      @options[:leading] = -4
+    end
+
+    it "should not overflow when enough height is removed" do
+      @options[:height] += @options[:leading] * @interlines
+      text_box = Prawn::Text::Box.new(@text, @options)
+      text_box.render
+      text_box.text.should == @text
+    end
+
+    it "should overflow when too much height is removed" do
+      @options[:height] += @options[:leading] * @interlines - 1
+      text_box = Prawn::Text::Box.new(@text, @options)
+      text_box.render
+      text_box.text.should.not == @text
+    end
+  end
+end
+
 describe "Text::Box printing UTF-8 string with higher bit characters" do
   before(:each) do
     create_pdf    


### PR DESCRIPTION
Hello,

There's a bug with wrapping when text boxes have a positive or negative leading, illustrated in this example: https://github.com/piglop/prawn/blob/text_box_with_leading_example/examples/text/text_box_with_leading.rb

The leading is considered when the cursor is moved down in <code>Prawn::Text::Formatted::Box#move_baseline_down</code> but not when the available space is checked in <code>Prawn::Core::Text::Formatted::Wrap#enough_height_for_this_line?</code>

The fix was easy once located. All specs pass, but I'm not certain <code>@leading</code> is always available in <code>Wrap#enough_height_for_this_line?</code>

I tried to write understandable specs, but the visual example is probably more clear (I didn't include it in the pull request though).
