### PR TITLE
Allowing overriding of the Producer metadata in a generated PDF

### DIFF
--- a/lib/prawn/core/document_state.rb
+++ b/lib/prawn/core/document_state.rb
@@ -41,7 +41,7 @@ module Prawn
       def normalize_metadata(options)
         options[:info] ||= {}
         options[:info][:Creator] ||= "Prawn"
-        options[:info][:Producer] = "Prawn"
+        options[:info][:Producer] ||= "Prawn"
 
         info = options[:info]
       end


### PR DESCRIPTION
The Prawn manual suggests that the producer metadata can be overridden but has been forced to "Prawn"
