### PR TITLE
ruby-head does not reflect correctly MRI 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,14 @@ rvm:
   - 1.8.7
   - 1.9.2
   - 1.9.3
-  - ruby-head
+  - 2.0.0
   - rbx-18mode
   - rbx-19mode
   - jruby-18mode
   - jruby-19mode
 matrix:
   allowed_failures:
-    - rvm: ruby-head
+    - rvm: 2.0.0
     - rvm: rbx-18mode
     - rvm: rbx-19mode
     - rvm: jruby-18mode


### PR DESCRIPTION
Update to use 2.0.0 instead
