### PR TITLE
Optionally prevent 'experimental' template warning

### DIFF
--- a/lib/prawn/templates.rb
+++ b/lib/prawn/templates.rb
@@ -1,9 +1,10 @@
-warn "Templates are no longer supported in Prawn!\n" +
-     "This code is for experimental testing only, and\n" +
-     "will extracted into its own gem in a future Prawn release"
-
 module Prawn
   module Templates
+    warn "Templates are no longer supported in Prawn!\n" +
+         "This code is for experimental testing only, and\n" +
+         "will be extracted into its own gem in a future Prawn release" \
+         unless defined? ::Prawn::Templates::PREVENT_EXPERIMENTAL_WARNING
+
     def initialize_first_page(options)
       return super unless options[:template]
 


### PR DESCRIPTION
Some users (such as myself) generate their own template PDFs to use with Prawn. We have complete control over the format and content of these templates, which makes them safer.

Therefore (in that context), we need some optional way (such as this pull request) to prevent prawn/templates' "experimental" warning message from alarming our end users via the console or logs.

Indeed, we understand that Prawn templates are experimental. And, we understand that we use them at our own risk.

However, to prevent this warning message from raising the ire of our end users, without some similar patch we must constrain our Prawn gem version to before 0.14.0 and miss the latest (and much future!) Prawn goodness. :)

Presumably, the necessary '< 0.14.0' gem version constraint might survive quite long, until the template functionality is extracted successfully (enough for us) from Prawn.
