### PR TITLE
Delegate background_color to the master_cell [closes #412]

### DIFF
--- a/lib/prawn/table/cell/span_dummy.rb
+++ b/lib/prawn/table/cell/span_dummy.rb
@@ -13,6 +13,9 @@ module Prawn
       # group.
       #
       class SpanDummy < Cell
+        extend Forwardable
+        def_delegator :@master_cell, :background_color
+
         def initialize(pdf, master_cell)
           super(pdf, [0, pdf.cursor])
           @master_cell = master_cell

--- a/spec/table/span_dummy_spec.rb
+++ b/spec/table/span_dummy_spec.rb
@@ -1,0 +1,17 @@
+# encoding: utf-8
+
+require File.join(File.expand_path(File.dirname(__FILE__)), "..", "spec_helper")
+require 'set'
+
+describe "Prawn::Table::Cell::SpanDummy" do
+  before(:each) do
+    @pdf = Prawn::Document.new
+    @table = @pdf.table([[{:content => "Row", :colspan => 2}]])
+    @master_cell = @table.cells[0,0]
+    @span_dummy  = @master_cell.dummy_cells.first
+  end
+
+  it "delegates background_color to the master cell" do
+    @span_dummy.background_color.should == @master_cell.background_color
+  end
+end


### PR DESCRIPTION
I went ahead and implemented @jonsgreen's suggested fix. Works great and closes #412 

Here is my modified version of @ottost's provided example

``` ruby
data = [[
{colspan: 3, content: 'Iniciativa', align: :center, background_color: 'AAAAAA'},
{colspan: 4, content: 'Alcance', align: :center, background_color: 'AAAAAA'},
{colspan: 8, content: 'Estrategia', align: :center, background_color: 'AAAAAA'},
{colspan: 4, content: 'Enfoque', align: :center, background_color: 'AAAAAA'},
{colspan: 2, content: 'WOW', align: :center, size: 10, background_color: 'AAAAAA'}
]]

# data = ["foo " * 40] * 31
pdf = Prawn::Document.new
pdf.table(data, row_colors: ['DDDDDD','EFEFEF'])
```

Result:

![Screen Shot 2013-03-08 at 2 39 43 PM](https://f.cloud.github.com/assets/40662/238669/1662c05a-8841-11e2-8c53-48d62a3b927e.png)
