### PR TITLE
Don't wrap by chars if we're going to shrink to fit anyway.

### DIFF
--- a/lib/prawn/core/text/formatted/line_wrap.rb
+++ b/lib/prawn/core/text/formatted/line_wrap.rb
@@ -157,6 +157,8 @@ module Prawn
             @kerning = options[:kerning]
             @width = options[:width]
 
+            @disable_wrap_by_char = options[:disable_wrap_by_char]
+
             @accumulated_width = 0
             @line_empty = true
             @line_contains_more_than_one_word = false
@@ -226,7 +228,7 @@ module Prawn
 
           def end_of_the_line_reached(segment)
             update_line_status_based_on_last_output
-            wrap_by_char(segment) unless @line_contains_more_than_one_word
+            wrap_by_char(segment) unless @disable_wrap_by_char || @line_contains_more_than_one_word
             @line_full = true
           end
 

--- a/lib/prawn/core/text/formatted/wrap.rb
+++ b/lib/prawn/core/text/formatted/wrap.rb
@@ -45,7 +45,8 @@ module Prawn
               @line_wrap.wrap_line(:document => @document,
                                    :kerning => @kerning,
                                    :width => available_width,
-                                   :arranger => @arranger)
+                                   :arranger => @arranger,
+                                   :disable_wrap_by_char => (@overflow == :shrink_to_fit))
 
               if enough_height_for_this_line?
                 move_baseline_down

--- a/lib/prawn/text/formatted/box.rb
+++ b/lib/prawn/text/formatted/box.rb
@@ -469,11 +469,13 @@ module Prawn
         # Decrease the font size until the text fits or the min font
         # size is reached
         def shrink_to_fit(text)
-          wrap(text)
-          until @everything_printed || @font_size <= @min_font_size
+          loop do
+            wrap(text) rescue Errors::CannotFit
+
+            break if @everything_printed || @font_size <= @min_font_size
+
             @font_size = [@font_size - 0.5, @min_font_size].max
             @document.font_size = @font_size
-            wrap(text)
           end
         end
 


### PR DESCRIPTION
Wrapping by characters seems to be unexpected behavior when the user has specified that the text should be shrunk to fit.
