### PR TITLE
Better table cell rotation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 nbproject
 pkg 
 .rvmrc
+.ruby-version
+.ruby-gemset
 .bundle
 Gemfile.lock
 drop_to_console.rb

--- a/lib/prawn/table.rb
+++ b/lib/prawn/table.rb
@@ -13,6 +13,9 @@ require 'prawn/table/cell/text'
 require 'prawn/table/cell/subtable'
 require 'prawn/table/cell/image'
 require 'prawn/table/cell/span_dummy'
+require 'prawn/table/cell/formatted/wrap'
+require 'prawn/table/cell/formatted/box'
+require 'prawn/table/cell/box'
 
 module Prawn
 

--- a/lib/prawn/table/cell/box.rb
+++ b/lib/prawn/table/cell/box.rb
@@ -1,0 +1,29 @@
+# encoding: utf-8
+
+# text/rectangle.rb : Implements text boxes
+#
+# Copyright November 2009, Daniel Nelson. All Rights Reserved.
+#
+# This is free software. Please see the LICENSE and COPYING files for details.
+#
+
+module Prawn
+  class Table
+    class Cell
+      # Generally, one would use the Prawn::Table#new method to create a table
+      #
+      class Box < Prawn::Table::Cell::Formatted::Box
+
+        def initialize(string, options={})
+          super([{ :text => string }], options)
+        end
+
+        def render(flags={})
+          leftover = super(flags)
+          leftover.collect { |hash| hash[:text] }.join
+        end
+
+      end
+    end
+  end
+end

--- a/lib/prawn/table/cell/formatted/box.rb
+++ b/lib/prawn/table/cell/formatted/box.rb
@@ -1,0 +1,80 @@
+# encoding: utf-8
+
+# text/formatted/rectangle.rb : Implements text boxes with formatted text
+#
+# Copyright February 2010, Daniel Nelson. All Rights Reserved.
+#
+# This is free software. Please see the LICENSE and COPYING files for details.
+#
+
+module Prawn
+  class Table
+    class Cell
+      module Formatted
+        # Generally, one would use the Prawn::Text::Formatted#formatted_text_box
+        # convenience method. However, using Table::Cell::Formatted::Box.new lets
+        # you create a formatted box with the table cell rotation algorithm. In
+        # conjunction with #render(:dry_run => true) you can do look-ahead
+        # calculations prior to placing text on the page, or to determine how much
+        # vertical space was consumed by the printed text
+        #
+        class Box < Prawn::Text::Formatted::Box
+          include Prawn::Table::Cell::Formatted::Wrap
+
+          # drop rotate_around, which is not relevant to a table cell
+          def valid_options
+            Prawn::Core::Text::VALID_OPTIONS + [:at, :height, :width,
+                                                :align, :valign,
+                                                :rotate, 
+                                                :overflow, :min_font_size,
+                                                :leading, :character_spacing,
+                                                :mode, :single_line,
+                                                :skip_encoding,
+                                                :document,
+                                                :direction,
+                                                :fallback_fonts,
+                                                :draw_text_callback]
+          end
+
+          # The width available at this point in the box
+          #
+          def available_width
+            if @rotate != 0 && 
+              ((@rotate > 45 && @rotate < 135) || (@rotate > 225 && @rotate < 315))
+              @height
+            else
+              @width
+            end
+          end
+
+          # The height available at this point in the box
+          #
+          def available_height
+            if @rotate != 0 && 
+              ((@rotate > 45 && @rotate < 135) || (@rotate > 225 && @rotate < 315))
+              @width
+            else
+              @height
+            end
+          end
+
+          private
+
+          def render_rotated(text)
+            unprinted_text = ''
+
+            x = @at[0] + @height/2.0 - 1.0
+            y = @at[1] - @height/2.0 + 4.0
+
+            @document.rotate(@rotate, :origin => [x, y]) do
+              unprinted_text = wrap(text)
+            end
+            unprinted_text
+          end
+
+        end
+
+      end
+    end
+  end
+end

--- a/lib/prawn/table/cell/formatted/wrap.rb
+++ b/lib/prawn/table/cell/formatted/wrap.rb
@@ -1,0 +1,33 @@
+module Prawn
+  class Table
+    class Cell
+      module Formatted #:nodoc:
+        module Wrap #:nodoc:
+          include Prawn::Core::Text::Formatted::Wrap
+
+          private
+
+          def enough_height_for_this_line?
+            @line_height = @arranger.max_line_height
+            @descender   = @arranger.max_descender
+            @ascender    = @arranger.max_ascender
+            if @baseline_y == 0
+              diff = @ascender + @descender
+            else
+              diff = @descender + @line_height + @leading
+            end
+            required_total_height = @baseline_y.abs + diff
+            if required_total_height > available_height + 0.0001
+              # no room for the full height of this line
+              @arranger.repack_unretrieved
+              false
+            else
+              true
+            end
+          end
+
+        end
+      end
+    end
+  end
+end

