### PR TITLE
add git commit information on manual's cover only if in Git repo

### DIFF
--- a/manual/manual/cover.rb
+++ b/manual/manual/cover.rb
@@ -23,7 +23,7 @@ Prawn::Example.generate(filename) do
                         :size => 60}
                      ], :at => [170, cursor - 160])
 
-  if Dir.exists(File.expand_path("../../.git", File.dirname(__FILE__)))
+  if Dir.exist?("#{Prawn::BASEDIR}/.git")
     #long git commit hash
     #commit = `git show --pretty=%H`
     #short git commit hash


### PR DESCRIPTION
Hi,

With this change I propose to add git commit information on the cover of Prawn's manual only if we are in a Git repository, i.e., if a .git directory is found in ../.., relatively to manual/manual/cover.rb.

Cheers,

Cédric
