### PR TITLE
DecodeParms typo fixed

### DIFF
--- a/lib/prawn/core/stream.rb
+++ b/lib/prawn/core/stream.rb
@@ -82,7 +82,7 @@ module Prawn
             d[:Filter] = filter_names
           end
           if filter_params.any? {|f| !f.nil? }
-            d[:DecodeParams] = filter_params
+            d[:DecodeParms] = filter_params
           end
 
           d

--- a/spec/stream_spec.rb
+++ b/spec/stream_spec.rb
@@ -53,6 +53,6 @@ describe "Stream object" do
     stream << "Hello"
     stream.filters << { :FlateDecode => { :Predictor => 15 } }
 
-    stream.data[:DecodeParams].should == [{ :Predictor => 15 }]
+    stream.data[:DecodeParms].should == [{ :Predictor => 15 }]
   end
 end


### PR DESCRIPTION
This typo caused filter parameters to be saved under wrong key and thus missed
by PDF processor.

Fixes #477

PS: Doesn't **DecodeParms** look like a typo in the spec?
