### PR TITLE
Keep outline items when compacting object store

### DIFF
--- a/lib/prawn/core/object_store.rb
+++ b/lib/prawn/core/object_store.rb
@@ -86,7 +86,7 @@ module Prawn
 
       def compact
         # Clear live markers
-        each { |o| o.live = false }
+        each { |o| o.live = o.data.is_a?(Prawn::OutlineItem) }
 
         # Recursively mark reachable objects live, starting from the roots
         # (the only objects referenced in the trailer)

--- a/spec/outline_spec.rb
+++ b/spec/outline_spec.rb
@@ -374,6 +374,22 @@ context "foreign character encoding" do
   end
 end
 
+context "with optimize_objects option" do
+  before(:each) do
+    pdf = Prawn::Document.new(:optimize_objects => true) do
+      outline.define do
+        section 'section', :destination => 1, :closed => true
+      end
+    end
+    @hash = PDF::Reader::ObjectHash.new(StringIO.new(pdf.render, 'r+'))
+  end
+
+  it "should generate an outline" do
+    object = find_by_title('section')
+    object.should.not == nil
+  end
+end
+
 def render_and_find_objects
   output = StringIO.new(@pdf.render, 'r+')
   @hash = PDF::Reader::ObjectHash.new(output)


### PR DESCRIPTION
I noticed that the outline was missing when I created PDFs with `:optimize_objects => true`.

This is due to the way `compact` works: _"clear live markers"_ and then _"recursively mark reachable objects live, starting from the roots"_. Since outline items are not "reachable" from the outline root, they are not marked live.

I'm approaching this problem by not clearing live markers for outline items in the first place.
