### PR TITLE
Fix github #537 : force text rendering mode for templates

### DIFF
--- a/lib/prawn/core/text.rb
+++ b/lib/prawn/core/text.rb
@@ -184,12 +184,19 @@ module Prawn
       # * :fill_stroke_clip - fill then stroke text, then add to path for clipping
       # * :clip             - add text to path for clipping
       #
+      # There's the special mode :unknown which only occurs when we're working
+      # with templates.  If left in :unknown, the first text command will force
+      # an assertion to :fill.
       def text_rendering_mode(mode=nil)
         return @text_rendering_mode || :fill if mode.nil?
         unless MODES.key?(mode)
           raise ArgumentError, "mode must be between one of #{MODES.keys.join(', ')} (#{mode})"
         end
         original_mode = @text_rendering_mode || :fill
+        if original_mode == :unknown
+          original_mode = :fill
+          add_content "\n#{MODES[:fill]} Tr"
+        end
         if original_mode == mode
           yield
         else
@@ -199,6 +206,10 @@ module Prawn
           add_content "\n#{MODES[original_mode]} Tr"
           @text_rendering_mode = original_mode
         end
+      end
+
+      def forget_text_rendering_mode!
+        @text_rendering_mode = :unknown
       end
 
       # Increases or decreases the space between characters.

--- a/lib/prawn/document.rb
+++ b/lib/prawn/document.rb
@@ -278,6 +278,7 @@ module Prawn
 
       state.page.new_content_stream if options[:template]
       use_graphic_settings(options[:template])
+      forget_text_rendering_mode! if options[:template]
 
       unless options[:orphan]
         state.insert_page(state.page, @page_number)

--- a/lib/prawn/document/internals.rb
+++ b/lib/prawn/document/internals.rb
@@ -100,6 +100,7 @@ module Prawn
           apply_margin_options(options)
           generate_margin_box
           use_graphic_settings(options[:template])
+          forget_text_rendering_mode!
         end
       end
 

--- a/lib/prawn/text/formatted/box.rb
+++ b/lib/prawn/text/formatted/box.rb
@@ -211,6 +211,11 @@ module Prawn
           @skip_encoding     = options[:skip_encoding] || @document.skip_encoding
           @draw_text_callback = options[:draw_text_callback]
 
+          # if the text rendering mode is :unknown, force it back to :fill
+          if @mode == :unknown
+            @mode = :fill
+          end
+
           if @overflow == :expand
             # if set to expand, then we simply set the bottom
             # as the bottom of the document bounds, since that


### PR DESCRIPTION
Add method forget_text_rendering_mode! to drop the text state when
working with templates.
