### PR TITLE
Extract YARD options into .yardoc

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,9 @@
+--charset UTF-8
+--main README.md
+--title 'Prawn Documentation'
+lib/**/*.rb
+-
+CONTRIBUTING.md
+COPYING
+LICENSE
+README.md

--- a/Rakefile
+++ b/Rakefile
@@ -21,13 +21,10 @@ task :stats do
                       ["Specs", "spec"] ).to_s
 end
 
-desc "genrates documentation"
 YARD::Rake::YardocTask.new do |t|
-  t.files   = ['lib/**/*.rb', '-', 'README.md', 
-               'COPYING', 'LICENSE', 'CONTRIBUTING.md']   # optional
-  t.options = ['--main', 'README.md', '--output-dir', 'doc/html', 
-               '--title', 'Prawn Documentation']
+  t.options = ['--output-dir', 'doc/html']
 end
+task :docs => :yard
 
 
 desc "Generate the 'Prawn by Example' manual"

--- a/prawn.gemspec
+++ b/prawn.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
                 Dir.glob("data/fonts/{MustRead.html,*.afm}") +
                 ["data/shift_jis_text.txt"] +
                 ["Rakefile", "prawn.gemspec", "Gemfile",
-                 "COPYING", "LICENSE", "GPLv2", "GPLv3"]
+                 "COPYING", "LICENSE", "GPLv2", "GPLv3", ".yardopts"]
   spec.require_path = "lib"
   spec.required_ruby_version = '>= 1.9.3'
   spec.required_rubygems_version = ">= 1.3.6"


### PR DESCRIPTION
This is required for YARD to build docs on gem install

:shipit:
