### PR TITLE
Simple fix for an issue related to security fixes in ActiveSupport 3.0.9 (Cannot modify SafeBuffer in place)

### DIFF
--- a/lib/prawn/core/text/formatted/line_wrap.rb
+++ b/lib/prawn/core/text/formatted/line_wrap.rb
@@ -39,7 +39,7 @@ module Prawn
             while fragment = @arranger.next_string
               @fragment_output = ""
 
-              fragment = fragment.lstrip if first_fragment_on_this_line?(fragment)
+              fragment.to_s.lstrip! if first_fragment_on_this_line?(fragment)
               next if empty_line?(fragment)
 
               unless apply_font_settings_and_add_fragment_to_line(fragment)


### PR DESCRIPTION
fixed issue where line wrapping leads to an exception "Cannot modify SafeBuffer in place" - problem only occurs if activesupport 3.0.9 is loaded (w.r.t. security fix in rails 3.0.9)
