### PR TITLE
Allow importing a stream for page template [PATCH]

### DIFF
--- a/manual/templates/page_template.rb
+++ b/manual/templates/page_template.rb
@@ -4,6 +4,11 @@
 # with the <code>start_new_page</code> method. You may pass it a
 # <code>:template</code> option with the path for an existing pdf and a
 # <code>:template_page</code> option to specify which page to load.
+# You can also load a <code>:template</code> using a URI:
+#
+# <code>require 'open-uri'</code>
+#
+# <code> start_new_page(:template => open('http://server.com/document.pdf'))</code>
 #
 # The following example loads some pages from an existing PDF. If we don't
 # specify the <code>:template_page</code> option, the first page of the template
@@ -20,6 +25,8 @@ Prawn::Example.generate(filename) do
   move_down 10
   text "You also might want to look at the pdf used as a template: "
   url = "https://github.com/sandal/prawn/raw/master/data/pdfs/form.pdf"
+  move_down 10
+  
   formatted_text [{:text => url, :link => url}]
   
   filename = "#{Prawn::DATADIR}/pdfs/form.pdf"

--- a/spec/template_spec.rb
+++ b/spec/template_spec.rb
@@ -161,6 +161,16 @@ describe "Document built from a template" do
     str = @pdf.render
     str[0,4].should == "%PDF"
   end
+  
+  context "with the template as a stream" do
+    it "should correctly import a template file from a stream" do
+      filename = "#{Prawn::DATADIR}/pdfs/hexagon.pdf"
+      io = StringIO.new(File.read(filename))      
+      @pdf = Prawn::Document.new(:template => io)
+      str = @pdf.render
+      str[0,4].should == "%PDF"      
+    end
+  end
 
 end
 
@@ -282,6 +292,19 @@ describe "Document#start_new_page with :template option" do
     resources = template_page[:Resources]
     fonts = resources[:Font]
     fonts.size.should == 2
+  end
+  
+  context "with the template as a stream" do
+    it "should correctly import a template file from a stream" do
+      filename = "#{Prawn::DATADIR}/pdfs/hexagon.pdf"
+      io = StringIO.new(File.read(filename))
+      
+      @pdf = Prawn::Document.new()
+      @pdf.start_new_page(:template => io)
+      
+      str = @pdf.render
+      str[0,4].should == "%PDF"      
+    end
   end
   
   context "using template_page option" do


### PR DESCRIPTION
We needed to be able to import page templates from S3 (heroku only gives you so much space on the filesystem).

Prawn was limiting these to filepaths only, but PDF::Reader supports IOStreams, so we added support for that.

Tests and (a so-so) manual update included.  I didn't think we wanted to actually use open-uri when building the manual, so I just referenced it under page templates.
