### PR TITLE
added ability to scale background image

### DIFF
--- a/lib/prawn/document.rb
+++ b/lib/prawn/document.rb
@@ -136,6 +136,7 @@ module Prawn
     # <tt>:compress</tt>:: Compresses content streams before rendering them [false]
     # <tt>:optimize_objects</tt>:: Reduce number of PDF objects in output, at expense of render time [false]
     # <tt>:background</tt>:: An image path to be used as background on all pages [nil]
+    # <tt>:background_scale</tt>:: Backgound image scale [1] [nil]
     # <tt>:info</tt>:: Generic hash allowing for custom metadata properties [nil]
     # <tt>:template</tt>:: The path to an existing PDF file to use as a template [nil]
     #
@@ -185,6 +186,7 @@ module Prawn
       min_version(state.store.min_version) if state.store.min_version
 
       @background = options[:background]
+      @background_scale = options[:background_scale] || 1
       @font_size  = 12
 
       @bounding_box  = nil
@@ -277,7 +279,7 @@ module Prawn
         state.insert_page(state.page, @page_number)
         @page_number += 1
 
-        canvas { image(@background, :at => bounds.top_left) } if @background
+        canvas { image(@background, :scale => @background_scale, :at => bounds.top_left) } if @background
         @y = @bounding_box.absolute_top
 
         float do


### PR DESCRIPTION
Back in February github user augusto came up with a simple way to scale the background image on the PDFs:

https://github.com/augusto/prawn/commit/29bc681690ea9e02875e2ac230530c9666e5eaf7

It allows us to have a high-resolution background for print materials or a low resolution background for other uses.

We've been successfully using his branch in production for six months, but would love to have this be part of the master, so we can take advantage of the 1.0 release coming up. I'm submitting this pull request because I didn't see any requests from augusto.

Thanks for your consideration.
