### PR TITLE
Mention require prawn/table

### DIFF
--- a/manual/table/table.rb
+++ b/manual/table/table.rb
@@ -36,7 +36,7 @@ Prawn::ManualBuilder::Example.generate("table.pdf", :page_size => "FOLIO") do
     end
 
     p.intro do
-      prose("Prawn comes with table support out of the box. Tables can be styled in whatever way you see fit. The whole table, rows, columns and cells can be styled independently from each other.
+      prose("Tables can be styled in whatever way you see fit. The whole table, rows, columns and cells can be styled independently from each other.
 
       The examples show:")
 
@@ -46,6 +46,10 @@ Prawn::ManualBuilder::Example.generate("table.pdf", :page_size => "FOLIO") do
             "How to style the whole table",
             "How to use initializer blocks to style only specific portions of the table"
           )
+          
+       prose("To enable table support, require prawn/table in your code. This functionality is slated to be moved to a separate gem in the future.
+       
+       ")
     end
 
   end


### PR DESCRIPTION
Table support is not required by default since d14906e2ac5f57f60f4e03bfeeb018b1c8aaef3c.
