### PR TITLE
Add basic support for linking to local files

### DIFF
--- a/lib/prawn/text/formatted/box.rb
+++ b/lib/prawn/text/formatted/box.rb
@@ -49,6 +49,12 @@ module Prawn
       #     created to that destination. Note that you must explicitly underline
       #     and color using the appropriate tags if you which to draw attention
       #     to the link
+      # <tt>:local</tt>::
+      #     a file or application to be opened locally. A clickable link will be
+      #     created to the provided local file or application. If the file is
+      #     another PDF, it will be opened in a new window. Note that you must
+      #     explicitly underline and color using the appropriate tags if you which
+      #     to draw attention to the link
       # <tt>:draw_text_callback</tt>:
       #     if provided, this Proc will be called instead of #draw_text! once
       #     per fragment for every low-level addition of text to the page.
@@ -522,6 +528,7 @@ module Prawn
           draw_fragment_overlay_styles(fragment)
           draw_fragment_overlay_link(fragment)
           draw_fragment_overlay_anchor(fragment)
+          draw_fragment_overlay_local(fragment)
           fragment.callback_objects.each do |obj|
             obj.render_in_front(fragment) if obj.respond_to?(:render_in_front)
           end
@@ -545,12 +552,23 @@ module Prawn
                                     :Dest => fragment.anchor)
         end
 
+        def draw_fragment_overlay_local(fragment)
+          return unless fragment.local
+          box = fragment.absolute_bounding_box
+          @document.link_annotation(box,
+                                    :Border => [0, 0, 0],
+                                    :A => { :Type => :Action,
+                                            :S => :Launch,
+                                            :F => Prawn::Core::LiteralString.new(fragment.local),
+                                            :NewWindow => true })
+        end
+
         def draw_fragment_overlay_styles(fragment)
           underline = fragment.styles.include?(:underline)
           if underline
             @document.stroke_line(fragment.underline_points)
           end
-          
+
           strikethrough = fragment.styles.include?(:strikethrough)
           if strikethrough
             @document.stroke_line(fragment.strikethrough_points)

--- a/lib/prawn/text/formatted/fragment.rb
+++ b/lib/prawn/text/formatted/fragment.rb
@@ -105,6 +105,10 @@ module Prawn
           @format_state[:anchor]
         end
 
+        def local
+          @format_state[:local]
+        end
+
         def color
           @format_state[:color]
         end

--- a/manual/text/formatted_text.rb
+++ b/manual/text/formatted_text.rb
@@ -17,8 +17,9 @@
 # <code>:character_spacing</code> (additional space between the characters),
 # <code>:font</code> (the name of a registered font), <code>:color</code> (the
 # same input accepted by <code>fill_color</code> and <code>stroke_color</code>),
-# <code>:link</code> (an URL to create a link), and <code>:anchor</code> (a
-# destination inside the document).
+# <code>:link</code> (an URL to create a link), <code>:anchor</code> (a
+# destination inside the document), and <code>:local</code> (a link to a local
+# file).
 #
 require File.expand_path(File.join(File.dirname(__FILE__),
                                    %w[.. example_helper]))
@@ -37,7 +38,10 @@ Prawn::Example.generate(filename) do
                      :link => "https://github.com/sandal/prawn/wiki/" },
                    { :text => "Link to the Text Reference. "  ,
                      :color => "0000FF",
-                     :anchor => "Text Reference" }
+                     :anchor => "Text Reference" },
+                   { :text => "Link to a local file. ",
+                     :color => "0000FF",
+                     :local => "./local_file.txt" }
                  ]
   
   formatted_text_box [ { :text => "Just your regular" },

--- a/spec/formatted_text_box_spec.rb
+++ b/spec/formatted_text_box_spec.rb
@@ -512,6 +512,16 @@ describe "Text::Formatted::Box#render" do
     text_box = Prawn::Text::Formatted::Box.new(array, :document => @pdf)
     text_box.render
   end
+  it "should be able to add local actions" do
+    create_pdf
+    @pdf.expects(:link_annotation).with(kind_of(Array), :Border => [0,0,0],
+           :A => { :Type => :Action, :S => :Launch, :F => "../example.pdf", :NewWindow => true })
+    array = [{ :text => "click " },
+             { :text => "here", :local => "../example.pdf" },
+             { :text => " to open a local file" }]
+    text_box = Prawn::Text::Formatted::Box.new(array, :document => @pdf)
+    text_box.render
+  end
   it "should be able to set font size" do
     create_pdf
     array = [{ :text => "this contains " },


### PR DESCRIPTION
For the case when you want a PDF table of contents linking to a directory of local files that can be passed around on a flash drive.  Old school.

When using Prawn's URI support, the file is opened in a browser.  But, section 12.6.4.5 of the PDF spec allows for 'Launch Actions' where a local file is opened using whatever native application is available (eg. a .doc will open in Word, a .xls in Excel, etc).

This code allows the following to be passed in the formatted_text hash:

:local =>  './relative-link-to-local-file'
