### PR TITLE
fix rake stats

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -16,10 +16,9 @@ end
 
 desc "Show library's code statistics"
 task :stats do
-  require 'code_statistics'
-  CodeStatistics::TEST_TYPES << "Specs"
-  CodeStatistics.new( ["Prawn", "lib"],
-                      ["Specs", "spec"] ).to_s
+  require 'code_statistics/code_statistics'
+  puts CodeStatistics::CodeStatistics.new( [["Prawn", "lib"],
+                      ["Specs", "spec"]] ).to_s
 end
 
 YARD::Rake::YardocTask.new do |t|

--- a/prawn.gemspec
+++ b/prawn.gemspec
@@ -36,6 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency('prawn-manual_builder', ">= 0.2.0")
   spec.add_development_dependency('pdf-reader', '~>1.2')
   spec.add_development_dependency('rubocop', '0.20.1')
+  spec.add_development_dependency('code_statistics', '0.2.13')
 
   spec.homepage = "http://prawn.majesticseacreature.com"
   spec.description = <<END_DESC


### PR DESCRIPTION
``` bash

rake stats
+----------------------+-------+-------+---------+---------+-----+-------+
| Name                 | Lines | LOC   | Classes | Methods | M/C | LOC/M |
+----------------------+-------+-------+---------+---------+-----+-------+
| Prawn                |  9164 |  4725 |      44 |     583 |  13 |     6 |
| Specs                |  8784 |  7317 |       6 |     741 | 123 |     7 |
| spec/acceptance      |    25 |    17 |       0 |       0 |   0 |     0 |
| spec/extensions      |    57 |    29 |       2 |       6 |   3 |     2 |
+----------------------+-------+-------+---------+---------+-----+-------+
| Total                | 18030 | 12088 |      52 |    1330 |  25 |     7 |
+----------------------+-------+-------+---------+---------+-----+-------+
 Code LOC: 4725  Test LOC: 7363  Code to Test Ratio: 1:1.6

```
