### PR TITLE
please consider using a constant variable for Prawn::BASEDIR/data

### DIFF
--- a/bench/png_type_6.rb
+++ b/bench/png_type_6.rb
@@ -8,7 +8,7 @@ Benchmark.bmbm do |x|
   x.report("PNG Type 6") do     
     N.times do
       Prawn::Document.new do 
-        image "#{Prawn::BASEDIR}/data/images/dice.png"
+        image "#{Prawn::DATADIR}/images/dice.png"
       end.render
     end         
   end   

--- a/bench/ttf_text_bench.rb
+++ b/bench/ttf_text_bench.rb
@@ -7,7 +7,7 @@ N=2000
 Benchmark.bmbm do |x|         
   x.report("TTF text") do
     Prawn::Document.new {  
-       font "#{Prawn::BASEDIR}/data/fonts/DejaVuSans.ttf"     
+       font "#{Prawn::DATADIR}/fonts/DejaVuSans.ttf"     
        N.times do                                     
          (1..5).each do |i|
            draw_text "Hello Prawn", :at => [200, i * 100]

--- a/bugs/resolved/layout/cell_width_miscalculation.rb
+++ b/bugs/resolved/layout/cell_width_miscalculation.rb
@@ -12,7 +12,7 @@ require "prawn"
 require "prawn/layout"
 
 Prawn::Document.generate("broken_table.pdf") do 
-  font "#{Prawn::BASEDIR}/data/fonts/comicsans.ttf"
+  font "#{Prawn::DATADIR}/fonts/comicsans.ttf"
   table [["foo",    "baaar",             "1" ],
          ["This is","a sample",          "2" ],
          ["Table",  "dont\ncha\nknow?",  "3" ]],

--- a/bugs/resolved/layout/table_row_background_color_issue.rb
+++ b/bugs/resolved/layout/table_row_background_color_issue.rb
@@ -13,7 +13,7 @@ require "prawn"
 require "prawn/layout"
 
 Prawn::Document.generate("table_with_background_color_problems.pdf") do 
-  font "#{Prawn::BASEDIR}/data/fonts/DejaVuSans.ttf"
+  font "#{Prawn::DATADIR}/fonts/DejaVuSans.ttf"
   table [["ὕαλον ϕαγεῖν",    "baaar",             "1" ],
          ["This is","a sample",          "2" ],
          ["Table",  "dont\ncha\nknow?",  "3" ],

--- a/bugs/resolved/png_barcode_issue.rb
+++ b/bugs/resolved/png_barcode_issue.rb
@@ -7,5 +7,5 @@ $LOAD_PATH << File.join(File.dirname(__FILE__), '..', '..','lib')
 require "prawn/core"
 
 Prawn::Document.generate('png_barcode_issue.pdf') do
-  image "#{Prawn::BASEDIR}/data/images/barcode_issue.png"
+  image "#{Prawn::DATADIR}/images/barcode_issue.png"
 end

--- a/bugs/resolved/ttf_fails_in_transactions.rb
+++ b/bugs/resolved/ttf_fails_in_transactions.rb
@@ -18,7 +18,7 @@ $LOAD_PATH << File.join(File.dirname(__FILE__), '..', '..','lib')
 require 'prawn/core' 
 
 Prawn::Document.generate("err.pdf") do
-  font "#{Prawn::BASEDIR}/data/fonts/DejaVuSans.ttf"
+  font "#{Prawn::DATADIR}/fonts/DejaVuSans.ttf"
   text "Hi there"
   transaction { text "Nice, thank you" }
 end

--- a/lib/prawn/core.rb
+++ b/lib/prawn/core.rb
@@ -29,7 +29,9 @@ module Prawn
                           
   # The base source directory for Prawn as installed on the system
   #
-  BASEDIR = File.expand_path(File.join(dir, '..', '..'))
+  # 
+  BASEDIR = File.expand_path(File.join(dir, '..','..'))
+  DATADIR = File.expand_path(File.join(dir, '..', '..', 'data'))
 
   # Whe set to true, Prawn will verify hash options to ensure only valid keys
   # are used.  Off by default.

--- a/lib/prawn/core/text.rb
+++ b/lib/prawn/core/text.rb
@@ -131,11 +131,11 @@ module Prawn
       #
       # Call with an empty array to turn off fallback fonts
       #
-      # file = "#{Prawn::BASEDIR}/data/fonts/gkai00mp.ttf"
+      # file = "#{Prawn::DATADIR}/fonts/gkai00mp.ttf"
       # font_families["Kai"] = {
       #   :normal => { :file => file, :font => "Kai" }
       # }
-      # file = "#{Prawn::BASEDIR}/data/fonts/Action Man.dfont"
+      # file = "#{Prawn::DATADIR}/fonts/Action Man.dfont"
       # font_families["Action Man"] = {
       #   :normal      => { :file => file, :font => "ActionMan" },
       # }

--- a/lib/prawn/document.rb
+++ b/lib/prawn/document.rb
@@ -166,7 +166,7 @@ module Prawn
     #   pdf = Prawn::Document.new(:page_size => [200, 300])
     #
     #   # New document, with background
-    #   pdf = Prawn::Document.new(:background => "#{Prawn::BASEDIR}/data/images/pigs.jpg")
+    #   pdf = Prawn::Document.new(:background => "#{Prawn::DATADIR}/images/pigs.jpg")
     #
     def initialize(options={},&block)
       options = options.dup

--- a/lib/prawn/encoding.rb
+++ b/lib/prawn/encoding.rb
@@ -84,7 +84,7 @@ module Prawn
       ]    
       
       def initialize
-        @mapping_file = "#{Prawn::BASEDIR}/data/encodings/win_ansi.txt"
+        @mapping_file = "#{Prawn::DATADIR}/encodings/win_ansi.txt"
         load_mapping if self.class.mapping.empty?
       end
 

--- a/lib/prawn/font/afm.rb
+++ b/lib/prawn/font/afm.rb
@@ -28,7 +28,7 @@ module Prawn
             ".", "/usr/lib/afm",
             "/usr/local/lib/afm",
             "/usr/openwin/lib/fonts/afm/",
-             Prawn::BASEDIR+'/data/fonts/']
+             Prawn::DATADIR+'/fonts/']
         end
       end
 

--- a/lib/prawn/images.rb
+++ b/lib/prawn/images.rb
@@ -32,10 +32,10 @@ module Prawn
     # <tt>:fit</tt>:: scale the dimensions of the image proportionally to fit inside [width,height]
     # 
     #   Prawn::Document.generate("image2.pdf", :page_layout => :landscape) do     
-    #     pigs = "#{Prawn::BASEDIR}/data/images/pigs.jpg" 
+    #     pigs = "#{Prawn::DATADIR}/images/pigs.jpg" 
     #     image pigs, :at => [50,450], :width => 450                                      
     #
-    #     dice = "#{Prawn::BASEDIR}/data/images/dice.png"
+    #     dice = "#{Prawn::DATADIR}/images/dice.png"
     #     image dice, :at => [50, 450], :scale => 0.75 
     #   end   
     #

