### PR TITLE
Allow setting the height option for number_pages.

### DIFF
--- a/lib/prawn/document.rb
+++ b/lib/prawn/document.rb
@@ -577,7 +577,7 @@ module Prawn
       total_pages = opts.delete(:total_pages)
       txtcolor = opts.delete(:color)
       # An explicit height so that we can draw page numbers in the margins
-      opts[:height] = 50
+      opts[:height] = 50 unless opts.has_key?(:height)
       
       start_count = false
       pseudopage = 0

--- a/spec/document_spec.rb
+++ b/spec/document_spec.rb
@@ -676,6 +676,27 @@ describe "The number_pages method" do
       end
     end
   end
+
+  context "height option" do
+    before do
+      @pdf.start_new_page
+    end
+
+    it "with 10 height" do
+      @pdf.expects(:text_box).with("1 1", { :height => 10 })
+      @pdf.number_pages "<page> <total>", :height => 10
+    end
+
+    it "with nil height" do
+      @pdf.expects(:text_box).with("1 1", { :height => nil })
+      @pdf.number_pages "<page> <total>", :height => nil
+    end
+
+    it "with no height" do
+      @pdf.expects(:text_box).with("1 1", { :height => 50 })
+      @pdf.number_pages "<page> <total>", :height => 50
+    end
+  end
 end
 
 describe "The page_match? method" do


### PR DESCRIPTION
Allow height to be set to nil or a specified height. If height isn't passed then it'll use the default 50.
