### PR TITLE
Jpg optimization

### DIFF
--- a/lib/prawn/images/jpg.rb
+++ b/lib/prawn/images/jpg.rb
@@ -18,7 +18,6 @@ module Prawn
       attr_accessor :scaled_width, :scaled_height
 
       JPEG_SOF_BLOCKS = [0xC0, 0xC1, 0xC2, 0xC3, 0xC5, 0xC6, 0xC7, 0xC9, 0xCA, 0xCB, 0xCD, 0xCE, 0xCF]
-      JPEG_APP_BLOCKS = %W(\xe0 \xe1 \xe2 \xe3 \xe4 \xe5 \xe6 \xe7 \xe8 \xe9 \xea \xeb \xec \xed \xee \xef)
 
       def self.can_render?(image_blob)
         image_blob[0, 3].unpack("C*") == [255, 216, 255]


### PR DESCRIPTION
There were a few unnecessary reads. Speed up is especially prominent on JRuby.

JPEG Image: 9,311,851 bytes
1,000,000 iterations

The following measurements are only for JPG initialization:

``` ruby
Prawn::Images::JPG.new(img)
```
### MRI 1.9.3

```
             user     system      total        real    memory
Before: 32.770000   0.260000  33.030000 ( 33.491774)  34.5 MB
After:  19.600000   0.050000  19.650000 ( 19.793003)  29.6 MB
```

Speed: **1.68x faster**
Memory: **14% less**
### MRI 2.0.0

```
             user     system      total        real   memory
Before: 37.660000   0.200000  37.860000 ( 38.482895)  33.9 MB
After:  24.170000   0.060000  24.230000 ( 24.422936)  29.8 MB
```

Speed: **1.56x faster**
Memory: **12% less**
### JRuby 1.7.9

```
                user     system        total         real   memory
Before: 10487.800000 295.590000 10783.390000 (7131.061000)  528.3 MB (549.9 MB peak)
After:      7.350000   0.180000     7.530000 (   6.400000)  114.7 MB
```

Speed: **1,432x faster**
Memory: **78% less**
### Rubinius 2.2.1

```
             user     system      total        real   memory
Before: 21.270153   0.239070  21.509223 ( 20.862641)  150.1 Mb
After:  16.131227   0.186280  16.317507 ( 15.169135)  143.4 MB
```

Speed: **1.32x faster**
Memory: **4% less**
