### PR TITLE
Add initial x coordinate to add_header

### DIFF
--- a/lib/prawn/table.rb
+++ b/lib/prawn/table.rb
@@ -322,16 +322,17 @@ module Prawn
 
             # start a new page or column
             @pdf.bounds.move_past_bottom
+            x_offset = @pdf.bounds.left_side - @pdf.bounds.absolute_left
             if cell.row > 0 && @header
               if @header.is_a? Integer
                 header_height = 0
                 y_coord = @pdf.cursor
                 @header.times do |h|
-                  additional_header_height = add_header(cells_this_page, y_coord-header_height, cell.row-1, h)
+                  additional_header_height = add_header(cells_this_page, x_offset, y_coord-header_height, cell.row-1, h)
                   header_height += additional_header_height
                 end
               else
-                header_height = add_header(cells_this_page, @pdf.cursor, cell.row-1)
+                header_height = add_header(cells_this_page, x_offset, @pdf.cursor, cell.row-1)
               end
             else
               header_height = 0
@@ -518,13 +519,13 @@ module Prawn
     #
     # Return the height of the header.
     #
-    def add_header(page_of_cells, y, row, row_of_header=nil)
+    def add_header(page_of_cells, x_offset, y, row, row_of_header=nil)
       rows_to_operate_on = @header_row
       rows_to_operate_on = @header_row.rows(row_of_header) if row_of_header
       rows_to_operate_on.each do |cell|
         cell.row = row
         cell.dummy_cells.each {|c| c.row = row }
-        page_of_cells << [cell, [cell.x, y]]
+        page_of_cells << [cell, [cell.x + x_offset, y]]
       end
       rows_to_operate_on.height
     end

--- a/spec/table_spec.rb
+++ b/spec/table_spec.rb
@@ -974,6 +974,22 @@ describe "Prawn::Table" do
         @pdf.table(data, :header => true)
       end
 
+      it "draws headers at the correct position with column box" do
+        data = [["header"]] + [["foo"]] * 40
+
+        Prawn::Table::Cell.expects(:draw_cells).times(2).checking do |cells|
+          cells.each do |cell, pt|
+            if cell.content == "header"
+              pt[0].should == @pdf.bounds.left
+            end
+          end
+        end
+        @pdf = Prawn::Document.new
+        @pdf.column_box [0, @pdf.cursor], :width => @pdf.bounds.width, :columns => 2 do
+            @pdf.table(data, :header => true)
+          end
+      end
+
       it "should_not draw header twice when starting new page" do
         @pdf = Prawn::Document.new
         @pdf.y = 0


### PR DESCRIPTION
Hi,

This is a new pull request to replace #372. Here is an example that produces the problem:

``` ruby
# This file is bugs/column_boxes_and_tables.rb
$LOAD_PATH << File.join(File.dirname(__FILE__), '..', 'lib')
require "prawn"
Prawn::Document.generate('headers_drawing_on_same_column.pdf') do
  data = [["This row should be repeated on every new page AND COLUMN"]]
  data += [["..."]] * 50
  column_box([0, cursor], :columns => 2, :width => 
bounds.width) do
    table(data, :header => true)
  end
end
```

This produces: 
![headers_drawing_on_same_column pdf__page_1_of_2_-7](https://f.cloud.github.com/assets/4662860/1568277/33f5b828-50ac-11e3-9260-26f886aeb253.jpg)

Thanks for your time and let me know what you think!
