### PR TITLE
Keep only .afm files regarding fonts

### DIFF
--- a/prawn.gemspec
+++ b/prawn.gemspec
@@ -3,9 +3,12 @@ Gem::Specification.new do |spec|
   spec.version = File.read(File.expand_path('VERSION', File.dirname(__FILE__))).strip
   spec.platform = Gem::Platform::RUBY
   spec.summary = "A fast and nimble PDF generator for Ruby"
-  spec.files =  Dir.glob("{examples,lib,spec,data,manual}/**/**/*") +
-    ["Rakefile", "prawn.gemspec", "COPYING", "LICENSE", "GPLv2", "GPLv3",
-     "Gemfile"]
+  spec.files =  Dir.glob("{examples,lib,spec,manual}/**/**/*") +
+                Dir.glob("data/{encodings,images,pdfs}/*") +
+                Dir.glob("data/fonts/{MustRead.html,*.afm}") +
+                ["data/shift_jis_text.txt"] +
+                ["Rakefile", "prawn.gemspec", "Gemfile",
+                 "COPYING", "LICENSE", "GPLv2", "GPLv3"]
   spec.require_path = "lib"
   spec.required_ruby_version = '>= 1.8.7'
   spec.required_rubygems_version = ">= 1.3.6"


### PR DESCRIPTION
Prawn does not use the *.ttf fonts internally so it's better not to include them in the final package. Prawn uses and offers developers build-in fonts using *.afm files, but there is no build-in support for .ttf fonts and in general it's a bad idea to include them.

Should solve font files licensing issue [1].

[1] https://github.com/prawnpdf/prawn/issues/474
