### PR TITLE
Refactor so images via Pathname are read in binmode

### DIFF
--- a/lib/prawn/images.rb
+++ b/lib/prawn/images.rb
@@ -76,19 +76,8 @@ module Prawn
     # the given image. Return a pair: [pdf_obj, info].
     #
     def build_image_object(file)
-      # Rewind if the object we're passed is an IO, so that multiple embeds of
-      # the same IO object will work
-      file.rewind  if file.respond_to?(:rewind)
-      # read the file as binary so the size is calculated correctly
-      file.binmode if file.respond_to?(:binmode)
-
-      if file.respond_to?(:read)
-        image_content = file.read
-      else
-        raise ArgumentError, "#{file} not found" unless File.file?(file)  
-        image_content = File.binread(file)
-      end
-      
+      io = verify_and_open_image(file)
+      image_content = io.read
       image_sha1 = Digest::SHA1.hexdigest(image_content)
 
       # if this image has already been embedded, just reuse it
@@ -137,6 +126,25 @@ module Prawn
     end
 
     private
+
+    def verify_and_open_image(io_or_path)
+      # File or IO
+      if io_or_path.respond_to?(:rewind)
+        io = io_or_path
+        # Rewind if the object we're passed is an IO, so that multiple embeds of
+        # the same IO object will work
+        io.rewind
+        # read the file as binary so the size is calculated correctly
+        # guard binmode because some objects acting io-like don't implement it
+        io.binmode if io.respond_to?(:binmode)
+        return io
+      end
+      # String or Pathname
+      io_or_path = Pathname.new(io_or_path)
+      raise ArgumentError, "#{io_or_path} not found" unless io_or_path.file?
+      io = io_or_path.open('rb')
+      io
+    end
 
     def image_position(w,h,options)
       options[:position] ||= :left

--- a/spec/images_spec.rb
+++ b/spec/images_spec.rb
@@ -51,6 +51,23 @@ describe "the image() function" do
     info.height.should == 453
   end
 
+  context "setting the length of the bytestream" do
+    it "should correctly work with images from Pathname objects" do
+      info = @pdf.image(Pathname.new(@filename))
+      expect(@pdf).to have_parseable_xobjects
+    end
+
+    it "should correctly work with images from IO objects" do
+      info = @pdf.image(File.open(@filename, 'rb'))
+      expect(@pdf).to have_parseable_xobjects
+    end
+
+    it "should correctly work with images from IO objects not set to mode rb" do
+      info = @pdf.image(File.open(@filename, 'r'))
+      expect(@pdf).to have_parseable_xobjects
+    end
+  end
+
   it "should raise_error an UnsupportedImageType if passed a BMP" do
     filename = "#{Prawn::DATADIR}/images/tru256.bmp"
     lambda { @pdf.image filename, :at => [100,100] }.should raise_error(Prawn::Errors::UnsupportedImageType)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,6 +29,16 @@ def create_pdf(klass=Prawn::Document)
   @pdf = klass.new(:margin => 0)
 end    
 
+RSpec::Matchers.define :have_parseable_xobjects do
+  match do |actual|
+    expect { PDF::Inspector::XObject.analyze(actual.render) }.not_to raise_error
+    true
+  end
+  failure_message_for_should do |actual|
+    "expected that #{actual}'s XObjects could be successfully parsed"
+  end
+end
+
 # Make some methods public to assist in testing
 module Prawn::Graphics
   public :map_to_absolute


### PR DESCRIPTION
- Separate out image IO opening and verification logic
- test that embedded images parse correctly (this was the problem that
  was being masked before)
- Add simple matcher to tidy up checking XObject parseability
- fixes #570:
- don't rely on binmode being defined on IO-like objects (re: #585)

Pathname instances respond to #read but not #binmode, and the old code
was assuming that anything which responded to #read was an IO, with the
result that Pathname instances were beign treated as IO's and getting
read called on them, bypassing File.binread (things responding
to #binmode have that called so with a real IO it would have #read
called after it had been put into binmode...

The fix is simple enough: treat everything that responds to `rewind` as
an IO (IO's and Files), and anything else treat as a path, and open it
'rb'.

The call to `#binmode` is guarded because of #585, and the chances of other 
IO-alikes not implementing binmode either.
