### PR TITLE
Add more thorough searching for :MediaBox entry

### DIFF
--- a/lib/prawn/core/page.rb
+++ b/lib/prawn/core/page.rb
@@ -34,7 +34,7 @@ module Prawn
       def layout
         return @layout if @layout
 
-        mb = dictionary.data[:MediaBox]
+        mb = media_box
         if mb[3] > mb[2]
           :portrait
         else
@@ -139,7 +139,7 @@ module Prawn
       end
 
       def dimensions
-        return inherited_dictionary_value(:MediaBox) if imported_page?
+        return media_box if imported_page?
 
         coords = Prawn::Document::PageGeometry::SIZES[size] || size
         [0,0] + case(layout)
@@ -185,23 +185,13 @@ module Prawn
         @stamp_dictionary  = nil
       end
 
-      # some entries in the Page dict can be inherited from parent Pages dicts.
-      #
-      # Starting with the current page dict, this method will walk up the
-      # inheritance chain return the first value that is found for key
-      #
-      #     inherited_dictionary_value(:MediaBox)
-      #     => [ 0, 0, 595, 842 ]
-      #
-      def inherited_dictionary_value(key, local_dict = nil)
-        local_dict ||= dictionary.data
-
-        if local_dict.has_key?(key)
-          local_dict[key]
-        elsif local_dict.has_key?(:Parent)
-          inherited_dictionary_value(key, local_dict[:Parent].data)
+      def media_box
+        if dictionary.data.has_key?(:MediaBox)
+          dictionary.data[:MediaBox]
         else
-          nil
+          document.state.store.detect { |ref|
+            ref.data.has_key?(:MediaBox)
+          }.data[:MediaBox]
         end
       end
 

--- a/spec/template_spec.rb
+++ b/spec/template_spec.rb
@@ -161,12 +161,21 @@ describe "Document built from a template" do
     fonts.size.should == 2
   end
 
-  it "should correctly import a template file that is missing a MediaBox entry" do
-    filename = "#{Prawn::DATADIR}/pdfs/page_without_mediabox.pdf"
+  context "when the template is missing a MediaBox entry" do
+    it "should correctly import the template" do
+      filename = "#{Prawn::DATADIR}/pdfs/page_without_mediabox.pdf"
 
-    @pdf = Prawn::Document.new(:template => filename)
-    str = @pdf.render
-    str[0,4].should == "%PDF"
+      @pdf = Prawn::Document.new(:template => filename)
+      str = @pdf.render
+      str[0,4].should == "%PDF"
+    end
+
+    it "should allow you to create a new page manually" do
+      filename = "#{Prawn::DATADIR}/pdfs/page_without_mediabox.pdf"
+
+      @pdf = Prawn::Document.new(:template => filename, :skip_page_creation => true)
+      lambda { @pdf.start_new_page }.should_not raise_error
+    end
   end
 
   context "with the template as a stream" do
@@ -346,6 +355,11 @@ describe "Document#start_new_page with :template option" do
       text = PDF::Inspector::Text.analyze(@pdf.render)
       text.strings.first.should == "This is template page 2"
     end
-  end
 
+    it "should work when the template is missing a MediaBox entry" do
+      filename = "#{Prawn::DATADIR}/pdfs/page_without_mediabox.pdf"
+      @pdf = Prawn::Document.new(:skip_page_creation => true)
+      lambda { @pdf.start_new_page(:template => filename) }.should_not raise_error
+    end
+  end
 end


### PR DESCRIPTION
This is a solution, though perhaps not the best one, for this issue in prawnpdf/prawn: https://github.com/prawnpdf/prawn/issues/386

I think it might be relevant to change the search in document.state.store to be the following:

``` diff
def media_box
  if dictionary.data.has_key?(:MediaBox)
    dictionary.data[:MediaBox]
  else
--  document.state.store.detect { |ref|
++  document.state.store.to_a.reverse.detect { |ref|
      ref.data.has_key?(:MediaBox)
    }.data[:MediaBox]
  end
end
```

But I think that would only matter if you want to search the previous pages in the order they were added (if my understanding of how ObjectStore works is correct).

I'm happy to take suggestions or a full rewrite from someone that knows the internals of Prawn better.

Cheers.
