### PR TITLE
Checking graphic state exists for previous page before duping when starting new_page

### DIFF
--- a/lib/prawn/document.rb
+++ b/lib/prawn/document.rb
@@ -258,7 +258,7 @@ module Prawn
                       :layout  => options[:layout] || last_page_layout,
                       :margins => last_page_margins}
       if last_page
-        new_graphic_state = last_page.graphic_state.dup  if last_page.graphic_state.present?
+        new_graphic_state = last_page.graphic_state.dup  if last_page.graphic_state
         #erase the color space so that it gets reset on new page for fussy pdf-readers
         new_graphic_state.color_space = {} if new_graphic_state
         page_options.merge!(:graphic_state => new_graphic_state)


### PR DESCRIPTION
Whenver pdf.start_new_page is called. The previous page graphic_state is duped without checking if graphic state exists for the previous page which result in can't dup nil class error 
