### PR TITLE
Remember the bounds when a bounding box flows to existing page

### DIFF
--- a/lib/prawn/document/bounding_box.rb
+++ b/lib/prawn/document/bounding_box.rb
@@ -486,6 +486,7 @@ module Prawn
           @document.start_new_page
         else
           @document.go_to_page(@document.page_number + 1)
+          @document.bounds = self
         end
       end
 

--- a/spec/bounding_box_spec.rb
+++ b/spec/bounding_box_spec.rb
@@ -507,4 +507,15 @@ describe "BoundingBox#move_past_bottom" do
     pages[0][:strings].should == ["Foo"]
     pages[1][:strings].should == ["Bar"]
   end
+
+  it "should remember the bounding box when going to an existing page" do
+    @pdf.start_new_page
+    @pdf.go_to_page 1
+
+    @pdf.bounding_box([0, @pdf.cursor], :width => 100) do
+      original_bounds = @pdf.bounds
+      @pdf.bounds.move_past_bottom
+      @pdf.bounds.should == original_bounds
+    end
+  end
 end


### PR DESCRIPTION
This issue occurs for example when creating a page with a bounding box that flows to the next page. Then you go back to the starting page, create a new bounding box, and also let it flow to the next page (multiple columns that span multiple pages).

Before this fix, the second bounding box would forget its bounds when on the second page.
