### PR TITLE
Use the current font style in a cell.

### DIFF
--- a/lib/prawn/table/cell/text.rb
+++ b/lib/prawn/table/cell/text.rb
@@ -91,6 +91,7 @@ module Prawn
           @pdf.save_font do
             options = {}
             options[:style] = @text_options[:style] if @text_options[:style]
+            options[:style] ||= @pdf.font.options[:style] if @pdf.font.options[:style]
 
             @pdf.font(@font || @pdf.font.family, options)
 

--- a/spec/cell_spec.rb
+++ b/spec/cell_spec.rb
@@ -486,6 +486,27 @@ describe "Prawn::Table::Cell" do
       c.draw
     end
 
+
+    it "uses the style of the current font if none given" do
+      font_path = "#{Prawn::BASEDIR}/data/fonts/Action Man.dfont"
+      @pdf.font_families.merge!("Action Man" => {
+        :normal    => { :file => font_path, :font => "ActionMan" },
+        :bold      => { :file => font_path, :font => "ActionMan-Bold" },
+      })
+      @pdf.font "Action Man", style: :bold
+
+      c = cell(:content => "text")
+
+      box = Prawn::Text::Box.new("text", :document => @pdf)
+      Prawn::Text::Box.expects(:new).checking do |text, options|
+        text.should == "text"
+        @pdf.font.family.should == 'Action Man'
+        @pdf.font.options[:style].should == :bold
+      end.at_least_once.returns(box)
+
+      c.draw
+    end
+
     it "should allow inline formatting in cells" do
       c = cell(:content => "foo <b>bar</b> baz", :inline_format => true)
 


### PR DESCRIPTION
When no font style is given for a cell, use the current one.
This is especially relevant for dfont fonts, where the same
font path refers to multiple fonts.

Without this fix, when using a global style for a dfont font,
it is lost in the table.
