### PR TITLE
Set Encoding.default_external to UTF-8 to build manual on systems with non Unicode locale

### DIFF
--- a/manual/manual/manual.rb
+++ b/manual/manual/manual.rb
@@ -2,6 +2,9 @@
 #
 # Generates the Prawn by example manual.
 #
+
+Encoding.default_external = "UTF-8" if defined? Encoding
+
 require File.expand_path(File.join(File.dirname(__FILE__),
                                    %w[.. example_helper]))
 


### PR DESCRIPTION
Hi!

When trying to build the manual on a system with non Unicode locale (i.e. C) with Ruby 1.9, the compilation of the manual fails because Ruby has to read strings supposed to be ASCII but containing Unicode characters.
Adding the single line:

```
Encoding.default_external = "UTF-8" if defined? Encoding
```

at the top of manual/manual/manual.rb fixes this issue.

Thanks.
