### PR TITLE
Add spec for long strings inside subtables

### DIFF
--- a/spec/table_spec.rb
+++ b/spec/table_spec.rb
@@ -153,6 +153,15 @@ describe "Prawn::Table" do
       # Before we fixed #407, this line incorrectly raise a CannotFit error
       pdf.table(table_data, :column_widths => column_widths)
     end
+
+    it "should not allow oversized subtables when parent column width is constrained" do
+      pdf = Prawn::Document.new
+      child_1 = pdf.make_table([['foo'*100]])
+      child_2 = pdf.make_table([['foo']])
+      lambda do
+        pdf.table([[child_1], [child_2]], column_widths: [pdf.bounds.width/2] * 2)
+      end.should raise_error(Prawn::Errors::CannotFit)
+    end
   end
 
   describe "#initialize" do


### PR DESCRIPTION
Currently subtables containing very long strings throw CannotFit errors if their parent table's column width is constrained (spec I committed is passing.) If this is the correct behavior, please add my spec.
