### PR TITLE
Add experimental YARDoc task

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ end
 group :development do
   gem "coderay", "~> 1.0.7"
   gem "rdoc"
+  gem "yard"
 end
 
 group :test do

--- a/Rakefile
+++ b/Rakefile
@@ -4,6 +4,7 @@ Bundler.setup
 require 'rake'
 require 'rspec/core/rake_task'
 require 'rdoc/task'
+require 'yard'
 require 'rubygems/package_task'
 
 task :default => [:spec]
@@ -31,6 +32,12 @@ RDoc::Task.new do |rdoc|
   rdoc.rdoc_dir = "doc/html"
   rdoc.title    = "Prawn Documentation"
 end
+
+YARD::Rake::YardocTask.new do |t|
+  t.files   = ['lib/**/*.rb', '-', 'README.md', 'COPYING', 'LICENSE', 'CONTRIBUTING.md']   # optional
+  t.options = ['--main', 'README.md', '--output-dir', 'doc/html', '--title', 'Prawn Documentation']
+end
+
 
 desc "Generate the 'Prawn by Example' manual"
 task :manual do


### PR DESCRIPTION
Generate documentation with YARD using the following command:

```
bundle exec rake yard
```

_Note_: This is only a half of it. It only adds `yard` task. You still can use old doc task. If this is OK let me know and I'll commit removal of RDoc task.
