### PR TITLE
Fixed table is not going to top of new page when inside of column_box

### DIFF
--- a/lib/prawn/document/column_box.rb
+++ b/lib/prawn/document/column_box.rb
@@ -17,9 +17,9 @@ module Prawn
     # number of :columns and a :spacer (in points) between columns.
     #
     # Defaults are :columns = 3 and :spacer = font_size
-    # 
+    #
     # Under PDF::Writer, "spacer" was known as "gutter"
-    # 
+    #
     def column_box(*args, &block)
       init_column_box(block) do |parent_box|
         map_to_absolute!(args[0])
@@ -40,7 +40,7 @@ module Prawn
 
       @bounding_box = parent_box
     end
-    
+
     # Implements the necessary functionality to allow Document#column_box to
     # work.
     #
@@ -99,12 +99,13 @@ module Prawn
 
       # Moves to the next column or starts a new page if currently positioned at
       # the rightmost column.
-      def move_past_bottom 
+      def move_past_bottom
         @current_column = (@current_column + 1) % @columns
-        @document.y = @y
         if 0 == @current_column
           @document.start_new_page
+          @y = @parent.absolute_top
         end
+        @document.y = @y
       end
 
       # Override the padding functions so as not to split the padding amount


### PR DESCRIPTION
When table is more long than one page, it doesn't go to the top of the new page when inside of column_box.
It will be in initial position of the column_box.

This fix will set the y position of the column box to top of new page.
