### PR TITLE
Paths to font files should accept Pathname objects too...

### DIFF
--- a/lib/prawn/font.rb
+++ b/lib/prawn/font.rb
@@ -257,7 +257,7 @@ module Prawn
     # will be passed through to Font::AFM.new()
     #
     def self.load(document,name,options={})
-      case name
+      case name.to_s
       when /\.ttf$/i   then TTF.new(document, name, options)
       when /\.dfont$/i then DFont.new(document, name, options)
       when /\.afm$/i   then AFM.new(document, name, options)

--- a/spec/font_spec.rb
+++ b/spec/font_spec.rb
@@ -1,9 +1,10 @@
 # encoding: utf-8
 
-require File.join(File.expand_path(File.dirname(__FILE__)), "spec_helper")           
+require File.join(File.expand_path(File.dirname(__FILE__)), "spec_helper")
 require 'iconv'
+require 'pathname'
 
-describe "Font behavior" do  
+describe "Font behavior" do
 
   it "should default to Helvetica if no font is specified" do
     @pdf = Prawn::Document.new
@@ -111,6 +112,21 @@ describe "font style support" do
     name = text.font_settings.map { |e| e[:name] }.first.to_s
     name = name.sub(/\w+\+/, "subset+")
     name.should == "subset+ActionMan-Italic"
+  end
+
+  it "should accept Pathname objects for font files" do
+    file = Pathname.new( "#{Prawn::DATADIR}/fonts/Chalkboard.ttf" )
+    @pdf.font_families["Chalkboard"] = {
+      :normal => file
+    }
+
+    @pdf.font "Chalkboard"
+    @pdf.text "In Chalkboard"
+
+    text = PDF::Inspector::Text.analyze(@pdf.render)
+    name = text.font_settings.map { |e| e[:name] }.first.to_s
+    name = name.sub(/\w+\+/, "subset+")
+    name.should == "subset+Chalkboard"
   end
 end
 


### PR DESCRIPTION
Found this bug while using 0.12.0 in a Rails app with:

``` ruby
font_families.update( "Foo" =>
  :normal => Rails.root.join("app/assets/fonts/foo.ttf")
)
```

This lead to unexplainable `app/assets/fonts/foo.ttf is not a known font. (Prawn::Errors::UnknownFont)` exceptions. All the tests pass with this tiny change.
