### PR TITLE
Fixed NoMethodError in line_wrap.rb in Unicode encoding

### DIFF
--- a/lib/prawn/core/text/formatted/line_wrap.rb
+++ b/lib/prawn/core/text/formatted/line_wrap.rb
@@ -203,7 +203,8 @@ module Prawn
             @previous_fragment = @fragment_output.dup
             pf = @previous_fragment
             @previous_fragment_ended_with_breakable = pf =~ /[#{break_chars}]$/
-            last_word_length = pf.slice(/[^#{break_chars}]*$/).length
+            last_word = pf.slice(/[^#{break_chars}]*$/)
+            last_word_length = last_word.nil? ? 0 : last_word.length
             @previous_fragment_output_without_last_word = pf.slice(0, pf.length - last_word_length)
           end
 

--- a/spec/formatted_text_box_spec.rb
+++ b/spec/formatted_text_box_spec.rb
@@ -75,6 +75,46 @@ describe "Text::Formatted::Box wrapping" do
     text_box.render
     text_box.text.should == "Hello World\n2"
   end
+
+  it "should properly handle empty slices using default encoding" do
+    texts = [{ :text => "Noua Delineatio Geographica generalis | Apostolicarum peregrinationum | S FRANCISCI XAUERII | Indiarum & Iaponiæ Apostoli", :font => 'Courier', :size => 10 }]
+    text_box = Prawn::Text::Formatted::Box.new(texts, :document => @pdf, :width => @pdf.width_of("Noua Delineatio Geographica gen"))
+    assert_nothing_raised do
+      text_box.render
+    end
+    text_box.text.should == "Noua Delineatio Geographica\ngeneralis | Apostolicarum\nperegrinationum | S FRANCISCI\nXAUERII | Indiarum & Iaponi\346\nApostoli"
+  end
+  
+  describe "Unicode" do
+    before do
+      if RUBY_VERSION < '1.9'
+        @reset_value = $KCODE
+        $KCODE='u'
+      else
+        @reset_value = [Encoding.default_external, Encoding.default_internal]
+        Encoding.default_external = Encoding::UTF_8
+        Encoding.default_internal = Encoding::UTF_8
+      end
+    end
+    
+    after do
+      if RUBY_VERSION < '1.9'
+        $KCODE=@reset_value
+      else
+        Encoding.default_external = @reset_value[0]
+        Encoding.default_internal = @reset_value[1]
+      end
+    end
+
+    it "should properly handle empty slices using Unicode encoding" do
+      texts = [{ :text => "Noua Delineatio Geographica generalis | Apostolicarum peregrinationum | S FRANCISCI XAUERII | Indiarum & Iaponiæ Apostoli", :font => 'Courier', :size => 10 }]
+      text_box = Prawn::Text::Formatted::Box.new(texts, :document => @pdf, :width => @pdf.width_of("Noua Delineatio Geographica gen"))
+      assert_nothing_raised do
+        text_box.render
+      end
+      text_box.text.should == "Noua Delineatio Geographica\ngeneralis | Apostolicarum\nperegrinationum | S FRANCISCI\nXAUERII | Indiarum & Iaponi\346\nApostoli"
+    end
+  end
 end
 
 describe "Text::Formatted::Box with :fallback_fonts option that includes" +


### PR DESCRIPTION
The behavior of String#slice() differs slightly between the default encoding and Unicode (`$KCODE=='u'`), returning `nil` instead of `""` when there is no match. That was causing a NoMethodError on `pf.slice(/[^#{break_chars}]*$/).length`. I've included two new spec tests (one for the default encoding, and one for Unicode) and a two-line fix. All tests pass.
