### PR TITLE
Making indents consistent across columns

### DIFF
--- a/lib/prawn/document/column_box.rb
+++ b/lib/prawn/document/column_box.rb
@@ -53,18 +53,23 @@ module Prawn
         @current_column = 0
       end
 
-      # The column width, not the width of the whole box.  Used to calculate
-      # how long a line of text can be.
+      # The column width, not the width of the whole box,
+      # before left and/or right padding
+      def bare_column_width
+        (@width - @spacer * (@columns - 1)) / @columns
+      end
+
+      # The column width after padding.
+      # Used to calculate how long a line of text can be.
       #
       def width
-        (super - @spacer * (@columns - 1)) / @columns -
-          (@total_left_padding + @total_right_padding)
+        bare_column_width - (@total_left_padding + @total_right_padding)
       end
 
       # Column width including the spacer.
       #
       def width_of_column
-        width + @spacer
+        bare_column_width + @spacer
       end
 
       # x coordinate of the left edge of the current column


### PR DESCRIPTION
Hi there!

A long-standing issue in prawn has been that the function `indent` does not properly indent text in a `column_box`, except for the first column. The problem originates in how `left` and `width` are specifically calculated within the `column_box`.

There is [another pull request](https://github.com/sandal/prawn/pull/221) on the same topic, but that solution, based on changing the `@spacer` did not work with right indents, as far as I can tell.

I think that the solution I am proposing works, although I am not sure that introducing a new function and effectively changing the meaning of ColumnBox#width is kosher at this stage.

I wrote a few ad hoc specs and [an example script](https://gist.github.com/1424200) to demonstrate the effect.

Please let me know if the solution is acceptable and/or if there is anything else I should do.
Columns and indents are absolutely essential in my project!

Cheers, Giuseppe
