### PR TITLE
Refactor so images via Pathname are read in binmode

### DIFF
--- a/spec/images_spec.rb
+++ b/spec/images_spec.rb
@@ -51,6 +51,23 @@ describe "the image() function" do
     info.height.should == 453
   end
 
+  context "setting the length of the bytestream" do
+    it "should correctly work with images from Pathname objects" do
+      info = @pdf.image(Pathname.new(@filename))
+      expect(@pdf).to have_parseable_xobjects
+    end
+
+    it "should correctly work with images from IO objects" do
+      info = @pdf.image(File.open(@filename, 'rb'))
+      expect(@pdf).to have_parseable_xobjects
+    end
+
+    it "should correctly work with images from IO objects not set to mode rb" do
+      info = @pdf.image(File.open(@filename, 'r'))
+      expect(@pdf).to have_parseable_xobjects
+    end
+  end
+
   it "should raise_error an UnsupportedImageType if passed a BMP" do
     filename = "#{Prawn::DATADIR}/images/tru256.bmp"
     lambda { @pdf.image filename, :at => [100,100] }.should raise_error(Prawn::Errors::UnsupportedImageType)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,6 +29,16 @@ def create_pdf(klass=Prawn::Document)
   @pdf = klass.new(:margin => 0)
 end    
 
+RSpec::Matchers.define :have_parseable_xobjects do
+  match do |actual|
+    expect { PDF::Inspector::XObject.analyze(actual.render) }.not_to raise_error
+    true
+  end
+  failure_message_for_should do |actual|
+    "expected that #{actual}'s XObjects could be successfully parsed"
+  end
+end
+
 # Make some methods public to assist in testing
 module Prawn::Graphics
   public :map_to_absolute


### PR DESCRIPTION
- Separate out image IO opening and verification logic
- test that embedded images parse correctly (this was the problem that
  was being masked before)
- Add simple matcher to tidy up checking XObject parseability
- fixes #570:

Pathname instances respond to #read but not #binmode, and the old code
was assuming that anything which responded to #read was an IO, with the
result that Pathname instances were beign treated as IO's and getting
read called on them, bypassing File.binread (things responding
to #binmode have that called so with a real IO it would have #read
called after it had been put into binmode...

The fix is simple enough: treat everything that responds to binmode as
an IO (IO's and Files), and anything else treat as a path, and open it
'rb'.
