### PR TITLE
When going to new page, update bounding box correctly.

### DIFF
--- a/lib/prawn/document.rb
+++ b/lib/prawn/document.rb
@@ -313,6 +313,7 @@ module Prawn
       @page_number = k
       state.page = state.pages[k-1]
       generate_margin_box
+      @bounding_box = @margin_box
       @y = @bounding_box.absolute_top
     end
 

--- a/spec/document_spec.rb
+++ b/spec/document_spec.rb
@@ -288,6 +288,10 @@ describe "When reopening pages" do
     Prawn::Document.new do
       start_new_page :layout => :landscape
       lsize = [bounds.width, bounds.height]
+      bounding_box([10, 20], :width => 30, :height => 40) do
+        text 'some text to move the bounding box'
+      end
+
       go_to_page 1
       [bounds.width, bounds.height].should == lsize.reverse
     end


### PR DESCRIPTION
When going from one page to a page with other dimensions, after
the bounding box was changed (for example by drawing a table),
the bounding box was not correctly updated to the new dimensions.

Not 100% sure this is the correct solution, maybe this should be solved in generate_margin_box?
