### PR TITLE
update gemspec to latest specification

### DIFF
--- a/prawn.gemspec
+++ b/prawn.gemspec
@@ -13,7 +13,6 @@ Gem::Specification.new do |spec|
   spec.required_rubygems_version = ">= 1.3.6"
 
   spec.test_files = Dir[ "spec/*_spec.rb" ]
-  spec.has_rdoc = true
   spec.extra_rdoc_files = %w{HACKING README LICENSE COPYING}
   spec.rdoc_options << '--title' << 'Prawn Documentation' <<
                        '--main'  << 'README' << '-q'


### PR DESCRIPTION
Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed on or after 2011-10-01.
