### PR TITLE
Properly copy graphics states

### DIFF
--- a/lib/pdf/core/graphics_state.rb
+++ b/lib/pdf/core/graphics_state.rb
@@ -63,6 +63,13 @@ module PDF
           "[#{@dash[:dash]} #{@dash[:space]}] #{@dash[:phase]} d"
         end
       end
+
+      private
+
+      def initialize_copy(other)
+        @color_space = other.color_space.dup
+        @dash = other.dash.dup
+      end
     end
   end
 end

--- a/spec/graphics_spec.rb
+++ b/spec/graphics_spec.rb
@@ -484,6 +484,12 @@ describe "When using graphics states" do
     new_state.color_space.object_id.should_not == @pdf.graphic_state.color_space.object_id
     new_state.dash.object_id.should_not == @pdf.graphic_state.dash.object_id
   end
+
+  it "should dup the color_space and dash hashes when duping" do
+    new_state = @pdf.graphic_state.dup
+    new_state.color_space.object_id.should_not == @pdf.graphic_state.color_space.object_id
+    new_state.dash.object_id.should_not == @pdf.graphic_state.dash.object_id
+  end
 end
 
 describe "When using transformation matrix" do


### PR DESCRIPTION
GraphicState's initializer was properly using `dup` to copy `color_space` from `previous_state`, but it was not using `dup` on the `dash` attribute, keeping `dash` tied to the previous state's `dash`.

Also added an `initialize_copy` method to make sure those two attributes are properly copied whenever we `dup`/`clone` a graphic state.

Added specs for both updates.

---

This somewhat helps with #473 because it makes sure the graphics state is truly immune to any changes after setting a repeater. However, for the time being, a repeater still has to be defined before **anything else** to ensure a clean slate.
