### PR TITLE
Allow a user to unregister an existing image handler

### DIFF
--- a/lib/prawn/image_handler.rb
+++ b/lib/prawn/image_handler.rb
@@ -18,6 +18,10 @@ module Prawn
       @handlers.unshift handler
     end
 
+    def unregister(handler)
+      @handlers.reject!{ |h| h == handler }
+    end
+
     def find(image_blob)
       handler = @handlers.find{ |h| h.can_render? image_blob }
 

--- a/spec/image_handler_spec.rb
+++ b/spec/image_handler_spec.rb
@@ -28,6 +28,18 @@ describe "ImageHandler" do
     handler.should == handler_b
   end
 
+  it "can unregister a handler" do
+    handler_b.expects(:can_render? => true)
+
+    image_handler.register(handler_a)
+    image_handler.register(handler_b)
+
+    image_handler.unregister(handler_a)
+
+    handler = image_handler.find('arbitrary blob')
+    handler.should == handler_b
+  end
+
   it "raises an error when no matching handler is found" do
     handler_a.expects(:can_render? => false)
     handler_b.expects(:can_render? => false)


### PR DESCRIPTION
This adds functionality and a spec so we can unregister an image handler.

The use case I plan for this is to unregister the default PNG handler then append a new handler that can handle PNG images faster, without having to also handle the special case JPEG images have with PDFs by using #register! to take priority over both the existing handlers.
