### PR TITLE
Explicitly set row on dummy cells

### DIFF
--- a/lib/prawn/table.rb
+++ b/lib/prawn/table.rb
@@ -17,7 +17,7 @@ require 'prawn/table/cell/span_dummy'
 module Prawn
 
   class Document
-    
+
     # Set up and draw a table on this document. A block can be given, which will
     # be run after cell setup but before layout and drawing.
     #
@@ -51,7 +51,7 @@ module Prawn
   #   Produces a text cell. This is the most common usage.
   # Prawn::Table::Cell::
   #   If you have already built a Cell or have a custom subclass of Cell you
-  #   want to use in a table, you can pass through Cell objects. 
+  #   want to use in a table, you can pass through Cell objects.
   # Prawn::Table::
   #   Creates a subtable (a table within a cell). You can use
   #   Prawn::Document#make_table to create a table for use as a subtable
@@ -78,7 +78,7 @@ module Prawn
   #   (for styling and other row-specific options) always indexes based on
   #   your data array. Whether or not you have a header, row(n) always refers
   #   to the nth element (starting from 0) of the +data+ array.
-  # +column_widths+:: 
+  # +column_widths+::
   #   Sets widths for individual columns. Manually setting widths can give
   #   better results than letting Prawn guess at them, as Prawn's algorithm
   #   for defaulting widths is currently pretty boneheaded. If you experience
@@ -101,7 +101,7 @@ module Prawn
   #   pdf.table(data) do |table|
   #     table.rows(1..3).width = 72
   #   end
-  # 
+  #
   # As with Prawn::Document#initialize, if the block has no arguments, it will
   # be evaluated in the context of the object itself. The above code could be
   # rewritten as:
@@ -110,7 +110,7 @@ module Prawn
   #     rows(1..3).width = 72
   #   end
   #
-  class Table  
+  class Table
 
     # Set up a table on the given document. Arguments:
     #
@@ -137,7 +137,7 @@ module Prawn
       set_column_widths
       set_row_heights
       position_cells
-    end                                        
+    end
 
     # Number of rows in the table.
     #
@@ -165,7 +165,7 @@ module Prawn
     # The block is passed a Cells object containing all cells to be rendered on
     # that page. You can change styling of the cells in this block, but keep in
     # mind that the cells have already been positioned and sized.
-    # 
+    #
     def before_rendering_page(&block)
       @before_rendering_page = block
     end
@@ -179,9 +179,9 @@ module Prawn
     # Sets column widths for the table. The argument can be one of the following
     # types:
     #
-    # +Array+:: 
+    # +Array+::
     #   <tt>[w0, w1, w2, ...]</tt> (specify a width for each column)
-    # +Hash+:: 
+    # +Hash+::
     #   <tt>{0 => w0, 1 => w1, ...}</tt> (keys are column names, values are
     #   widths)
     # +Numeric+::
@@ -317,14 +317,14 @@ module Prawn
             offset = @pdf.y - cell.y - header_height
             started_new_page_at_row = cell.row
           end
-   
+
           # Don't modify cell.x / cell.y here, as we want to reuse the original
           # values when re-inking the table. #draw should be able to be called
           # multiple times.
           x, y = cell.x, cell.y
-          y += offset 
+          y += offset
 
-          # Translate coordinates to the bounds we are in, since drawing is 
+          # Translate coordinates to the bounds we are in, since drawing is
           # relative to the cursor, not ref_bounds.
           x += @pdf.bounds.left_side - @pdf.bounds.absolute_left
           y -= @pdf.bounds.absolute_bottom
@@ -426,7 +426,7 @@ module Prawn
       assert_proper_table_data(data)
 
       cells = Cells.new
-      
+
       row_number = 0
       data.each do |row_cells|
         column_number = 0
@@ -491,6 +491,7 @@ module Prawn
     def add_header(page_of_cells, y, row)
       @header_row.each do |cell|
         cell.row = row
+        cell.dummy_cells.each {|c| c.row = row }
         page_of_cells << [cell, [cell.x, y]]
       end
       @header_row.height
@@ -547,7 +548,7 @@ module Prawn
     # values that will be used to ink the table.
     #
     def set_column_widths
-      column_widths.each_with_index do |w, col_num| 
+      column_widths.each_with_index do |w, col_num|
         column(col_num).width = w
       end
     end
@@ -564,7 +565,7 @@ module Prawn
     #
     def position_cells
       # Calculate x- and y-positions as running sums of widths / heights.
-      x_positions = column_widths.inject([0]) { |ary, x| 
+      x_positions = column_widths.inject([0]) { |ary, x|
         ary << (ary.last + x); ary }[0..-2]
       x_positions.each_with_index { |x, i| column(i).x = x }
 

--- a/spec/table_spec.rb
+++ b/spec/table_spec.rb
@@ -660,6 +660,17 @@ describe "Prawn::Table" do
         end
       end
 
+      it "updates dummy cell header rows" do
+        header = [[{:content => "header", :colspan => 2}]]
+        data   = [["foo", "bar"]] * 31
+        @pdf.table(header + data, :header => true) do |t|
+          t.before_rendering_page do |page|
+            cell = page[0, 0]
+            cell.dummy_cells.each {|dc| dc.row.should == cell.row }
+          end
+        end
+      end
+
       it "allows headers to be changed" do
         seq = sequence("render order")
         @pdf.expects(:draw_text!).with { |t, _| t == "hdr1"}.in_sequence(seq)


### PR DESCRIPTION
This fixes #452 (and #413?) - Table header styling for the second page

The diff is really messy because of my white space removal. Let me know if you'd like me to resubmit without the whitespace changes. Fix is on line 292

:satisfied:

![Headers Yay!](https://f.cloud.github.com/assets/40662/238113/8b156620-882b-11e2-9547-b6d331648e1f.png)
