### PR TITLE
Fixed many Ruby warnings when running prawn under 'ruby -w'

### DIFF
--- a/lib/prawn/compatibility.rb
+++ b/lib/prawn/compatibility.rb
@@ -18,6 +18,10 @@ class String  #:nodoc:
         unpack("U*")
       end
     end
+
+    def each_codepoint(&block)
+      unpack("U*").each(&block)
+    end
   end
 
   if "".respond_to?(:encode)

--- a/lib/prawn/core/document_state.rb
+++ b/lib/prawn/core/document_state.rb
@@ -44,7 +44,7 @@ module Prawn
         options[:info][:Creator] ||= "Prawn"
         options[:info][:Producer] ||= "Prawn"
 
-        info = options[:info]
+        options[:info]
       end
 
       def insert_page(page, page_number)

--- a/lib/prawn/core/filter_list.rb
+++ b/lib/prawn/core/filter_list.rb
@@ -27,13 +27,13 @@ module Prawn
       alias_method :to_a, :normalized
 
       def names
-        @list.map do |(name, params)|
+        @list.map do |(name, _)|
           name
         end
       end
 
       def decode_params
-        @list.map do |(name, params)|
+        @list.map do |(_, params)|
           params
         end
       end

--- a/lib/prawn/core/object_store.rb
+++ b/lib/prawn/core/object_store.rb
@@ -279,10 +279,10 @@ module Prawn
           unless @loaded_objects.has_key?(object.id)
             @loaded_objects[object.id] = ref(nil)
             new_obj = load_object_graph(hash, hash[object])
-          if new_obj.kind_of?(PDF::Reader::Stream)
-            stream_dict = load_object_graph(hash, new_obj.hash)
-            @loaded_objects[object.id].data = stream_dict
-            @loaded_objects[object.id] << new_obj.data
+            if new_obj.kind_of?(PDF::Reader::Stream)
+              stream_dict = load_object_graph(hash, new_obj.hash)
+              @loaded_objects[object.id].data = stream_dict
+              @loaded_objects[object.id] << new_obj.data
             else
               @loaded_objects[object.id].data = new_obj
             end

--- a/lib/prawn/core/page.rb
+++ b/lib/prawn/core/page.rb
@@ -15,7 +15,8 @@ module Prawn
 
       include Prawn::Core::Page::GraphicsState
 
-      attr_accessor :document, :content, :dictionary, :margins, :stack
+      attr_accessor :document, :margins, :stack
+      attr_writer :content, :dictionary
 
       def initialize(document, options={})
         @document = document
@@ -32,7 +33,7 @@ module Prawn
       end
 
       def layout
-        return @layout if @layout
+        return @layout if defined?(@layout) && @layout
 
         mb = dictionary.data[:MediaBox]
         if mb[3] > mb[2]
@@ -43,7 +44,7 @@ module Prawn
       end
 
       def size
-        @size || dimensions[2,2]
+        defined?(@size) && @size || dimensions[2,2]
       end
 
       def in_stamp_stream?
@@ -89,7 +90,7 @@ module Prawn
       end
 
       def dictionary
-        @stamp_dictionary || document.state.store[@dictionary]
+        defined?(@stamp_dictionary) && @stamp_dictionary || document.state.store[@dictionary]
       end
 
       def resources
@@ -172,6 +173,10 @@ module Prawn
         @size     = options[:size]    ||  "LETTER"
         @layout   = options[:layout]  || :portrait
 
+        @stamp_stream      = nil
+        @stamp_dictionary  = nil
+        @imported_page     = false
+
         @content    = document.ref({})
         content << "q" << "\n"
         @dictionary = document.ref(:Type        => :Page,
@@ -180,9 +185,6 @@ module Prawn
                                    :Contents    => content)
 
         resources[:ProcSet] = [:PDF, :Text, :ImageB, :ImageC, :ImageI]
-
-        @stamp_stream      = nil
-        @stamp_dictionary  = nil
       end
 
       # some entries in the Page dict can be inherited from parent Pages dicts.

