### PR TITLE
delegate to the AFM gem for parsing AFM files

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source :rubygems
 
 gem "ttfunk", "~>1.0.3"
 gem "pdf-reader", "~> 1.2"
+gem "afm"
 
 group :development do
   gem "coderay", "~> 1.0.7"

--- a/lib/prawn/font/afm.rb
+++ b/lib/prawn/font/afm.rb
@@ -7,6 +7,7 @@
 # This is free software. Please see the LICENSE and COPYING files for details.
 
 require 'prawn/encoding'
+require 'afm'
 
 module Prawn
   class Font
@@ -48,23 +49,21 @@ module Prawn
         file_name << ".afm" unless file_name =~ /\.afm$/
         file_name = file_name[0] == ?/ ? file_name : find_font(file_name)
 
-        font_data = @@font_data[file_name] ||= parse_afm(file_name)
-        @glyph_widths    = font_data[:glyph_widths]
-        @glyph_table     = font_data[:glyph_table]
-        @bounding_boxes  = font_data[:bounding_boxes]
-        @kern_pairs      = font_data[:kern_pairs]
-        @kern_pair_table = font_data[:kern_pair_table]
-        @attributes      = font_data[:attributes]
+        font_data = @@font_data[file_name] ||= ::AFM::Font.new(file_name)
+        @glyph_table     = build_glyph_table(font_data)
+        @kern_pairs      = font_data.kern_pairs
+        @kern_pair_table = build_kern_pair_table(@kern_pairs)
+        @attributes      = font_data.metadata
 
-        @ascender  = @attributes["ascender"].to_i
-        @descender = @attributes["descender"].to_i
+        @ascender  = @attributes["Ascender"].to_i
+        @descender = @attributes["Descender"].to_i
         @line_gap  = Float(bbox[3] - bbox[1]) - (@ascender - @descender)
       end
 
       # The font bbox, as an array of integers
       #
       def bbox
-        @bbox ||= @attributes['fontbbox'].split(/\s+/).map { |e| Integer(e) }
+        @bbox ||= @attributes['FontBBox'].split(/\s+/).map { |e| Integer(e) }
       end
 
       # NOTE: String *must* be encoded as WinAnsi
@@ -142,7 +141,7 @@ module Prawn
       end
 
       def symbolic?
-        attributes["characterset"] == "Special"
+        attributes["CharacterSet"] == "Special"
       end
 
       def find_font(file)
@@ -151,61 +150,6 @@ module Prawn
         raise Prawn::Errors::UnknownFont,
           "Couldn't find the font: #{file} in any of:\n" +
            self.class.metrics_path.join("\n")
-      end
-
-      def parse_afm(file_name)
-        data    = {:glyph_widths => {}, :bounding_boxes => {}, :kern_pairs => {}, :attributes => {}}         
-        section = []
-
-        File.foreach(file_name) do |line|
-          case line
-          when /^Start(\w+)/
-            section.push $1
-            next
-          when /^End(\w+)/
-            section.pop
-            next
-          end
-
-          case section
-          when ["FontMetrics", "CharMetrics"]
-            next unless line =~ /^CH?\s/
-
-            name                        = line[/\bN\s+(\.?\w+)\s*;/, 1]
-            data[:glyph_widths][name]   = line[/\bWX\s+(\d+)\s*;/, 1].to_i
-            data[:bounding_boxes][name] = line[/\bB\s+([^;]+);/, 1].to_s.rstrip
-          when ["FontMetrics", "KernData", "KernPairs"]
-            next unless line =~ /^KPX\s+(\.?\w+)\s+(\.?\w+)\s+(-?\d+)/
-            data[:kern_pairs][[$1, $2]] = $3.to_i
-          when ["FontMetrics", "KernData", "TrackKern"],
-            ["FontMetrics", "Composites"]
-            next
-          else
-            parse_generic_afm_attribute(line, data)
-          end
-        end
-        
-        # process data parsed from AFM file to build tables which
-        #   will be used when measuring and kerning text
-        data[:glyph_table] = (0..255).map do |i|
-          data[:glyph_widths][Encoding::WinAnsi::CHARACTERS[i]].to_i
-        end
-
-        character_hash = Hash[Encoding::WinAnsi::CHARACTERS.zip((0..Encoding::WinAnsi::CHARACTERS.size).to_a)]
-        data[:kern_pair_table] = data[:kern_pairs].inject({}) do |h,p|
-          h[p[0].map { |n| character_hash[n] }] = p[1]
-          h
-        end
-
-        data.each_value { |hash| hash.freeze }
-        data.freeze
-      end
-
-      def parse_generic_afm_attribute(line, hash)
-        line =~ /(^\w+)\s+(.*)/
-        key, value = $1.to_s.downcase, $2
-
-        hash[:attributes][key] = hash[:attributes][key] ? Array(hash[:attributes][key]) << value : value
       end
 
       # converts a string into an array with spacing offsets
@@ -232,7 +176,22 @@ module Prawn
         }
       end
       
-      private
+      def build_kern_pair_table(kern_pairs)
+        character_hash = Hash[Encoding::WinAnsi::CHARACTERS.zip((0..Encoding::WinAnsi::CHARACTERS.size).to_a)]
+        kern_pairs.inject({}) do |h,p|
+          h[
+            [character_hash[p[0]], character_hash[p[1]]]
+          ] = p[2]
+          h
+        end
+      end
+
+      def build_glyph_table(font_data)
+        (0..255).map do |char|
+          metrics = font_data.metrics_for(char)
+          metrics ? metrics[:wx] : 0
+        end
+      end
       
       def unscaled_width_of(string)
         string.bytes.inject(0) do |s,r|

--- a/prawn.gemspec
+++ b/prawn.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.rubyforge_project = "prawn"
   spec.add_dependency('pdf-reader', '>=0.9.0', '<2.0')
   spec.add_dependency('ttfunk', '~>1.0.3')
+  spec.add_dependency('afm')
   spec.add_development_dependency('pdf-inspector', '~> 1.0.1')
   spec.add_development_dependency('coderay', '~> 1.0.7')
   spec.add_development_dependency('rdoc')


### PR DESCRIPTION
This is another suggestion along the lines of the rc4 pull request. pdf-reader master depends on the afm gem for improved text rendering features. We may as well share code and avoid 3 AFM parsing classes in the ruby ecosystem.

Here's the dot points from the commit comments:
- reduces the responsibilities of the Prawn::Font::AFM class. It's about
  adding the font to the ObjectStore and encoding text, not parsing a file
  format.
- allows pdf-reader and prawn to share the same AFM parsing code. More
  eyeballs, less repetition, etc.
- the afm gem is minimal, stable and tested
