### PR TITLE
Update Prawn::Images#image method documentation to be more precise

### DIFF
--- a/lib/prawn/images.rb
+++ b/lib/prawn/images.rb
@@ -18,7 +18,7 @@ module Prawn
     # images with alpha channels can be processor and memory intensive.)
     #
     # Arguments:
-    # <tt>file</tt>:: path to file or an object that responds to #read
+    # <tt>file</tt>:: path to file or an object that responds to #read and #rewind
     #
     # Options:
     # <tt>:at</tt>:: an array [x,y] with the location of the top left corner of the image.


### PR DESCRIPTION
Looks like some time between 0.12.0 and 0.15.0 the requirement for this object went from only responding to #read to also needing to respond to #rewind.  Now, if it doesn't respond to #rewind, it tries to treat it as a path and complains that it's not a string.

My pull request simply adds to the documentation that an object also needs to respond to #rewind now.
