### PR TITLE
Outline destination enhancement (backwards-compatible code, tests and documentation)

### DIFF
--- a/lib/prawn/outline.rb
+++ b/lib/prawn/outline.rb
@@ -156,8 +156,10 @@ module Prawn
     # outline#add_subsection_to
     # Takes the following arguments:
     #   title: the outline text that appears for the section.
-    #   options: destination - optional integer defining the page number for a destination link.
-    #                 - currently only :FIT destination supported with link to top of page.
+    #   options: destination - optional integer defining the page number for a destination link
+    #                          to the top of the page (using a :FIT destination).
+    #                 - or an array with a custom destination (see the #dest_* methods of the
+    #                   Prawn::Core::Destination module)
     #            closed - whether the section should show its nested outline elements.
     #                   - defaults to false.
     #            block: more nested subsections and/or page blocks
@@ -184,8 +186,10 @@ module Prawn
     # Takes the following arguments:
     #     options:
     #            title - REQUIRED. The outline text that appears for the page.
-    #            destination - integer defining the page number for the destination link.
-    #              currently only :FIT destination supported with link to top of page.
+    #            destination - optional integer defining the page number for a destination link
+    #                          to the top of the page (using a :FIT destination).
+    #                 - or an array with a custom destination (see the #dest_* methods of the
+    #                   Prawn::Core::Destination module)
     #            closed - whether the section should show its nested outline elements.
     #                   - defaults to false.
     # example usage:
@@ -224,9 +228,12 @@ module Prawn
     def create_outline_item(title, options)
       outline_item = OutlineItem.new(title, parent, options)
 
-      if options[:destination]
+      case options[:destination]
+      when Integer
         page_index = options[:destination] - 1
         outline_item.dest = [document.state.pages[page_index].dictionary, :Fit]
+      when Array
+        outline_item.dest = options[:destination]
       end
 
       outline_item.prev = prev if @prev

--- a/spec/outline_spec.rb
+++ b/spec/outline_spec.rb
@@ -87,6 +87,28 @@ describe "Outline" do
 
   end
 
+  describe "adding a custom destination" do
+    before(:each) do
+      @pdf.start_new_page
+      @pdf.text "Page 3 with a destination"
+      @pdf.add_dest('customdest', @pdf.dest_xyz(200, 200))
+      pdf = @pdf
+      @pdf.outline.update do
+        page :destination => pdf.dest_xyz(200, 200), :title => 'Custom Destination'
+      end
+      render_and_find_objects
+    end
+
+    it "should create an outline item" do
+      @custom_dest.should_not be_nil
+    end
+
+    it "should reference the custom destination" do
+      referenced_object(@custom_dest[:Dest].first).should == referenced_object(@pages.last)
+    end
+
+  end
+
   describe "addding a section later with outline#section" do
     before(:each) do
       @pdf.start_new_page
@@ -405,6 +427,7 @@ def render_and_find_objects
   @inserted_page = find_by_title('Inserted Page')
   @subsection = find_by_title('Added SubSection')
   @added_page_3 = find_by_title('Added Page 3')
+  @custom_dest = find_by_title('Custom Destination')
 end
 
 # Outline titles are stored as UTF-16. This method accepts a UTF-8 outline title


### PR DESCRIPTION
Currently, only simple :FIT destinations are allowed for outline destinations.

With this pull request it is allowed to use an Array instead of an Integer for the `:destination` key. When an array is used, it must be a correct destination, for example generated by one of the `#dest_*` methods of `Prawn::Core::Destination`.

Why? The outline normally contains links to headings and there may be more than one heading on a page and it is nice if the PDF viewer jumps to the correct location instead of the top of the page.

I needed this for a kramdown-to-pdf converter (I'm currently patching the outline object directly) and thought this might be useful to others.
