### PR TITLE
fix: force StringIO encoding to ASCII_8BIT

### DIFF
--- a/lib/prawn/document.rb
+++ b/lib/prawn/document.rb
@@ -353,6 +353,9 @@ module Prawn
     # Pass an open file descriptor to render to file.
     #
     def render(output = StringIO.new)
+      if output.instance_of?(StringIO)
+        output.set_encoding(::Encoding::ASCII_8BIT)
+      end
       finalize_all_page_contents
 
       render_header(output)


### PR DESCRIPTION
`render` method in `Prawn::Document` uses a `StringIO` instance as default output.
But on JRuby for Windows this class uses a default encoding of `UTF-8` instead of `ASCII_8BIT`, than breaking in`render_header` method by pushing non-UTF characters in the `StringIO` instance.

It was also breaking a lot of tests (I'm not listing all of them. Should be at least every in-memory `render` calls).

Environment:
- Windows 7 x64 SP1
- Java 1.7rev51
- JRuby 1.7.10
