### PR TITLE
improving manual / metadata example

### DIFF
--- a/manual/document_and_page_options/metadata.rb
+++ b/manual/document_and_page_options/metadata.rb
@@ -19,5 +19,5 @@ Prawn::Document.generate("metadata.pdf",
   }) do
   
   text "This is a test of setting metadata properties via the info option."
-  text "If you want, it allows you to specify non standard properties too."
+  text "While the keys are arbitrary, the above example sets common attributes."
 end


### PR DESCRIPTION
Removing example 'grok' property from the example to reduce the example to the standard property set, adding a note above the example indicating that the user may add arbitrary keys and improving the text in the example to say the same too.
