### PR TITLE
Use require_relative to prevent encoding.rb from being loaded twice

### DIFF
--- a/lib/prawn/font/afm.rb
+++ b/lib/prawn/font/afm.rb
@@ -6,7 +6,7 @@
 #
 # This is free software. Please see the LICENSE and COPYING files for details.
 
-require 'prawn/encoding'
+require_relative '../../prawn/encoding'
 
 module Prawn
   class Font


### PR DESCRIPTION
Ever since 2c321b24ca, I get this warning when loading up a console session:

```
/usr/local/Cellar/rbenv/0.4.0/versions/1.9.3-p429/lib/ruby/gems/1.9.1/gems/prawn-0.13.1/lib/prawn/encoding.rb:12:
warning: already initialized constant CHARACTERS
```

From what I can tell, this happens because prawn.rb now uses `require_relative` to load in the rest of the library. When it loads `prawn/font`, `prawn/font/afm` gets required, which in turn requires `prawn/encoding`. Next, prawn.rb loads `prawn/encoding`, which should be ignored, because it's already loaded, but what I find is that, for me, locally, `require` loads encoding.rb from `/usr/local/opt/rbenv/{etc}`, while `require_relative` loads it from `/usr/local/Cellar/rbenv/{etc}`.

These are the same files (I'm using rbenv and homebrew), but it seems like ruby doesn't realize that and tries to load both. This commit switches the `require` in afm.rb to use `require_relative`, which resolves the issue for me.

If there is an alternate way to resolve this, perhaps at a config level on just my system, I am all ears!