--- a/lib/prawn/core/pdf_object.rb
+++ b/lib/prawn/core/pdf_object.rb
@@ -16,7 +16,7 @@ module Prawn
     if "".respond_to?(:encode)
       # Ruby 1.9+
       def utf8_to_utf16(str)
-        utf16 = "\xFE\xFF".force_encoding("UTF-16BE") + str.encode("UTF-16BE")
+        "\xFE\xFF".force_encoding("UTF-16BE") + str.encode("UTF-16BE")
       end
 
       # encodes any string into a hex representation. The result is a string

--- a/lib/prawn/core/reference.rb
+++ b/lib/prawn/core/reference.rb
@@ -70,7 +70,7 @@ module Prawn
 
       # Marks this and all referenced objects live, recursively.
       def mark_live
-        return if @live
+        return if defined?(@live) && @live
         @live = true
         referenced_objects.each { |o| o.mark_live }
       end

--- a/lib/prawn/core/text.rb
+++ b/lib/prawn/core/text.rb
@@ -49,7 +49,7 @@ module Prawn
       # Defaults to true
       #
       def default_kerning?
-        return true if @default_kerning.nil?
+        return true if !defined?(@default_kerning)
         @default_kerning
       end
 
@@ -81,8 +81,7 @@ module Prawn
       #
       def default_leading(number=nil)
         if number.nil?
-          return 0 if @default_leading.nil?
-          @default_leading
+          defined?(@default_leading) && @default_leading || 0
         else
           @default_leading = number
         end
@@ -112,8 +111,7 @@ module Prawn
       #
       def text_direction(direction=nil)
         if direction.nil?
-          return :ltr if @text_direction.nil?
-          @text_direction
+          defined?(@text_direction) && @text_direction || :ltr
         else
           @text_direction = direction
         end
@@ -155,8 +153,7 @@ module Prawn
       #
       def fallback_fonts(fallback_fonts=nil)
         if fallback_fonts.nil?
-          return [] if @fallback_fonts.nil?
-          @fallback_fonts
+          defined?(@fallback_fonts) && @fallback_fonts || []
         else
           @fallback_fonts = fallback_fonts
         end
@@ -188,11 +185,11 @@ module Prawn
       # with templates.  If left in :unknown, the first text command will force
       # an assertion to :fill.
       def text_rendering_mode(mode=nil)
-        return @text_rendering_mode || :fill if mode.nil?
+        return (defined?(@text_rendering_mode) && @text_rendering_mode || :fill) if mode.nil?
         unless MODES.key?(mode)
           raise ArgumentError, "mode must be between one of #{MODES.keys.join(', ')} (#{mode})"
         end
-        original_mode = @text_rendering_mode || :fill
+        original_mode = self.text_rendering_mode
         if original_mode == :unknown
           original_mode = :fill
           add_content "\n#{MODES[:fill]} Tr"
@@ -217,7 +214,7 @@ module Prawn
       # For veritical text, a positive value will decrease the space.
       #
       def character_spacing(amount=nil)
-        return @character_spacing || 0 if amount.nil?
+        return defined?(@character_spacing) && @character_spacing || 0 if amount.nil?
         original_character_spacing = character_spacing
         if original_character_spacing == amount
           yield
@@ -235,7 +232,7 @@ module Prawn
       # For veritical text, a positive value will decrease the space.
       #
       def word_spacing(amount=nil)
-        return @word_spacing || 0 if amount.nil?
+        return defined?(@word_spacing) && @word_spacing || 0 if amount.nil?
         original_word_spacing = word_spacing
         if original_word_spacing == amount
           yield

--- a/lib/prawn/core/text/formatted/arranger.rb
+++ b/lib/prawn/core/text/formatted/arranger.rb
@@ -281,9 +281,9 @@ module Prawn
           end
 
           def set_line_measurement_maximums(fragment)
-            @max_line_height = [@max_line_height, fragment.line_height].compact.max
-            @max_descender = [@max_descender, fragment.descender].compact.max
-            @max_ascender = [@max_ascender, fragment.ascender].compact.max
+            @max_line_height = [defined?(@max_line_height) && @max_line_height, fragment.line_height].compact.max
+            @max_descender = [defined?(@max_descender) && @max_descender, fragment.descender].compact.max
+            @max_ascender = [defined?(@max_ascender) && @max_ascender, fragment.ascender].compact.max
           end
           
         end

--- a/lib/prawn/core/text/formatted/wrap.rb
+++ b/lib/prawn/core/text/formatted/wrap.rb
@@ -81,11 +81,11 @@ module Prawn
 
             accumulated_width = 0
             fragments_this_line.reverse! if @direction == :rtl
-            fragments_this_line.each do |fragment|
-              fragment.default_direction = @direction
-              format_and_draw_fragment(fragment, accumulated_width,
+            fragments_this_line.each do |fragment_this_line|
+              fragment_this_line.default_direction = @direction
+              format_and_draw_fragment(fragment_this_line, accumulated_width,
                                        @line_wrap.width, word_spacing)
-              accumulated_width += fragment.width
+              accumulated_width += fragment_this_line.width
             end
 
             if "".respond_to?(:force_encoding)

--- a/lib/prawn/document/page_geometry.rb
+++ b/lib/prawn/document/page_geometry.rb
@@ -131,6 +131,6 @@ module Prawn
              "LETTER" => [612.00, 792.00],
             "TABLOID" => [792.00, 1224.00] }
 
-   end
+    end
   end
 end

--- a/lib/prawn/document/snapshot.rb
+++ b/lib/prawn/document/snapshot.rb
@@ -50,7 +50,7 @@ module Prawn
         # monotonically as data is added to the document, so we share that
         # between the old and new copies.
         {:page_content    => state.page.content.deep_copy,
-         :current_page    => state.page.dictionary.deep_copy(share=[:Parent]),
+         :current_page    => state.page.dictionary.deep_copy([:Parent]),
          :bounds          => bounds.deep_copy,
          :page_number     => page_number,
          :page_kids       => state.store.pages.data[:Kids].compact.map{|kid| kid.identifier},

--- a/lib/prawn/document/span.rb
+++ b/lib/prawn/document/span.rb
@@ -33,7 +33,7 @@ module Prawn
       when :left
         margin_box.absolute_left
       when :center
-        margin_box.absolute_left + margin_box.width / 2.0 - width /2.0
+        margin_box.absolute_left + margin_box.width / 2.0 - width / 2.0
       when :right
         margin_box.absolute_right - width
       when Numeric

--- a/lib/prawn/encoding.rb
+++ b/lib/prawn/encoding.rb
@@ -111,7 +111,7 @@ module Prawn
         RUBY_VERSION >= "1.9" ? mode = "r:BINARY" : mode = "r"
         File.open(@mapping_file, mode) do |f|
           f.each do |l|
-            m, single_byte, unicode = *l.match(/([0-9A-Za-z]+);([0-9A-F]{4})/)
+            _, single_byte, unicode = *l.match(/([0-9A-Za-z]+);([0-9A-F]{4})/)
             self.class.mapping["0x#{unicode}".hex] = "0x#{single_byte}".hex if single_byte
           end
         end

--- a/lib/prawn/font.rb
+++ b/lib/prawn/font.rb
@@ -295,14 +295,6 @@ module Prawn
       @line_gap / 1000.0 * size
     end
 
-    def identifier_for(subset)
-      "#{@identifier}.#{subset}".to_sym
-    end
-
-    def inspect
-      "#{self.class.name}< #{name}: #{size} >"
-    end
-
     # Normalizes the encoding of the string to an encoding supported by the
     # font. The string is expected to be UTF-8 going in. It will be re-encoded
     # and the new string will be returned. For an in-place (destructive)

--- a/lib/prawn/font/afm.rb
+++ b/lib/prawn/font/afm.rb
@@ -161,7 +161,7 @@ module Prawn
         kerned = [[]]
         last_byte = nil
 
-        string.bytes do |byte|
+        string.each_byte do |byte|
           if k = last_byte && @kern_pair_table[[last_byte, byte]]
             kerned << -k << [byte]
           else

--- a/lib/prawn/font/ttf.rb
+++ b/lib/prawn/font/ttf.rb
@@ -188,7 +188,7 @@ module Prawn
       def kern(string)
         a = []
 
-        string.codepoints do |r|
+        string.each_codepoint do |r|
           if a.empty?
             a << [r]
           elsif (kern = kern_pairs_table[[cmap[a.last.last], cmap[r]]])
@@ -287,7 +287,7 @@ module Prawn
         map = @subsets[subset].to_unicode_map
 
         ranges = [[]]
-        lines = map.keys.sort.inject("") do |s, code|
+        map.keys.sort.inject("") do |s, code|
           ranges << [] if ranges.last.length >= 100
           unicode = map[code]
           ranges.last << "<%02x><%04x>" % [code, unicode]

--- a/lib/prawn/graphics.rb
+++ b/lib/prawn/graphics.rb
@@ -274,7 +274,6 @@ module Prawn
     # requires a radius to define bezier curve and three points. The first two points define
     # the line segment and the third point helps define the curve for the vertex.
     def rounded_vertex(radius, *points)
-      x0,y0,x1,y1,x2,y2 = points.flatten
       radial_point_1 = point_on_line(radius, points[0], points[1])
       bezier_point_1 = point_on_line((radius - radius*KAPPA), points[0], points[1] )
       radial_point_2 = point_on_line(radius, points[2], points[1])

--- a/lib/prawn/graphics/patterns.rb
+++ b/lib/prawn/graphics/patterns.rb
@@ -125,7 +125,7 @@ module Prawn
           :Extend => [true, true],
         })
 
