### PR TITLE
Lock to a specific version of Rubocop

### DIFF
--- a/prawn.gemspec
+++ b/prawn.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency('rake')
   spec.add_development_dependency('simplecov')
   spec.add_development_dependency('pdf-reader', '~>1.2')
-  spec.add_development_dependency('rubocop')
+  spec.add_development_dependency('rubocop', '0.20.1')
 
   spec.homepage = "http://prawn.majesticseacreature.com"
   spec.description = <<END_DESC


### PR DESCRIPTION
The reason we lock to a specific version instead of pessimistic versions
is we don't want a new cop to appear in the test suite that will fail
previously passing code. When we upgrade Rubocop ourselves we can see
what new cops where added and enable/disable them at that time.