--- a/manual/document_and_page_options/background.rb
+++ b/manual/document_and_page_options/background.rb
@@ -7,7 +7,7 @@
 require File.expand_path(File.join(File.dirname(__FILE__),
                                    %w[.. example_helper]))
 
-img = "#{Prawn::BASEDIR}/data/images/letterhead.jpg"
+img = "#{Prawn::DATADIR}/images/letterhead.jpg"
 
 Prawn::Document.generate("background.pdf",
                          :background => img,

--- a/manual/example_helper.rb
+++ b/manual/example_helper.rb
@@ -143,11 +143,11 @@ module Prawn
   
       text(extract_introduction_text(data), :inline_format => true)
 
-      kai_file = "#{Prawn::BASEDIR}/data/fonts/gkai00mp.ttf"
+      kai_file = "#{Prawn::DATADIR}/fonts/gkai00mp.ttf"
       font_families["Kai"] = {
         :normal => { :file => kai_file, :font => "Kai" }
       }
-      dejavu_file = "#{Prawn::BASEDIR}/data/fonts/DejaVuSans.ttf"
+      dejavu_file = "#{Prawn::DATADIR}/fonts/DejaVuSans.ttf"
       font_families["DejaVu"] = {
         :normal => { :file => dejavu_file, :font => "DejaVu" }
       }

--- a/manual/images/absolute_position.rb
+++ b/manual/images/absolute_position.rb
@@ -17,7 +17,7 @@ Prawn::Example.generate(filename) do
   y_position = cursor
   text "The image won't go below this line of text."
   
-  image "#{Prawn::BASEDIR}/data/images/fractal.jpg", :at => [200, y_position]
+  image "#{Prawn::DATADIR}/images/fractal.jpg", :at => [200, y_position]
   
   text "And this line of text will go just below the previous one."
 end

--- a/manual/images/fit.rb
+++ b/manual/images/fit.rb
@@ -15,7 +15,7 @@ Prawn::Example.generate(filename) do
   
   text "Using the fit option"
   bounding_box([0, cursor], :width => size, :height => size) do
-    image "#{Prawn::BASEDIR}/data/images/pigs.jpg", :fit => [size, size]
+    image "#{Prawn::DATADIR}/images/pigs.jpg", :fit => [size, size]
     stroke_bounds
   end
 end

--- a/manual/images/horizontal.rb
+++ b/manual/images/horizontal.rb
@@ -16,10 +16,10 @@ Prawn::Example.generate(filename) do
     
     [:left, :center, :right].each do |position|
       text "Image aligned to the #{position}."
-      image "#{Prawn::BASEDIR}/data/images/stef.jpg", :position => position
+      image "#{Prawn::DATADIR}/images/stef.jpg", :position => position
     end
     
     text "The next image has a 50 point offset from the left boundary"
-    image "#{Prawn::BASEDIR}/data/images/stef.jpg", :position => 50
+    image "#{Prawn::DATADIR}/images/stef.jpg", :position => 50
   end
 end

--- a/manual/images/plain_image.rb
+++ b/manual/images/plain_image.rb
@@ -14,5 +14,5 @@ require File.expand_path(File.join(File.dirname(__FILE__),
 filename = File.basename(__FILE__).gsub('.rb', '.pdf')
 Prawn::Example.generate(filename) do
   text "The image will go right below this line of text."
-  image "#{Prawn::BASEDIR}/data/images/pigs.jpg"
+  image "#{Prawn::DATADIR}/images/pigs.jpg"
 end

--- a/manual/images/scale.rb
+++ b/manual/images/scale.rb
@@ -11,13 +11,13 @@ require File.expand_path(File.join(File.dirname(__FILE__),
 filename = File.basename(__FILE__).gsub('.rb', '.pdf')
 Prawn::Example.generate(filename) do
   text "Normal size"
-  image "#{Prawn::BASEDIR}/data/images/stef.jpg"
+  image "#{Prawn::DATADIR}/images/stef.jpg"
   move_down 10
   
   text "Scaled to 50%"
-  image "#{Prawn::BASEDIR}/data/images/stef.jpg", :scale => 0.5
+  image "#{Prawn::DATADIR}/images/stef.jpg", :scale => 0.5
   move_down 10
   
   text "Scaled to 200%"
-  image "#{Prawn::BASEDIR}/data/images/stef.jpg", :scale => 2
+  image "#{Prawn::DATADIR}/images/stef.jpg", :scale => 2
 end

--- a/manual/images/vertical.rb
+++ b/manual/images/vertical.rb
@@ -15,13 +15,13 @@ Prawn::Example.generate(filename) do
     
     [:top, :center, :bottom].each do |vposition|
       text "Image vertically aligned to the #{vposition}.", :valign => vposition
-      image "#{Prawn::BASEDIR}/data/images/stef.jpg", :position => 250,
+      image "#{Prawn::DATADIR}/images/stef.jpg", :position => 250,
                                                       :vposition => vposition
     end
     
     text_box "The next image has a 100 point offset from the top boundary",
              :at => [bounds.width - 110, bounds.top - 10], :width => 100
-    image "#{Prawn::BASEDIR}/data/images/stef.jpg", :position => :right,
+    image "#{Prawn::DATADIR}/images/stef.jpg", :position => :right,
                                                     :vposition => 100
   end
 end

--- a/manual/images/width_and_height.rb
+++ b/manual/images/width_and_height.rb
@@ -13,13 +13,13 @@ require File.expand_path(File.join(File.dirname(__FILE__),
 filename = File.basename(__FILE__).gsub('.rb', '.pdf')
 Prawn::Example.generate(filename) do
   text "Scale by setting only the width"
-  image "#{Prawn::BASEDIR}/data/images/pigs.jpg", :width => 150
+  image "#{Prawn::DATADIR}/images/pigs.jpg", :width => 150
   move_down 10
   
   text "Scale by setting only the height"
-  image "#{Prawn::BASEDIR}/data/images/pigs.jpg", :height => 100
+  image "#{Prawn::DATADIR}/images/pigs.jpg", :height => 100
   move_down 10
   
   text "Stretch to fit the width and height provided"
-  image "#{Prawn::BASEDIR}/data/images/pigs.jpg", :width => 500, :height => 100
+  image "#{Prawn::DATADIR}/images/pigs.jpg", :width => 500, :height => 100
 end

--- a/manual/manual/cover.rb
+++ b/manual/manual/cover.rb
@@ -9,7 +9,7 @@ filename = File.basename(__FILE__).gsub('.rb', '.pdf')
 Prawn::Example.generate(filename) do
   move_down 200
 
-  image "#{Prawn::BASEDIR}/data/images/prawn.png",
+  image "#{Prawn::DATADIR}/images/prawn.png",
         :scale => 0.9,
         :at => [10, cursor]
         

--- a/manual/table/image_cells.rb
+++ b/manual/table/image_cells.rb
@@ -17,7 +17,7 @@ require File.expand_path(File.join(File.dirname(__FILE__),
 
 filename = File.basename(__FILE__).gsub('.rb', '.pdf')
 Prawn::Example.generate(filename) do
-  image = "#{Prawn::BASEDIR}/data/images/prawn.png"
+  image = "#{Prawn::DATADIR}/images/prawn.png"
 
   table [
     ["Standard image cell",   {:image => image}],

--- a/manual/templates/full_template.rb
+++ b/manual/templates/full_template.rb
@@ -11,7 +11,7 @@
 require File.expand_path(File.join(File.dirname(__FILE__),
                                    %w[.. example_helper]))
 
-filename = "#{Prawn::BASEDIR}/data/pdfs/multipage_template.pdf"
+filename = "#{Prawn::DATADIR}/pdfs/multipage_template.pdf"
 
 Prawn::Example.generate("full_template.pdf", :template => filename) do
   go_to_page(page_count)

--- a/manual/templates/page_template.rb
+++ b/manual/templates/page_template.rb
@@ -22,7 +22,7 @@ Prawn::Example.generate(filename) do
   url = "https://github.com/sandal/prawn/raw/master/data/pdfs/form.pdf"
   formatted_text [{:text => url, :link => url}]
   
-  filename = "#{Prawn::BASEDIR}/data/pdfs/form.pdf"
+  filename = "#{Prawn::DATADIR}/pdfs/form.pdf"
   start_new_page(:template => filename)
   
   start_new_page(:template => filename, :template_page => 2)

--- a/manual/text/fallback_fonts.rb
+++ b/manual/text/fallback_fonts.rb
@@ -9,11 +9,11 @@ require File.expand_path(File.join(File.dirname(__FILE__),
 
 filename = File.basename(__FILE__).gsub('.rb', '.pdf')
 Prawn::Example.generate(filename) do
-  file = "#{Prawn::BASEDIR}/data/fonts/gkai00mp.ttf"
+  file = "#{Prawn::DATADIR}/fonts/gkai00mp.ttf"
   font_families["Kai"] = {
     :normal => { :file => file, :font => "Kai" }
   }
-  file = "#{Prawn::BASEDIR}/data/fonts/Action Man.dfont"
+  file = "#{Prawn::DATADIR}/fonts/Action Man.dfont"
   font_families["Action Man"] = {
     :normal      => { :file => file, :font => "ActionMan" },
   }

--- a/manual/text/line_wrapping.rb
+++ b/manual/text/line_wrapping.rb
@@ -29,7 +29,7 @@ Prawn::Example.generate(filename) do
     "nearer your destination the more you're slip#{nbsp}sliding away."
   move_down 20
 
-  font("#{Prawn::BASEDIR}/data/fonts/gkai00mp.ttf", :size => 16) do
+  font("#{Prawn::DATADIR}/fonts/gkai00mp.ttf", :size => 16) do
     long_text = "No word boundaries:\n更可怕的是，同质化竞争对手可以按照URL中后面这个ID来遍历您的DB中的内容，写个小爬虫把你的页面上的关键信息顺次爬下来也不是什么难事，这样的话，你就非常被动了。更可怕的是，同质化竞争对手可以按照URL中后面这个ID来遍历您的DB中的内容，写个小爬虫把你的页面上的关键信息顺次爬下来也不是什么难事，这样的话，你就非常被动了。"
     text long_text
     move_down 20

--- a/manual/text/registering_families.rb
+++ b/manual/text/registering_families.rb
@@ -15,7 +15,7 @@ filename = File.basename(__FILE__).gsub('.rb', '.pdf')
 Prawn::Example.generate(filename) do
   # Registering a single TTF font
   font_families.update("Chalkboard" => {
-    :normal => "#{Prawn::BASEDIR}/data/fonts/Chalkboard.ttf"
+    :normal => "#{Prawn::DATADIR}/fonts/Chalkboard.ttf"
   })
   
   font("Chalkboard") do
@@ -24,7 +24,7 @@ Prawn::Example.generate(filename) do
   move_down 20
   
   # Registering a DFONT package
-  font_path = "#{Prawn::BASEDIR}/data/fonts/Action Man.dfont"
+  font_path = "#{Prawn::DATADIR}/fonts/Action Man.dfont"
   font_families.update("Action Man" => {
     :normal      => { :file => font_path, :font => "ActionMan" },
     :italic      => { :file => font_path, :font => "ActionMan-Italic" },

--- a/manual/text/right_to_left_text.rb
+++ b/manual/text/right_to_left_text.rb
@@ -16,7 +16,7 @@ Prawn::Example.generate(filename) do
   # set the direction document-wide
   self.text_direction = :rtl
 
-  font("#{Prawn::BASEDIR}/data/fonts/gkai00mp.ttf", :size => 16) do
+  font("#{Prawn::DATADIR}/fonts/gkai00mp.ttf", :size => 16) do
     long_text = "写个小爬虫把你的页面上的关键信息顺次爬下来也不是什么难事写个小爬虫把你的页面上的关键信息顺次爬下来也不是什么难事写个小爬虫把你的页面上的关键信息顺次爬下来也不是什么难事写个小"
     text long_text
     move_down 20

--- a/manual/text/single_usage.rb
+++ b/manual/text/single_usage.rb
@@ -17,7 +17,7 @@ require File.expand_path(File.join(File.dirname(__FILE__),
 filename = File.basename(__FILE__).gsub('.rb', '.pdf')
 Prawn::Example.generate(filename) do
   # Using a TTF font file
-  font "#{Prawn::BASEDIR}/data/fonts/Chalkboard.ttf" do
+  font "#{Prawn::DATADIR}/fonts/Chalkboard.ttf" do
     text "Written with the Chalkboard TTF font."
   end
   move_down 20
@@ -26,7 +26,7 @@ Prawn::Example.generate(filename) do
   move_down 20
   
   # Using an DFONT font file
-  font "#{Prawn::BASEDIR}/data/fonts/Action Man.dfont" do
+  font "#{Prawn::DATADIR}/fonts/Action Man.dfont" do
     text "Written with the Action Man DFONT font"
   end
   move_down 20

--- a/manual/text/utf8.rb
+++ b/manual/text/utf8.rb
@@ -21,7 +21,7 @@ Prawn::Example.generate(filename) do
   text "Let's try them with another font."
   move_down 20
   
-  font("#{Prawn::BASEDIR}/data/fonts/DejaVuSans.ttf") do
+  font("#{Prawn::DATADIR}/fonts/DejaVuSans.ttf") do
     text "ὕαλον ϕαγεῖν δύναμαι· τοῦτο οὔ με βλάπτει."
     text "There you go."
   end

--- a/spec/cell_spec.rb
+++ b/spec/cell_spec.rb
@@ -509,7 +509,7 @@ describe "Image cells" do
   describe "with default options" do
     before(:each) do
       @cell = Prawn::Table::Cell.make(@pdf,
-        :image => "#{Prawn::BASEDIR}/data/images/prawn.png")
+        :image => "#{Prawn::DATADIR}/images/prawn.png")
     end
 
     it "should create a Cell::Image" do
@@ -525,7 +525,7 @@ describe "Image cells" do
   describe "hash syntax" do
     before(:each) do
       @table = @pdf.make_table([[{
-        :image => "#{Prawn::BASEDIR}/data/images/prawn.png",
+        :image => "#{Prawn::DATADIR}/images/prawn.png",
         :scale => 2,
         :fit => [100, 200],
         :image_width => 123,

--- a/spec/document_spec.rb
+++ b/spec/document_spec.rb
@@ -89,7 +89,7 @@ describe "When beginning each new page" do
 
   describe "Background template feature" do
     before(:each) do
-      @filename = "#{Prawn::BASEDIR}/data/images/pigs.jpg"
+      @filename = "#{Prawn::DATADIR}/images/pigs.jpg"
       @pdf = Prawn::Document.new(:background => @filename)
     end
     it "should place a background image if it is in options block" do
@@ -235,7 +235,7 @@ describe "Document compression" do
     doc_uncompressed = Prawn::Document.new
     doc_compressed   = Prawn::Document.new(:compress => true)
     [doc_compressed, doc_uncompressed].each do |pdf|
-       pdf.font "#{Prawn::BASEDIR}/data/fonts/gkai00mp.ttf"
+       pdf.font "#{Prawn::DATADIR}/fonts/gkai00mp.ttf"
        pdf.text "更可怕的是，同质化竞争对手可以按照URL中后面这个ID来遍历" * 10
     end
 

--- a/spec/font_spec.rb
+++ b/spec/font_spec.rb
@@ -24,7 +24,7 @@ describe "#width_of" do
   it "should exclude newlines" do
     create_pdf
     # Use a TTF font that has a non-zero width for \n
-    @pdf.font("#{Prawn::BASEDIR}/data/fonts/gkai00mp.ttf")
+    @pdf.font("#{Prawn::DATADIR}/fonts/gkai00mp.ttf")
 
     @pdf.width_of("\nhello world\n").should ==
       @pdf.width_of("hello world")
@@ -96,7 +96,7 @@ describe "font style support" do
   end
 
   it "should allow font familes to be defined in a single dfont" do
-    file = "#{Prawn::BASEDIR}/data/fonts/Action Man.dfont"
+    file = "#{Prawn::DATADIR}/fonts/Action Man.dfont"
     @pdf.font_families["Action Man"] = {
       :normal      => { :file => file, :font => "ActionMan" },
       :italic      => { :file => file, :font => "ActionMan-Italic" },
@@ -253,15 +253,15 @@ describe "#glyph_present" do
   end
 
   it "should return true when present in a TTF font" do
-    font = @pdf.find_font("#{Prawn::BASEDIR}/data/fonts/Activa.ttf")
+    font = @pdf.find_font("#{Prawn::DATADIR}/fonts/Activa.ttf")
     font.glyph_present?("H").should.be true
   end
 
   it "should return false when absent in a TTF font" do
-    font = @pdf.find_font("#{Prawn::BASEDIR}/data/fonts/Activa.ttf")
+    font = @pdf.find_font("#{Prawn::DATADIR}/fonts/Activa.ttf")
     font.glyph_present?("再").should.be false
 
-    font = @pdf.find_font("#{Prawn::BASEDIR}/data/fonts/gkai00mp.ttf")
+    font = @pdf.find_font("#{Prawn::DATADIR}/fonts/gkai00mp.ttf")
     font.glyph_present?("€").should.be false
   end
 end
@@ -270,7 +270,7 @@ describe "TTF fonts" do
   
   setup do
     create_pdf
-    @activa = @pdf.find_font "#{Prawn::BASEDIR}/data/fonts/Activa.ttf"
+    @activa = @pdf.find_font "#{Prawn::DATADIR}/fonts/Activa.ttf"
   end
   
   it "should calculate string width taking into account accented characters" do
@@ -336,7 +336,7 @@ describe "TTF fonts" do
     it "should allow TTF fonts to be used alongside document transactions" do
       lambda {
         Prawn::Document.new do
-          font "#{Prawn::BASEDIR}/data/fonts/DejaVuSans.ttf"
+          font "#{Prawn::DATADIR}/fonts/DejaVuSans.ttf"
           text "Hi there"
           transaction { text "Nice, thank you" }
         end
@@ -346,7 +346,7 @@ describe "TTF fonts" do
     it "should allow TTF fonts to be used inside transactions" do
       pdf = Prawn::Document.new do
         transaction do
-          font "#{Prawn::BASEDIR}/data/fonts/DejaVuSans.ttf"
+          font "#{Prawn::DATADIR}/fonts/DejaVuSans.ttf"
           text "Hi there"
         end
       end
@@ -364,7 +364,7 @@ end
 describe "DFont fonts" do
   setup do
     create_pdf
-    @file = "#{Prawn::BASEDIR}/data/fonts/Action Man.dfont"
+    @file = "#{Prawn::DATADIR}/fonts/Action Man.dfont"
   end
 
   it "should list all named fonts" do
@@ -403,7 +403,7 @@ end
 describe "#character_count(text)" do
   it "should work on TTF fonts" do
     create_pdf
-    @pdf.font("#{Prawn::BASEDIR}/data/fonts/gkai00mp.ttf")
+    @pdf.font("#{Prawn::DATADIR}/fonts/gkai00mp.ttf")
     @pdf.font.character_count("こんにちは世界").should == 7
     @pdf.font.character_count("Hello, world!").should == 13
   end

--- a/spec/formatted_text_box_spec.rb
+++ b/spec/formatted_text_box_spec.rb
@@ -21,7 +21,7 @@ describe "Text::Formatted::Box wrapping" do
   it "should not raise Encoding::CompatibilityError when keeping a TTF and an " +
     "AFM font together" do
     ruby_19 do
-      file = "#{Prawn::BASEDIR}/data/fonts/gkai00mp.ttf"
+      file = "#{Prawn::DATADIR}/fonts/gkai00mp.ttf"
       @pdf.font_families["Kai"] = {
         :normal => { :file => file, :font => "Kai" }
       }
@@ -121,7 +121,7 @@ describe "Text::Formatted::Box with :fallback_fonts option that includes" +
   "a Chinese font and set of Chinese glyphs not in the current font" do
   it "should change the font to the Chinese font for the Chinese glyphs" do
     create_pdf
-    file = "#{Prawn::BASEDIR}/data/fonts/gkai00mp.ttf"
+    file = "#{Prawn::DATADIR}/fonts/gkai00mp.ttf"
     @pdf.font_families["Kai"] = {
       :normal => { :file => file, :font => "Kai" }
     }
@@ -149,7 +149,7 @@ describe "Text::Formatted::Box with :fallback_fonts option that includes" +
   "an AFM font and Win-Ansi glyph not in the current Chinese font" do
   it "should change the font to the AFM font for the Win-Ansi glyph" do
     create_pdf
-    file = "#{Prawn::BASEDIR}/data/fonts/gkai00mp.ttf"
+    file = "#{Prawn::DATADIR}/fonts/gkai00mp.ttf"
     @pdf.font_families["Kai"] = {
       :normal => { :file => file, :font => "Kai" }
     }
@@ -178,7 +178,7 @@ describe "Text::Formatted::Box with :fallback_fonts option and fragment " +
   "level font" do
   it "should use the fragment level font except for glyphs not in that font" do
     create_pdf
-    file = "#{Prawn::BASEDIR}/data/fonts/gkai00mp.ttf"
+    file = "#{Prawn::DATADIR}/fonts/gkai00mp.ttf"
     @pdf.font_families["Kai"] = {
       :normal => { :file => file, :font => "Kai" }
     }
@@ -205,7 +205,7 @@ end
 describe "Text::Formatted::Box" do
   before(:each) do
     create_pdf
-    file = "#{Prawn::BASEDIR}/data/fonts/gkai00mp.ttf"
+    file = "#{Prawn::DATADIR}/fonts/gkai00mp.ttf"
     @pdf.font_families["Kai"] = {
       :normal => { :file => file, :font => "Kai" }
     }

--- a/spec/images_spec.rb
+++ b/spec/images_spec.rb
@@ -7,7 +7,7 @@ require 'pathname'
 describe "the image() function" do
 
   before(:each) do
-    @filename = "#{Prawn::BASEDIR}/data/images/pigs.jpg" 
+    @filename = "#{Prawn::DATADIR}/images/pigs.jpg" 
     create_pdf
   end
 
@@ -44,17 +44,17 @@ describe "the image() function" do
   end
 
   it "should raise an UnsupportedImageType if passed a BMP" do
-    filename = "#{Prawn::BASEDIR}/data/images/tru256.bmp"
+    filename = "#{Prawn::DATADIR}/images/tru256.bmp"
     lambda { @pdf.image filename, :at => [100,100] }.should.raise(Prawn::Errors::UnsupportedImageType)
   end
 
   it "should raise an UnsupportedImageType if passed an interlaced PNG" do
-    filename = "#{Prawn::BASEDIR}/data/images/dice_interlaced.png"
+    filename = "#{Prawn::DATADIR}/images/dice_interlaced.png"
     lambda { @pdf.image filename, :at => [100,100] }.should.raise(Prawn::Errors::UnsupportedImageType)
   end
 
   it "should bump PDF version to 1.5 or greater on embedding 16-bit PNGs" do
-    @pdf.image "#{Prawn::BASEDIR}/data/images/16bit.png"
+    @pdf.image "#{Prawn::DATADIR}/images/16bit.png"
     @pdf.state.version.should >= 1.5
   end
 
@@ -63,7 +63,7 @@ describe "the image() function" do
   # or anything. OS X Preview handles those files just fine.
   #
   it "should embed 8-bit alpha channels for 16-bit PNGs" do
-    @pdf.image "#{Prawn::BASEDIR}/data/images/16bit.png"
+    @pdf.image "#{Prawn::DATADIR}/images/16bit.png"
 
     output = @pdf.render
     output.should =~ /\/BitsPerComponent 16/

--- a/spec/jpg_spec.rb
+++ b/spec/jpg_spec.rb
@@ -9,7 +9,7 @@ require File.join(File.expand_path(File.dirname(__FILE__)), "spec_helper")
 describe "When reading a JPEG file" do
 
   before(:each) do
-    @filename = "#{Prawn::BASEDIR}/data/images/pigs.jpg"
+    @filename = "#{Prawn::DATADIR}/images/pigs.jpg"
     @img_data = File.open(@filename, "rb") { |f| f.read }
   end
    

--- a/spec/line_wrap_spec.rb
+++ b/spec/line_wrap_spec.rb
@@ -51,7 +51,7 @@ describe "Core::Text::Formatted::LineWrap#wrap_line" do
   end
 
   it "should break on zero-width space" do
-    @pdf.font("#{Prawn::BASEDIR}/data/fonts/DejaVuSans.ttf")
+    @pdf.font("#{Prawn::DATADIR}/fonts/DejaVuSans.ttf")
     array = [{ :text => "hello#{Prawn::Text::ZWSP}world" }]
     @arranger.format_array = array
     string = @line_wrap.wrap_line(:arranger => @arranger,
@@ -61,7 +61,7 @@ describe "Core::Text::Formatted::LineWrap#wrap_line" do
   end
 
   it "should not display zero-width space" do
-    @pdf.font("#{Prawn::BASEDIR}/data/fonts/DejaVuSans.ttf")
+    @pdf.font("#{Prawn::DATADIR}/fonts/DejaVuSans.ttf")
     array = [{ :text => "hello#{Prawn::Text::ZWSP}world" }]
     @arranger.format_array = array
     string = @line_wrap.wrap_line(:arranger => @arranger,
@@ -116,7 +116,7 @@ describe "Core::Text::Formatted::LineWrap#wrap_line" do
     expected.force_encoding("utf-8") if "".respond_to?(:force_encoding)
     string.should == expected
 
-    @pdf.font("#{Prawn::BASEDIR}/data/fonts/DejaVuSans.ttf")
+    @pdf.font("#{Prawn::DATADIR}/fonts/DejaVuSans.ttf")
     @line_wrap = Prawn::Core::Text::Formatted::LineWrap.new
 
     string = "hello#{Prawn::Text::SHY}world"
@@ -137,7 +137,7 @@ describe "Core::Text::Formatted::LineWrap#wrap_line" do
                                   :document => @pdf)
     string.should == "helloworld"
 
-    @pdf.font("#{Prawn::BASEDIR}/data/fonts/DejaVuSans.ttf")
+    @pdf.font("#{Prawn::DATADIR}/fonts/DejaVuSans.ttf")
     @line_wrap = Prawn::Core::Text::Formatted::LineWrap.new
 
     string = "hello#{Prawn::Text::SHY}world"
@@ -166,7 +166,7 @@ describe "Core::Text::Formatted::LineWrap#wrap_line" do
                                   :document => @pdf)
     string.should == "hello"
 
-    @pdf.font("#{Prawn::BASEDIR}/data/fonts/DejaVuSans.ttf")
+    @pdf.font("#{Prawn::DATADIR}/fonts/DejaVuSans.ttf")
     @line_wrap = Prawn::Core::Text::Formatted::LineWrap.new
     enough_width_for_hello_world = 68
 
@@ -205,7 +205,7 @@ describe "Core::Text::Formatted::LineWrap#wrap_line" do
     expected.force_encoding("utf-8") if "".respond_to?(:force_encoding)
     string.should == expected
 
-    @pdf.font("#{Prawn::BASEDIR}/data/fonts/DejaVuSans.ttf")
+    @pdf.font("#{Prawn::DATADIR}/fonts/DejaVuSans.ttf")
     @line_wrap = Prawn::Core::Text::Formatted::LineWrap.new
 
     string = "hello#{Prawn::Text::SHY}-"

--- a/spec/object_store_spec.rb
+++ b/spec/object_store_spec.rb
@@ -35,7 +35,7 @@ describe "Prawn::ObjectStore" do
   end
 
   it "should import all objects from a PDF that has an indirect reference in a stream dict" do
-    filename = "#{Prawn::BASEDIR}/data/pdfs/indirect_reference.pdf"
+    filename = "#{Prawn::DATADIR}/pdfs/indirect_reference.pdf"
     store = Prawn::Core::ObjectStore.new(:template => filename)
     store.size.should == 8
   end
@@ -47,13 +47,13 @@ describe "Prawn::ObjectStore" do
   end
 
   it "should raise Prawn::Errors::TemplateError when given a non PDF as a template" do
-    filename = "#{Prawn::BASEDIR}/data/images/dice.png"
+    filename = "#{Prawn::DATADIR}/images/dice.png"
 
     lambda { Prawn::Core::ObjectStore.new(:template => filename) }.should.raise(Prawn::Errors::TemplateError)
   end
 
   it "should raise Prawn::Errors::TemplateError when given an encrypted PDF as a template" do
-    filename = "#{Prawn::BASEDIR}/data/pdfs/encrypted.pdf"
+    filename = "#{Prawn::DATADIR}/pdfs/encrypted.pdf"
 
     lambda { Prawn::Core::ObjectStore.new(:template => filename) }.should.raise(Prawn::Errors::TemplateError)
   end
@@ -118,37 +118,37 @@ end
 
 describe "Prawn::ObjectStorie#object_id_for_page" do
   it "should return the object ID of an imported template page" do
-    filename = "#{Prawn::BASEDIR}/data/pdfs/hexagon.pdf"
+    filename = "#{Prawn::DATADIR}/pdfs/hexagon.pdf"
     store = Prawn::Core::ObjectStore.new(:template => filename)
     store.object_id_for_page(0).should == 4
   end
 
   it "should return the object ID of the first imported template page" do
-    filename = "#{Prawn::BASEDIR}/data/pdfs/two_hexagons.pdf"
+    filename = "#{Prawn::DATADIR}/pdfs/two_hexagons.pdf"
     store = Prawn::Core::ObjectStore.new(:template => filename)
     store.object_id_for_page(1).should == 4
   end
 
   it "should return the object ID of the last imported template page" do
-    filename = "#{Prawn::BASEDIR}/data/pdfs/two_hexagons.pdf"
+    filename = "#{Prawn::DATADIR}/pdfs/two_hexagons.pdf"
     store = Prawn::Core::ObjectStore.new(:template => filename)
     store.object_id_for_page(-1).should == 6
   end
 
   it "should return the object ID of the first page of a template that uses nested Pages" do
-    filename = "#{Prawn::BASEDIR}/data/pdfs/nested_pages.pdf"
+    filename = "#{Prawn::DATADIR}/pdfs/nested_pages.pdf"
     store = Prawn::Core::ObjectStore.new(:template => filename)
     store.object_id_for_page(1).should == 5
   end
 
   it "should return the object ID of the last page of a template that uses nested Pages" do
-    filename = "#{Prawn::BASEDIR}/data/pdfs/nested_pages.pdf"
+    filename = "#{Prawn::DATADIR}/pdfs/nested_pages.pdf"
     store = Prawn::Core::ObjectStore.new(:template => filename)
     store.object_id_for_page(-1).should == 8
   end
 
   it "should return nil if given an invalid page number" do
-    filename = "#{Prawn::BASEDIR}/data/pdfs/hexagon.pdf"
+    filename = "#{Prawn::DATADIR}/pdfs/hexagon.pdf"
     store = Prawn::Core::ObjectStore.new(:template => filename)
     store.object_id_for_page(10).should == nil
   end

--- a/spec/png_spec.rb
+++ b/spec/png_spec.rb
@@ -12,8 +12,8 @@ require File.join(File.expand_path(File.dirname(__FILE__)), "spec_helper")
 describe "When reading a greyscale PNG file (color type 0)" do
 
   before(:each) do
-    @filename = "#{Prawn::BASEDIR}/data/images/web-links.png"
-    @data_filename = "#{Prawn::BASEDIR}/data/images/web-links.dat"
+    @filename = "#{Prawn::DATADIR}/images/web-links.png"
+    @data_filename = "#{Prawn::DATADIR}/images/web-links.dat"
     @img_data = File.binread(@filename)
   end
 
@@ -39,7 +39,7 @@ end
 describe "When reading a greyscale PNG file with transparency (color type 0)" do
 
   before(:each) do
-    @filename = "#{Prawn::BASEDIR}/data/images/ruport_type0.png"
+    @filename = "#{Prawn::DATADIR}/images/ruport_type0.png"
     @img_data = File.binread(@filename)
   end
 
@@ -56,8 +56,8 @@ end
 describe "When reading an RGB PNG file (color type 2)" do
 
   before(:each) do
-    @filename = "#{Prawn::BASEDIR}/data/images/ruport.png"
-    @data_filename = "#{Prawn::BASEDIR}/data/images/ruport_data.dat"
+    @filename = "#{Prawn::DATADIR}/images/ruport.png"
+    @data_filename = "#{Prawn::DATADIR}/images/ruport_data.dat"
     @img_data = File.binread(@filename)
   end
 
@@ -83,7 +83,7 @@ end
 describe "When reading an RGB PNG file with transparency (color type 2)" do
 
   before(:each) do
-    @filename = "#{Prawn::BASEDIR}/data/images/arrow2.png"
+    @filename = "#{Prawn::DATADIR}/images/arrow2.png"
     @img_data = File.binread(@filename)
   end
 
@@ -103,8 +103,8 @@ end
 describe "When reading an indexed color PNG file (color type 3)" do
 
   before(:each) do
-    @filename = "#{Prawn::BASEDIR}/data/images/rails.png"
-    @data_filename = "#{Prawn::BASEDIR}/data/images/rails.dat"
+    @filename = "#{Prawn::DATADIR}/images/rails.png"
+    @data_filename = "#{Prawn::DATADIR}/images/rails.dat"
     @img_data = File.binread(@filename)
   end
 
@@ -130,9 +130,9 @@ end
 describe "When reading a greyscale+alpha PNG file (color type 4)" do
 
   before(:each) do
-    @filename = "#{Prawn::BASEDIR}/data/images/page_white_text.png"
-    @data_filename = "#{Prawn::BASEDIR}/data/images/page_white_text.dat"
-    @alpha_data_filename = "#{Prawn::BASEDIR}/data/images/page_white_text.alpha"
+    @filename = "#{Prawn::DATADIR}/images/page_white_text.png"
+    @data_filename = "#{Prawn::DATADIR}/images/page_white_text.dat"
+    @alpha_data_filename = "#{Prawn::DATADIR}/images/page_white_text.alpha"
     @img_data = File.binread(@filename)
   end
 
@@ -166,9 +166,9 @@ end
 describe "When reading an RGB+alpha PNG file (color type 6)" do
 
   before(:each) do
-    @filename = "#{Prawn::BASEDIR}/data/images/dice.png"
-    @data_filename = "#{Prawn::BASEDIR}/data/images/dice.dat"
-    @alpha_data_filename = "#{Prawn::BASEDIR}/data/images/dice.alpha"
+    @filename = "#{Prawn::DATADIR}/images/dice.png"
+    @data_filename = "#{Prawn::DATADIR}/images/dice.dat"
+    @alpha_data_filename = "#{Prawn::DATADIR}/images/dice.alpha"
     @img_data = File.binread(@filename)
   end
 
@@ -202,10 +202,10 @@ end
 describe "When reading a 16bit RGB+alpha PNG file (color type 6)" do
 
   before(:each) do
-    @filename = "#{Prawn::BASEDIR}/data/images/16bit.png"
-    @data_filename = "#{Prawn::BASEDIR}/data/images/16bit.dat"
+    @filename = "#{Prawn::DATADIR}/images/16bit.png"
+    @data_filename = "#{Prawn::DATADIR}/images/16bit.dat"
     # alpha channel truncated to 8-bit
-    @alpha_data_filename = "#{Prawn::BASEDIR}/data/images/16bit.alpha"
+    @alpha_data_filename = "#{Prawn::DATADIR}/images/16bit.alpha"
     @img_data = File.binread(@filename)
   end
 

--- a/spec/template_spec.rb
+++ b/spec/template_spec.rb
@@ -59,7 +59,7 @@ describe "Document built from a template" do
   end
     
   it "should have a single page object if importing a single page template" do
-    filename = "#{Prawn::BASEDIR}/data/pdfs/hexagon.pdf"
+    filename = "#{Prawn::DATADIR}/pdfs/hexagon.pdf"
 
     @pdf = Prawn::Document.new(:template => filename)
     output = StringIO.new(@pdf.render)
@@ -71,7 +71,7 @@ describe "Document built from a template" do
   end
 
   it "should have two content streams if importing a single page template" do
-    filename = "#{Prawn::BASEDIR}/data/pdfs/hexagon.pdf"
+    filename = "#{Prawn::DATADIR}/pdfs/hexagon.pdf"
 
     @pdf = Prawn::Document.new(:template => filename)
     output = StringIO.new(@pdf.render)
@@ -83,7 +83,7 @@ describe "Document built from a template" do
   end
 
   it "should not die if using this PDF as a template" do
-    filename = "#{Prawn::BASEDIR}/data/pdfs/complex_template.pdf"
+    filename = "#{Prawn::DATADIR}/pdfs/complex_template.pdf"
 
     assert_nothing_raised do
       @pdf = Prawn::Document.new(:template => filename)
@@ -92,7 +92,7 @@ describe "Document built from a template" do
 
 
   it "should have balance q/Q operators on all content streams" do
-    filename = "#{Prawn::BASEDIR}/data/pdfs/hexagon.pdf"
+    filename = "#{Prawn::DATADIR}/pdfs/hexagon.pdf"
 
     @pdf = Prawn::Document.new(:template => filename)
     output = StringIO.new(@pdf.render)
@@ -108,7 +108,7 @@ describe "Document built from a template" do
   end
 
   it "should allow text to be added to a single page template" do
-    filename = "#{Prawn::BASEDIR}/data/pdfs/hexagon.pdf"
+    filename = "#{Prawn::DATADIR}/pdfs/hexagon.pdf"
 
     @pdf = Prawn::Document.new(:template => filename)
 
@@ -119,7 +119,7 @@ describe "Document built from a template" do
   end
 
   it "should allow PDFs with page resources behind an indirect object to be used as templates" do
-    filename = "#{Prawn::BASEDIR}/data/pdfs/resources_as_indirect_object.pdf"
+    filename = "#{Prawn::DATADIR}/pdfs/resources_as_indirect_object.pdf"
 
     @pdf = Prawn::Document.new(:template => filename)
 
@@ -131,7 +131,7 @@ describe "Document built from a template" do
   end
 
   it "should copy the PDF version from the template file" do
-    filename = "#{Prawn::BASEDIR}/data/pdfs/version_1_6.pdf"
+    filename = "#{Prawn::DATADIR}/pdfs/version_1_6.pdf"
 
     @pdf = Prawn::Document.new(:template => filename)
     str = @pdf.render
@@ -139,9 +139,9 @@ describe "Document built from a template" do
   end
 
   it "should correctly add a TTF font to a template that has existing fonts" do
-    filename = "#{Prawn::BASEDIR}/data/pdfs/contains_ttf_font.pdf"
+    filename = "#{Prawn::DATADIR}/pdfs/contains_ttf_font.pdf"
     @pdf = Prawn::Document.new(:template => filename)
-    @pdf.font "#{Prawn::BASEDIR}/data/fonts/Chalkboard.ttf"
+    @pdf.font "#{Prawn::DATADIR}/fonts/Chalkboard.ttf"
     @pdf.move_down(40)
     @pdf.text "Hi There"
 
@@ -155,7 +155,7 @@ describe "Document built from a template" do
   end
 
   it "should correctly import a template file that is missing a MediaBox entry" do
-    filename = "#{Prawn::BASEDIR}/data/pdfs/page_without_mediabox.pdf"
+    filename = "#{Prawn::DATADIR}/pdfs/page_without_mediabox.pdf"
 
     @pdf = Prawn::Document.new(:template => filename)
     str = @pdf.render
@@ -215,7 +215,7 @@ describe "Document#start_new_page with :template option" do
   end
   
   it "should have two content streams if importing a single page template" do
-    filename = "#{Prawn::BASEDIR}/data/pdfs/hexagon.pdf"
+    filename = "#{Prawn::DATADIR}/pdfs/hexagon.pdf"
     @pdf = Prawn::Document.new()
     @pdf.start_new_page(:template => filename)
     output = StringIO.new(@pdf.render)
@@ -226,7 +226,7 @@ describe "Document#start_new_page with :template option" do
   end
   
   it "should have balance q/Q operators on all content streams" do
-    filename = "#{Prawn::BASEDIR}/data/pdfs/hexagon.pdf"
+    filename = "#{Prawn::DATADIR}/pdfs/hexagon.pdf"
 
     @pdf = Prawn::Document.new()
     @pdf.start_new_page(:template => filename)
@@ -254,7 +254,7 @@ describe "Document#start_new_page with :template option" do
   end
   
   it "should allow PDFs with page resources behind an indirect object to be used as templates" do
-    filename = "#{Prawn::BASEDIR}/data/pdfs/resources_as_indirect_object.pdf"
+    filename = "#{Prawn::DATADIR}/pdfs/resources_as_indirect_object.pdf"
 
     @pdf = Prawn::Document.new()
     @pdf.start_new_page(:template => filename)
@@ -267,10 +267,10 @@ describe "Document#start_new_page with :template option" do
   end
   
   it "should correctly add a TTF font to a template that has existing fonts" do
-    filename = "#{Prawn::BASEDIR}/data/pdfs/contains_ttf_font.pdf"
+    filename = "#{Prawn::DATADIR}/pdfs/contains_ttf_font.pdf"
     @pdf = Prawn::Document.new()
     @pdf.start_new_page(:template => filename)
-    @pdf.font "#{Prawn::BASEDIR}/data/fonts/Chalkboard.ttf"
+    @pdf.font "#{Prawn::DATADIR}/fonts/Chalkboard.ttf"
     @pdf.move_down(40)
     @pdf.text "Hi There"
 
@@ -286,7 +286,7 @@ describe "Document#start_new_page with :template option" do
   
   context "using template_page option" do
     it "uses the specified page option" do
-      filename = "#{Prawn::BASEDIR}/data/pdfs/multipage_template.pdf"
+      filename = "#{Prawn::DATADIR}/pdfs/multipage_template.pdf"
       @pdf = Prawn::Document.new()
       @pdf.start_new_page(:template => filename, :template_page => 2)
       text = PDF::Inspector::Text.analyze(@pdf.render)

--- a/spec/text_at_spec.rb
+++ b/spec/text_at_spec.rb
@@ -107,9 +107,9 @@ describe "#draw_text" do
         Prawn::Errors::IncompatibleStringEncoding)
     end
     it "should not raise an exception when a shift-jis string is rendered" do
-      datafile = "#{Prawn::BASEDIR}/data/shift_jis_text.txt"
+      datafile = "#{Prawn::DATADIR}/shift_jis_text.txt"
       sjis_str = File.open(datafile, "r:shift_jis") { |f| f.gets }
-      @pdf.font("#{Prawn::BASEDIR}/data/fonts/gkai00mp.ttf")
+      @pdf.font("#{Prawn::DATADIR}/fonts/gkai00mp.ttf")
       lambda { @pdf.draw_text(sjis_str, :at => [0, 0]) }.should.not.raise(
         Prawn::Errors::IncompatibleStringEncoding)
     end
@@ -121,7 +121,7 @@ describe "#draw_text" do
         Prawn::Errors::IncompatibleStringEncoding)
     end
     it "should raise an exception when a shift-jis string is rendered" do
-      sjis_str = File.read("#{Prawn::BASEDIR}/data/shift_jis_text.txt")
+      sjis_str = File.read("#{Prawn::DATADIR}/shift_jis_text.txt")
       lambda { @pdf.draw_text(sjis_str, :at => [0, 0]) }.should.raise(
         Prawn::Errors::IncompatibleStringEncoding)
     end

--- a/spec/text_box_spec.rb
+++ b/spec/text_box_spec.rb
@@ -74,7 +74,7 @@ describe "Text::Box" do
     @pdf.text_direction(:rtl)
     @pdf.text_direction = :rtl
     @pdf.text_direction = :rtl
-    @pdf.font("#{Prawn::BASEDIR}/data/fonts/gkai00mp.ttf", :size => 16) do
+    @pdf.font("#{Prawn::DATADIR}/fonts/gkai00mp.ttf", :size => 16) do
       @pdf.text "写个小"
     end
     text = PDF::Inspector::Text.analyze(@pdf.render)
@@ -617,7 +617,7 @@ describe "Text::Box printing UTF-8 string with higher bit characters" do
       :height => bounding_height,
       :document => @pdf
     }
-    file = "#{Prawn::BASEDIR}/data/fonts/Action Man.dfont"
+    file = "#{Prawn::DATADIR}/fonts/Action Man.dfont"
     @pdf.font_families["Action Man"] = {
       :normal      => { :file => file, :font => "ActionMan" },
       :italic      => { :file => file, :font => "ActionMan-Italic" },
@@ -800,7 +800,7 @@ describe "Text::Box with a solid block of Chinese characters" do
       :height => 162.0,
       :document => @pdf
     }
-    @pdf.font "#{Prawn::BASEDIR}/data/fonts/gkai00mp.ttf"
+    @pdf.font "#{Prawn::DATADIR}/fonts/gkai00mp.ttf"
     @options[:overflow] = :truncate
     text_box = Prawn::Text::Box.new(@text, @options)
     text_box.render

--- a/spec/text_spacing_spec.rb
+++ b/spec/text_spacing_spec.rb
@@ -42,7 +42,7 @@ describe "#character_spacing" do
   #
   it "should calculate character spacing widths by characters, not bytes" do
     create_pdf
-    @pdf.font("#{Prawn::BASEDIR}/data/fonts/gkai00mp.ttf")
+    @pdf.font("#{Prawn::DATADIR}/fonts/gkai00mp.ttf")
 
     str = "こんにちは世界"
     @pdf.character_spacing(0) do

--- a/spec/text_spec.rb
+++ b/spec/text_spec.rb
@@ -259,7 +259,7 @@ describe "#text" do
   
   it "should not raise an exception when providing Pathname instance as font" do
     lambda {
-      @pdf.font Pathname.new("#{Prawn::BASEDIR}/data/fonts/comicsans.ttf")
+      @pdf.font Pathname.new("#{Prawn::DATADIR}/fonts/comicsans.ttf")
     }.should.not.raise(Prawn::Errors::UnknownFont)
   end
 
@@ -274,7 +274,7 @@ describe "#text" do
 
   it "should correctly render a utf-8 string when using a TTF font" do
     str = "©" # copyright symbol
-    @pdf.font "#{Prawn::BASEDIR}/data/fonts/DejaVuSans.ttf"
+    @pdf.font "#{Prawn::DATADIR}/fonts/DejaVuSans.ttf"
     @pdf.text str
 
     # grab the text from the rendered PDF and ensure it matches
@@ -315,9 +315,9 @@ describe "#text" do
         Prawn::Errors::IncompatibleStringEncoding)
     end
     it "should not raise an exception when a shift-jis string is rendered" do
-      datafile = "#{Prawn::BASEDIR}/data/shift_jis_text.txt"
+      datafile = "#{Prawn::DATADIR}/shift_jis_text.txt"
       sjis_str = File.open(datafile, "r:shift_jis") { |f| f.gets }
-      @pdf.font("#{Prawn::BASEDIR}/data/fonts/gkai00mp.ttf")
+      @pdf.font("#{Prawn::DATADIR}/fonts/gkai00mp.ttf")
       lambda { @pdf.text sjis_str }.should.not.raise(
         Prawn::Errors::IncompatibleStringEncoding)
     end
@@ -329,7 +329,7 @@ describe "#text" do
         Prawn::Errors::IncompatibleStringEncoding)
     end
     it "should raise an exception when a shift-jis string is rendered" do
-      sjis_str = File.read("#{Prawn::BASEDIR}/data/shift_jis_text.txt")
+      sjis_str = File.read("#{Prawn::DATADIR}/shift_jis_text.txt")
       lambda { @pdf.text sjis_str }.should.raise(
         Prawn::Errors::IncompatibleStringEncoding)
     end


### PR DESCRIPTION
Hi!
Converting prawn to a Linux distribution package requires to follow the Filesystem Hierarchy Standard, and things in the data/ directory need to be moved to some location (e.g. to /usr/share/ruby-prawn) that is not directly above the basedir of prawn (in /usr/lib/ruby/something).
Would you consider defining a new constant in lib/prawn/core.rb (e.g Prawn::DATADIR) that would be initially set to Prawn::BASEDIR/data,but could be easily modified with a one-liner patch? That would help a lot to move things around, without having to extensively patch the source.
The following commit implements such a proposition.

Thank you in advance for your consideration.

Cédric
