### PR TITLE
Remove AFM gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,6 @@ source "https://rubygems.org"
 gem "ttfunk", "~>1.0.3"
 gem "pdf-reader", "~> 1.2"
 gem "ruby-rc4"
-gem "afm"
 
 platforms :rbx do
   gem "rubysl-singleton", "~> 2.0"

--- a/prawn.gemspec
+++ b/prawn.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency('pdf-reader', '~>1.2')
   spec.add_dependency('ttfunk', '~>1.0.3')
   spec.add_dependency('ruby-rc4')
-  spec.add_dependency('afm')
   spec.add_development_dependency('pdf-inspector', '~> 1.1.0')
   spec.add_development_dependency('coderay', '~> 1.0.7')
   spec.add_development_dependency('rdoc')


### PR DESCRIPTION
This should fix #499 and #578, which appear to have been introduced by the AFM gem. I woud prefer we go back to managing this code ourselves anyway, because there isn't a ton of it and it is well constrained.

If we want PDF::Reader to use the same processor as us, that's OK. I think we can roll this into PDF::Core if and when we break it out.
