### PR TITLE
Fix bug for positioning of repeated table headers when a table is placed...

### DIFF
--- a/lib/prawn/table.rb
+++ b/lib/prawn/table.rb
@@ -491,8 +491,8 @@ module Prawn
     def add_header(page_of_cells, y, row)
       @header_row.each do |cell|
         cell.row = row
-        cell.dummy_cells.each {|c| c.row = row }
-        page_of_cells << [cell, [cell.x, y]]
+        x = cell.x + @pdf.bounds.left_side - @pdf.bounds.absolute_left
+        page_of_cells << [cell, [x, y]]
       end
       @header_row.height
     end


### PR DESCRIPTION
... inside of a column box and extends past the length of a page.

If you want a table to span multiple columns inside of a single page and have a header repeat for all of those columns this will allow you to do so. The current implementation makes room in the column, but writes the header over the top of the first column.
