### PR TITLE
table column widths where not always correctly calculated - fixes bug reported under issue #628

### DIFF
--- a/lib/prawn/table/cells.rb
+++ b/lib/prawn/table/cells.rb
@@ -240,6 +240,9 @@ module Prawn
           end
         end
 
+        #if there are only colspanned or rowspanned cells in a table
+        spanned_with_needs_fixing = true
+
         each do |cell|
           index = cell.send(row_or_column)
           if cell.colspan > 1
@@ -251,8 +254,9 @@ module Prawn
 
             #calculate future return value
             new_sum = cell.send(meth) * cell.colspan
+            spanned_with_needs_fixing = (new_sum > old_sum)
 
-            if new_sum >= old_sum
+            if spanned_with_needs_fixing
               #not entirely sure why we need this line, but with it the tests pass
               values[index] = [values[index], cell.send(meth)].compact.send(aggregate)
               #overwrite the old values with the new ones, but only if all entries existed
@@ -263,7 +267,7 @@ module Prawn
               }
             end
           else
-            if cell.class == Prawn::Table::Cell::SpanDummy
+            if spanned_with_needs_fixing and cell.class == Prawn::Table::Cell::SpanDummy
               values[index] = [values[index], cell.send(meth)].compact.send(aggregate)
             end
           end

--- a/spec/table_spec.rb
+++ b/spec/table_spec.rb
@@ -46,6 +46,19 @@ describe "Prawn::Table" do
   end
 
   describe "You can explicitly set the column widths and use a colspan > 1" do
+    it "should work with two different given colspans", :issue => 628 do 
+      data = [
+              [" ", " ", " "], 
+              [{:content=>" ", :colspan=>3}], 
+              [" ", {:content=>" ", :colspan=>2}]
+            ]
+      column_widths = [60, 240, 60]
+      pdf = Prawn::Document.new
+      #the next line raised an Prawn::Errors::CannotFit exception before issue 628 was fixed
+      table = Prawn::Table.new data, pdf, :column_widths => column_widths
+      table.column_widths.should == column_widths
+    end
+
     it "should work with a colspan > 1 with given column_widths (issue #407)" do
       #normal entries in line 1
       data = [


### PR DESCRIPTION
In the edge case reported under issue #628 the column widths where not calculated correctly.
This pull requests solves the issue.