-        shading_pattern = ref!({
+        ref!({
           :PatternType => 2, # shading pattern
           :Shading => shading,
           :Matrix => [1, 0,

--- a/lib/prawn/images/jpg.rb
+++ b/lib/prawn/images/jpg.rb
@@ -40,7 +40,7 @@ module Prawn
             break
           end
 
-          buffer = data.read(length - 2)
+          data.read(length - 2)
         end
       end
 

--- a/lib/prawn/images/png.rb
+++ b/lib/prawn/images/png.rb
@@ -290,28 +290,27 @@ module Prawn
           case filter
           when 0 # None
           when 1 # Sub
-            row_data.each_with_index do |byte, index|
+            row_data.each_with_index do |row_byte, index|
               left = index < pixel_bytes ? 0 : row_data[index - pixel_bytes]
-              row_data[index] = (byte + left) % 256
-              #p [byte, left, row_data[index]]
+              row_data[index] = (row_byte + left) % 256
             end
           when 2 # Up
-            row_data.each_with_index do |byte, index|
+            row_data.each_with_index do |row_byte, index|
               col = (index / pixel_bytes).floor
               upper = row == 0 ? 0 : pixels[row-1][col][index % pixel_bytes]
-              row_data[index] = (upper + byte) % 256
+              row_data[index] = (upper + row_byte) % 256
             end
           when 3  # Average
-            row_data.each_with_index do |byte, index|
+            row_data.each_with_index do |row_byte, index|
               col = (index / pixel_bytes).floor
               upper = row == 0 ? 0 : pixels[row-1][col][index % pixel_bytes]
               left = index < pixel_bytes ? 0 : row_data[index - pixel_bytes]
 
-              row_data[index] = (byte + ((left + upper)/2).floor) % 256
+              row_data[index] = (row_byte + ((left + upper)/2).floor) % 256
             end
           when 4 # Paeth
             left = upper = upper_left = nil
-            row_data.each_with_index do |byte, index|
+            row_data.each_with_index do |row_byte, index|
               col = (index / pixel_bytes).floor
 
               left = index < pixel_bytes ? 0 : row_data[index - pixel_bytes]
@@ -336,7 +335,7 @@ module Prawn
                 upper_left
               end
 
-              row_data[index] = (byte + paeth) % 256
+              row_data[index] = (row_byte + paeth) % 256
             end
           else
             raise ArgumentError, "Invalid filter algorithm #{filter}"

--- a/lib/prawn/outline.rb
+++ b/lib/prawn/outline.rb
@@ -320,7 +320,7 @@ module Prawn
       hash = { :Title => title,
                :Parent => parent,
                :Count => closed ? -count : count }
-      [{:First => first}, {:Last => last}, {:Next => @next},
+      [{:First => first}, {:Last => last}, {:Next => defined?(@next) && @next},
        {:Prev => prev}, {:Dest => dest}].each do |h|
         unless h.values.first.nil?
           hash.merge!(h)

--- a/lib/prawn/table.rb
+++ b/lib/prawn/table.rb
@@ -300,8 +300,8 @@ module Prawn
           if cell.height > (cell.y + offset) - ref_bounds.absolute_bottom &&
              cell.row > started_new_page_at_row
             # Ink all cells on the current page
-            if @before_rendering_page
-              c = Cells.new(cells_this_page.map { |c, _| c })
+            if defined?(@before_rendering_page) && @before_rendering_page
+              c = Cells.new(cells_this_page.map { |ci, _| ci })
               @before_rendering_page.call(c)
             end
             Cell.draw_cells(cells_this_page)
@@ -330,7 +330,7 @@ module Prawn
           y -= @pdf.bounds.absolute_bottom
 
           # Set background color, if any.
-          if @row_colors && (!@header || cell.row > 0)
+          if defined?(@row_colors) && @row_colors && (!@header || cell.row > 0)
             # Ensure coloring restarts on every page (to make sure the header
             # and first row of a page are not colored the same way).
             index = cell.row - [started_new_page_at_row, @header ? 1 : 0].max
@@ -341,8 +341,8 @@ module Prawn
           last_y = y
         end
         # Draw the last page of cells
-        if @before_rendering_page
-          c = Cells.new(cells_this_page.map { |c, _| c })
+        if defined?(@before_rendering_page) && @before_rendering_page
+          c = Cells.new(cells_this_page.map { |ci, _| ci })
           @before_rendering_page.call(c)
         end
         Cell.draw_cells(cells_this_page)
@@ -449,7 +449,7 @@ module Prawn
               next if i == 0 && j == 0
 
               # It is an error to specify spans that overlap; catch this here
-              if bad_cell = cells[row_number + i, column_number + j]
+              if cells[row_number + i, column_number + j]
                 raise Prawn::Errors::InvalidTableSpan,
                   "Spans overlap at row #{row_number + i}, " +
                   "column #{column_number + j}."
@@ -580,7 +580,7 @@ module Prawn
     # :position option, and yields.
     #
     def with_position
-      x = case @position || :left
+      x = case defined?(@position) && @position || :left
           when :left   then return yield
           when :center then (@pdf.bounds.width - width) / 2.0
           when :right  then  @pdf.bounds.width - width

--- a/lib/prawn/table/cell.rb
+++ b/lib/prawn/table/cell.rb
@@ -163,7 +163,7 @@ module Prawn
           content.kind_of?(Date)
 
         if content.is_a?(Hash)
-          if img = content[:image]
+          if content[:image]
             return Cell::Image.new(pdf, at, content)
           end
           options.update(content)
@@ -245,7 +245,7 @@ module Prawn
       def width_ignoring_span
         # We can't ||= here because the FP error accumulates on the round-trip
         # from #content_width.
-        @width || (content_width + padding_left + padding_right)
+        defined?(@width) && @width || (content_width + padding_left + padding_right)
       end
 
       # Returns the cell's width in points, inclusive of padding. If the cell is
@@ -275,7 +275,7 @@ module Prawn
       # Returns the width of the bare content in the cell, excluding padding.
       #
       def content_width
-        if @width # manually set
+        if defined?(@width) && @width # manually set
           return @width - padding_left - padding_right
         end
 
@@ -302,7 +302,7 @@ module Prawn
       def height_ignoring_span
         # We can't ||= here because the FP error accumulates on the round-trip
         # from #content_height.
-        @height || (content_height + padding_top + padding_bottom)
+        defined?(@height) && @height || (content_height + padding_top + padding_bottom)
       end
 
       # Returns the cell's height in points, inclusive of padding. If the cell
@@ -325,7 +325,7 @@ module Prawn
       # Returns the height of the bare content in the cell, excluding padding.
       #
       def content_height
-        if @height # manually set
+        if defined?(@height) && @height # manually set
           return @height - padding_top - padding_bottom
         end
 
@@ -359,7 +359,7 @@ module Prawn
       #   pdf.table([["foo", "bar"]]) { cells[0, 1].colspan = 2 }
       #
       def colspan=(span)
-        if @initializer_run
+        if defined?(@initializer_run) && @initializer_run
           raise Prawn::Errors::InvalidTableSpan,
             "colspan must be provided in the table's structure, never in the " +
             "initialization block. See Prawn's documentation for details."
@@ -380,7 +380,7 @@ module Prawn
       #   pdf.table([["foo", "bar"], ["baz"]]) { cells[0, 1].rowspan = 2 }
       #
       def rowspan=(span)
-        if @initializer_run
+        if defined?(@initializer_run) && @initializer_run
           raise Prawn::Errors::InvalidTableSpan,
             "rowspan must be provided in the table's structure, never in the " +
             "initialization block. See Prawn's documentation for details."
@@ -543,14 +543,6 @@ module Prawn
         @border_colors[0] = val
       end
 
-      def border_top_color
-        @border_colors[0]
-      end
-
-      def border_top_color=(val)
-        @border_colors[0] = val
-      end
-
       def border_right_color
         @border_colors[1]
       end
@@ -704,7 +696,7 @@ module Prawn
       # Draws the cell's background color.
       #
       def draw_background(pt)
-        if @background_color
+        if defined?(@background_color) && @background_color
           @pdf.mask(:fill_color) do
             @pdf.fill_color @background_color
             @pdf.fill_rectangle pt, width, height

--- a/lib/prawn/table/cell/text.rb
+++ b/lib/prawn/table/cell/text.rb
@@ -78,7 +78,7 @@ module Prawn
           # Sets a reasonable minimum width. If the cell has any content, make
           # sure we have enough width to be at least one character wide. This is
           # a bit of a hack, but it should work well enough.
-          unless @min_width
+          unless defined?(@min_width) && @min_width
             min_content_width = [natural_content_width, styled_width_of_single_character].min
             @min_width = padding_left + padding_right + min_content_width
             super
@@ -93,14 +93,14 @@ module Prawn
             options[:style] = @text_options[:style] if @text_options[:style]
             options[:style] ||= @pdf.font.options[:style] if @pdf.font.options[:style]
 
-            @pdf.font(@font || @pdf.font.family, options)
+            @pdf.font(defined?(@font) && @font || @pdf.font.family, options)
 
             yield
           end
         end
 
         def with_text_color
-          if @text_color
+          if defined?(@text_color) && @text_color
             begin
               old_color = @pdf.fill_color || '000000'
               @pdf.fill_color(@text_color)

--- a/lib/prawn/table/cells.rb
+++ b/lib/prawn/table/cells.rb
@@ -46,7 +46,7 @@ module Prawn
       #   table.rows(3..4) # selects rows four and five
       #
       def rows(row_spec)
-        index_cells unless @indexed
+        index_cells unless defined?(@indexed) && @indexed
         row_spec = transform_spec(row_spec, @first_row, @row_count)
         Cells.new(@rows[row_spec] ||= select { |c|
                     row_spec.respond_to?(:include?) ?
@@ -57,7 +57,7 @@ module Prawn
       # Returns the number of rows in the list.
       #
       def row_count
-        index_cells unless @indexed
+        index_cells unless defined?(@indexed) && @indexed
         @row_count
       end
 
@@ -69,7 +69,7 @@ module Prawn
       #   table.columns(3..4) # selects columns four and five
       #
       def columns(col_spec)
-        index_cells unless @indexed
+        index_cells unless defined?(@indexed) && @indexed
         col_spec = transform_spec(col_spec, @first_column, @column_count)
         Cells.new(@columns[col_spec] ||= select { |c|
                     col_spec.respond_to?(:include?) ? 
@@ -80,7 +80,7 @@ module Prawn
       # Returns the number of columns in the list.
       #
       def column_count
-        index_cells unless @indexed
+        index_cells unless defined?(@indexed) && @indexed
         @column_count
       end
 
@@ -100,7 +100,7 @@ module Prawn
       #
       def [](row, col)
         return nil if empty?
-        index_cells unless @indexed
+        index_cells unless defined?(@indexed) && @indexed
         row_array, col_array = @rows[@first_row + row] || [], @columns[@first_column + col] || []
         if row_array.length < col_array.length
           row_array.find { |c| c.column == @first_column + col }
@@ -116,7 +116,7 @@ module Prawn
         cell.row = row
         cell.column = col
 
-        if @indexed
+        if defined?(@indexed) && @indexed
           (@rows[row]    ||= []) << cell
           (@columns[col] ||= []) << cell
           @first_row    = row if !@first_row    || row < @first_row
@@ -154,7 +154,6 @@ module Prawn
       def width
         widths = {}
         each do |cell|
-          index = cell.column
           per_cell_width = cell.width_ignoring_span.to_f / cell.colspan
           cell.colspan.times do |n|
             widths[cell.column+n] = [widths[cell.column+n], per_cell_width].

--- a/lib/prawn/text.rb
+++ b/lib/prawn/text.rb
@@ -282,7 +282,7 @@ module Prawn
       text = text.to_s.dup
       save_font do
         process_text_options(options)
-        font.normalize_encoding!(text) unless @skip_encoding
+        font.normalize_encoding!(text)
         font_size(options[:size]) { draw_text!(text, options) }
       end
     end
@@ -326,7 +326,7 @@ module Prawn
       box = Text::Formatted::Box.new(array,
                           options.merge(:height   => 100000000,
                                         :document => self))
-      printed = box.render(:dry_run => true)
+      box.render(:dry_run => true)
 
       height = box.height
       height += box.line_gap + box.leading if @final_gap

--- a/lib/prawn/text/formatted/box.rb
+++ b/lib/prawn/text/formatted/box.rb
@@ -455,7 +455,7 @@ module Prawn
           # we need to wait until render() is called so that the fonts are set
           # up properly for wrapping. So guard with a boolean to ensure this is
           # only run once.
-          return if @vertical_alignment_processed
+          return if defined?(@vertical_alignment_processed) && @vertical_alignment_processed
           @vertical_alignment_processed = true
 
           return if @vertical_align == :top

--- a/lib/prawn/text/formatted/parser.rb
+++ b/lib/prawn/text/formatted/parser.rb
@@ -29,7 +29,7 @@ module Prawn
                          "<em>|</em>|" +
                          "<a[^>]*>|</a>|" +
                          "[^<\n]+"
-          regex = Regexp.new(regex_string, Regexp::MULTILINE)
+          Regexp.new(regex_string, Regexp::MULTILINE)
         end
 
         def self.to_array(string)


### PR DESCRIPTION
In issue #544 it was mentioned that the Ruby interpreter issues many warnings when running Prawn.

This pull request fixes all warnings in the main Prawn library (not pdf-reader nor ttfunk) that show when running `rake manual`.

This means that all
- places where variables were shadowed,
- places where instance variables are not initialized,
- places with mismatched indentation,
- places where deprecated methods are used and
- places with unused variables

that used to generate a warning are now fixed.

Running the specs under Ruby 2.0.0 produced no problems.
