### PR TITLE
Refactor so images via Pathname are read in binmode

### DIFF
--- a/lib/prawn/images.rb
+++ b/lib/prawn/images.rb
@@ -64,10 +64,11 @@ module Prawn
     # (See also: Prawn::Images::PNG , Prawn::Images::JPG)
     # 
     def image(file, options={})
+      io = verify_and_open_image(file)
       Prawn.verify_options [:at, :position, :vposition, :height, 
                             :width, :scale, :fit], options
 
-      pdf_obj, info = build_image_object(file)
+      pdf_obj, info = build_image_object(io)
       embed_image(pdf_obj, info, options)
 
       info
@@ -76,20 +77,8 @@ module Prawn
     # Builds an info object (Prawn::Images::*) and a PDF reference representing
     # the given image. Return a pair: [pdf_obj, info].
     #
-    def build_image_object(file)
-      # Rewind if the object we're passed is an IO, so that multiple embeds of
-      # the same IO object will work
-      file.rewind  if file.respond_to?(:rewind)
-      # read the file as binary so the size is calculated correctly
-      file.binmode if file.respond_to?(:binmode)
-
-      if file.respond_to?(:read)
-        image_content = file.read
-      else
-        raise ArgumentError, "#{file} not found" unless File.file?(file)  
-        image_content = File.binread(file)
-      end
-      
+    def build_image_object(io)
+      image_content = io.read
       image_sha1 = Digest::SHA1.hexdigest(image_content)
 
       # if this image has already been embedded, just reuse it
@@ -142,6 +131,24 @@ module Prawn
     end
     
     private   
+
+    def verify_and_open_image(io_or_path)
+      # File or IO
+      if io_or_path.respond_to?(:binmode)
+        io = io_or_path 
+        # Rewind if the object we're passed is an IO, so that multiple embeds of
+        # the same IO object will work
+        io.rewind
+        # read the file as binary so the size is calculated correctly
+        io.binmode
+        return io
+      end
+      # String or Pathname
+      io_or_path = Pathname.new(io_or_path)
+      raise ArgumentError, "#{io_or_path} not found" unless io_or_path.file?
+      io = io_or_path.open(:mode => 'rb')
+      io
+    end
 
     def image_position(w,h,options)
       options[:position] ||= :left

--- a/spec/images_spec.rb
+++ b/spec/images_spec.rb
@@ -51,6 +51,23 @@ describe "the image() function" do
     info.height.should == 453
   end
 
+  context "setting the length of the bytestream" do
+    it "should correctly work with images from Pathname objects" do
+      info = @pdf.image(Pathname.new(@filename))
+      expect(@pdf).to have_parseable_xobjects
+    end
+
+    it "should correctly work with images from IO objects" do
+      info = @pdf.image(File.open(@filename, 'rb'))
+      expect(@pdf).to have_parseable_xobjects
+    end
+
+    it "should correctly work with images from IO objects not set to mode rb" do
+      info = @pdf.image(File.open(@filename, 'r'))
+      expect(@pdf).to have_parseable_xobjects
+    end
+  end
+
   it "should raise_error an UnsupportedImageType if passed a BMP" do
     filename = "#{Prawn::DATADIR}/images/tru256.bmp"
     lambda { @pdf.image filename, :at => [100,100] }.should raise_error(Prawn::Errors::UnsupportedImageType)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,6 +29,16 @@ def create_pdf(klass=Prawn::Document)
   @pdf = klass.new(:margin => 0)
 end    
 
+RSpec::Matchers.define :have_parseable_xobjects do
+  match do |actual|
+    expect { PDF::Inspector::XObject.analyze(actual.render) }.not_to raise_error
+    true
+  end
+  failure_message_for_should do |actual|
+    "expected that #{actual}'s XObjects could be successfully parsed"
+  end
+end
+
 # Make some methods public to assist in testing
 module Prawn::Graphics
   public :map_to_absolute


### PR DESCRIPTION
- Separate out image IO opening and verification logic
- test that embedded images parse correctly (this was the problem that
  was being masked before)
- Add simple matcher to tidy up checking XObject parseability
- fixes #570:

Pathname instances respond to #read but not #binmode, and the old code
was assuming that anything which responded to #read was an IO, with the
result that Pathname instances were beign treated as IO's and getting
read called on them, bypassing File.binread (things responding
to #binmode have that called so with a real IO it would have #read
called after it had been put into binmode...

The fix is simple enough: treat everything that responds to binmode as
an IO (IO's and Files), and anything else treat as a path, and open it
'rb'.