--- a/lib/prawn/table/cell/text.rb
+++ b/lib/prawn/table/cell/text.rb
@@ -120,9 +120,9 @@ module Prawn
             options[:document] = @pdf
 
             array = ::Prawn::Text::Formatted::Parser.to_array(@content)
-            ::Prawn::Text::Formatted::Box.new(array, options)
+            ::Prawn::Table::Cell::Formatted::Box.new(array, options)
           else
-            ::Prawn::Text::Box.new(@content, @text_options.merge(extra_options).
+            ::Prawn::Table::Cell::Box.new(@content, @text_options.merge(extra_options).
                merge(:document => @pdf))
           end
         end

--- a/spec/cell_spec.rb
+++ b/spec/cell_spec.rb
@@ -443,9 +443,9 @@ describe "Prawn::Table::Cell" do
     it "should pass through text options like :align to Text::Box" do
       c = cell(:content => "text", :align => :right)
 
-      box = Prawn::Text::Box.new("text", :document => @pdf)
+      box = Prawn::Table::Cell::Box.new("text", :document => @pdf)
 
-      Prawn::Text::Box.expects(:new).checking do |text, options|
+      Prawn::Table::Cell::Box.expects(:new).checking do |text, options|
         text.should == "text"
         options[:align].should == :right
       end.at_least_once.returns(box)
@@ -456,9 +456,9 @@ describe "Prawn::Table::Cell" do
     it "should use font_style for Text::Box#style" do
       c = cell(:content => "text", :font_style => :bold)
 
-      box = Prawn::Text::Box.new("text", :document => @pdf)
+      box = Prawn::Table::Cell::Box.new("text", :document => @pdf)
 
-      Prawn::Text::Box.expects(:new).checking do |text, options|
+      Prawn::Table::Cell::Box.expects(:new).checking do |text, options|
         text.should == "text"
         options[:style].should == :bold
       end.at_least_once.returns(box)
@@ -476,8 +476,8 @@ describe "Prawn::Table::Cell" do
 
       c = cell(:content => "text", :font_style => :bold)
 
-      box = Prawn::Text::Box.new("text", :document => @pdf)
-      Prawn::Text::Box.expects(:new).checking do |text, options|
+      box = Prawn::Table::Cell::Box.new("text", :document => @pdf)
+      Prawn::Table::Cell::Box.expects(:new).checking do |text, options|
         text.should == "text"
         options[:style].should == :bold
         @pdf.font.family.should == 'Action Man'
@@ -489,9 +489,9 @@ describe "Prawn::Table::Cell" do
     it "should allow inline formatting in cells" do
       c = cell(:content => "foo <b>bar</b> baz", :inline_format => true)
 
-      box = Prawn::Text::Formatted::Box.new([], :document => @pdf)
+      box = Prawn::Table::Cell::Formatted::Box.new([], :document => @pdf)
 
-      Prawn::Text::Formatted::Box.expects(:new).checking do |array, options|
+      Prawn::Table::Cell::Formatted::Box.expects(:new).checking do |array, options|
         array[0][:text].should == "foo "
         array[0][:styles].should == []
 


### PR DESCRIPTION
Here is some initial work to improve table cell rotation. Right now Prawn doesn't stay within the cell (partly because the text is wrapped before the content is rotated, and partly because rotate_around moves text outside the cell for all but the simplest of cases.) This fix keeps the text wrapped correctly on rotations of 9, 90, 180, 270, etc. Intermediate angles are at better than they were for now. Here is what it looks like:

![prawn_table_rotate](https://f.cloud.github.com/assets/1423683/665435/6869ca90-d79e-11e2-8dfa-a2779f2dc600.gif)

Note that only table height is specified on that table. 

I've created Table::Cell::Box and Table::Cell::Formatted::Box which inherit from Prawn::Text::Formatted::Box. There is also Table::Cell::Formatted::Wrap which inherits from  Prawn::Core::Text::Formatted::Wrap. Only a few methods are overridden. If there is a better way to organize this, please let me know.

Intermediate angles still don't fit in the box, but they wrap reasonably well. The swap of height/width for wrapping happens on 45 degree angles. If this approach makes sense, sometime I'll tackle the wrap logic for other angles, and the text can still fit on an angle. 

One last thing. This code ignores rotate_around. I overrode valid_options so including rotate_around throws an error. Perhaps it should just be ignored?

Needed: 
- Vertical / horizontal alignment
- Wrapping in intermediate angles?
- Rotation may need to be adjusted for padding changes. 

Added a rotate test at the end of table_spec.rb. cell_spec.rb adjusted for new classes. All tests are passing. 

Other: I added .ruby-version and .ruby-gemset to .gitignore for the latest [rvm](https://github.com/wayneeseguin/rvm/issues/1694)

Issues referenced: [409](https://github.com/prawnpdf/prawn/issues/409#issuecomment-18233381) & [112](https://github.com/prawnpdf/prawn/issues/112)
