### PR TITLE
Fix slow method used in PDF generation

### DIFF
--- a/lib/prawn/font/afm.rb
+++ b/lib/prawn/font/afm.rb
@@ -210,8 +210,11 @@ module Prawn
       end
 
       def latin_kern_pairs_table
-        @kern_pairs_table ||= @kern_pairs.inject({}) do |h,p|
-          h[p[0].map { |n| Encoding::WinAnsi::CHARACTERS.index(n) }] = p[1]
+        return @kern_pairs_table if defined?(@kern_pairs_table)
+        
+        character_hash = Hash[Encoding::WinAnsi::CHARACTERS.zip((0..Encoding::WinAnsi::CHARACTERS.size).to_a)]
+        @kern_pairs_table = @kern_pairs.inject({}) do |h,p|
+          h[p[0].map { |n| character_hash[n] }] = p[1]
           h
         end
       end


### PR DESCRIPTION
While profiling my PDF generation to increase the speed they were generated I bumped into this method that adds 0.15s to the total time (on my machine).

Array#index was called ~ 10k times, and was a real bottleneck. This change fixes that, and when running the specs on my machine shaves of ~20 seconds.
