### PR TITLE
Expose scan_pattern through tokenize

### DIFF
--- a/lib/prawn/text/formatted/line_wrap.rb
+++ b/lib/prawn/text/formatted/line_wrap.rb
@@ -29,6 +29,10 @@ module Prawn
           @newline_encountered || is_next_string_newline? || @arranger.finished?
         end
 
+        def tokenize(fragment)
+          fragment.scan(scan_pattern)
+        end
+
         # Work in conjunction with the PDF::Formatted::Arranger
         # defined in the :arranger option to determine what formatted text
         # will fit within the width defined by the :width option
@@ -89,7 +93,7 @@ module Prawn
             @newline_encountered = true
             false
           else
-            fragment.scan(scan_pattern).each do |segment|
+            tokenize(fragment).each do |segment|
               if segment == zero_width_space
                 segment_width = 0
               else

--- a/spec/line_wrap_spec.rb
+++ b/spec/line_wrap_spec.rb
@@ -291,6 +291,10 @@ describe "Core::Text::Formatted::LineWrap" do
                                :document => @pdf)
     line.should be_empty
   end
+  it "should tokenize a string using the scan_pattern" do
+    tokens = @line_wrap.tokenize("one two three")
+    tokens.length.should == 6
+  end
 end
 
 describe "Core::Text::Formatted::LineWrap#paragraph_finished?" do


### PR DESCRIPTION
Hartwig / Gregory,

I'm putting my table rotation code into a fork of the extracted prawn-table gem. This one change is needed in prawn. It exposes the `scan_pattern` through a public tokenize method. The rotated table text needs to tokenize its first line to properly adjust the text vertically. 
