### PR TITLE
Commit failing UTF-8 test case for Line Wrap

### DIFF
--- a/spec/line_wrap_spec.rb
+++ b/spec/line_wrap_spec.rb
@@ -224,6 +224,15 @@ describe "Core::Text::Formatted::LineWrap#wrap_line" do
                                   :document => @pdf)
     string.should == "hello#{Prawn::Text::SHY}"
   end
+
+  it "should process UTF-8 chars" do
+    array = [{ :text => "Ｔｅｓｔ" }]
+    @arranger.format_array = array
+    string = @line_wrap.wrap_line(:arranger => @arranger,
+                                  :width => 300,
+                                  :document => @pdf)
+    string.should == "Ｔｅｓｔ"
+  end
 end
 
 describe "Core::Text::Formatted::LineWrap#space_count" do


### PR DESCRIPTION
I am experiencing character conversion issues in the LineWrap module. Using Ruby 1.9.3 on Windows. I've provided an example test case which gives:

```
Encoding::CompatibilityError: incompatible encoding regexp match (ASCII-8BIT regexp with UTF-8 string)
```
