### PR TITLE
Accept Pathname instance as font name

### DIFF
--- a/lib/prawn/font.rb
+++ b/lib/prawn/font.rb
@@ -52,7 +52,7 @@ module Prawn
         raise Prawn::Errors::NotOnPage 
       end
       
-      new_font = find_font(name, options)
+      new_font = find_font(name.to_s, options)
 
       if block_given?
         save_font do

--- a/spec/text_spec.rb
+++ b/spec/text_spec.rb
@@ -256,6 +256,12 @@ describe "#text" do
   it "should raise an exception when an unknown font is used" do
     lambda { @pdf.font "Pao bu" }.should.raise(Prawn::Errors::UnknownFont)
   end
+  
+  it "should not raise an exception when providing Pathname instance as font" do
+    lambda {
+      @pdf.font Pathname.new("#{Prawn::BASEDIR}/data/fonts/comicsans.ttf")
+    }.should.not.raise(Prawn::Errors::UnknownFont)
+  end
 
   it "should correctly render a utf-8 string when using a built-in font" do
     str = "©" # copyright symbol


### PR DESCRIPTION
While using Prawn with Rails, I notice that Pathname instances wasn't recognizing a given font since it wasn't a string, so something like `pdf.font Rails.root.join("fonts/myfont.ttf")` was raising an exception.

This patch fixes this issue.
