### PR TITLE
Adding a manual entry for alternate page numbers

### DIFF
--- a/manual/repeatable_content/alternate_page_numbering.rb
+++ b/manual/repeatable_content/alternate_page_numbering.rb
@@ -1,0 +1,32 @@
+# encoding: utf-8
+#
+# Below is the code to generate page numbers that alternate being rendered
+# on the right and left side of the page. The first page will have a "1" in
+# the bottom right corner. The second page will have a "2" in the bottom
+# left corner of the page. The third a "3" in the bottom right, etc.
+require File.expand_path(File.join(File.dirname(__FILE__),
+                                   %w[.. example_helper]))
+
+filename = File.basename(__FILE__).gsub('.rb', '.pdf')
+Prawn::ManualBuilder::Example.generate(filename) do
+  text "This is the first page!"
+
+  10.times do
+    start_new_page
+    text "Here comes yet another page."
+  end
+
+  string = "<page>"
+  odd_options = { :at => [bounds.right - 150, 0],
+                  :width => 150,
+                  :align => :right,
+                  :page_filter => :odd,
+                  :start_count_at => 1 }
+  even_options = { :at => [0, bounds.left],
+                   :width => 150,
+                   :align => :left,
+                   :page_filter => :even,
+                   :start_count_at => 2 }
+  number_pages string, odd_options
+  number_pages string, even_options
+end

--- a/manual/repeatable_content/repeatable_content.rb
+++ b/manual/repeatable_content/repeatable_content.rb
@@ -12,6 +12,7 @@ Prawn::ManualBuilder::Example.generate("repeatable_content.pdf", :page_size => "
     p.example "repeater",       :eval_source => false
     p.example "stamp"
     p.example "page_numbering", :eval_source => false
+    p.example "alternate_page_numbering", :eval_source => false
 
     p.intro do
       prose("Prawn offers two ways to handle repeatable content blocks. Repeater is useful for content that gets repeated at well defined intervals while Stamp is more appropriate if you need better control of when to repeat it.


### PR DESCRIPTION
It was unclear how to do this, and I had submitted a previous pull
request that did not explore the existing API.

After a bit of work, this was the method that I ended up using. I
wanted to make sure that the manual (which is very helpful) was
updated.
