### PR TITLE
Don’t set font on fragments without font when processing fallback #263

### DIFF
--- a/lib/prawn/text/formatted/box.rb
+++ b/lib/prawn/text/formatted/box.rb
@@ -390,33 +390,37 @@ module Prawn
 
           original_font = @document.font.family
           fragment_font = hash[:font] || original_font
-          @document.font(fragment_font)
 
           fallback_fonts = @fallback_fonts.dup
           # always default back to the current font if the glyph is missing from
           # all fonts
           fallback_fonts << fragment_font
 
-          hash[:text].each_char do |char|
-            @document.font(fragment_font)
-            font_glyph_pairs << [find_font_for_this_glyph(char,
-                                                          @document.font.family,
-                                                          fallback_fonts.dup),
-                                 char]
+          @document.save_font do
+            hash[:text].each_char do |char|
+              font_glyph_pairs << [find_font_for_this_glyph(char,
+                                                            fragment_font,
+                                                            fallback_fonts.dup),
+                                   char]
+            end
           end
 
-          @document.font(original_font)
+          # Don't add a :font to fragments if it wasn't there originally
+          if hash[:font].nil?
+            font_glyph_pairs.each do |pair|
+              pair[0] = nil if pair[0] == original_font
+            end
+          end
 
           form_fragments_from_like_font_glyph_pairs(font_glyph_pairs, hash)
         end
 
         def find_font_for_this_glyph(char, current_font, fallback_fonts)
+          @document.font(current_font)
           if fallback_fonts.length == 0 || @document.font.glyph_present?(char)
             current_font
           else
-            current_font = fallback_fonts.shift
-            @document.font(current_font)
-            find_font_for_this_glyph(char, @document.font.family, fallback_fonts)
+            find_font_for_this_glyph(char, fallback_fonts.shift, fallback_fonts)
           end
         end
 
@@ -426,11 +430,11 @@ module Prawn
           current_font = nil
 
           font_glyph_pairs.each do |font, char|
-            if font != current_font
+            if font != current_font || fragments.count == 0
               current_font = font
               fragment = hash.dup
               fragment[:text] = char
-              fragment[:font] = font
+              fragment[:font] = font unless font.nil?
               fragments << fragment
             else
               fragment[:text] += char

--- a/spec/text_spec.rb
+++ b/spec/text_spec.rb
@@ -434,4 +434,23 @@ describe "#text" do
     })
     pdf.fallback_fonts = ["dejavu"]
   end
+
+  describe "fallback_fonts" do
+    it "should preserve font style" do
+      create_pdf
+
+      @pdf.fallback_fonts ["Helvetica"]
+      @pdf.font "Times-Roman", :style => :italic do
+        @pdf.text "hello"
+      end
+
+      text = PDF::Inspector::Text.analyze(@pdf.render)
+      fonts_used = text.font_settings.map { |e| e[:name] }
+
+      fonts_used.length.should == 1
+      fonts_used[0].should == :"Times-Italic"
+      text.strings[0].should == "hello"
+    end
+  end
+
 end


### PR DESCRIPTION
The issue comes from the difference in how `Prawn::Text::Formatted::Box` and `Prawn::Text` handle styles. The fragments that are passed from `Prawn::Text` to `Prawn::Text::Formatted::Box` don't specify a font, relying on the font set on the document. After `Prawn::Text::Formatted::Box#analyze_glyphs_for_fallback_support`, the fragments are rewritten with font families specified but no styles. This patch preserves the original (:font-less) state for resulting fragments that don't require fallback.

Example that reproduces the issue (starting from example in manual): 

```
    pdf_data = Prawn::Document.new do
      fallback_fonts ["Times-Roman"]

      ["Courier", "Helvetica", "Times-Roman"].each do |example_font|
        move_down 20

        [:bold, :bold_italic, :italic, :normal].each do |style|
          font example_font, :style => style do
            text "I'm writing in #{example_font} (#{style})"
          end
        end
      end
    end
```

In this version, styles have no effect. Commenting `fallback_fonts ["Times-Roman"]` shows the styles working.
