### PR TITLE
Check private/protected methods in #method_missing

### DIFF
--- a/lib/prawn/view.rb
+++ b/lib/prawn/view.rb
@@ -64,7 +64,7 @@ module Prawn
     # Delegates all unhandled calls to object returned by +document+ method.
     # (which is an instance of Prawn::Document by default)
     def method_missing(m, *a, &b)
-      return super unless document.respond_to?(m)
+      return super unless document.respond_to?(m, true)
 
       document.send(m, *a, &b)
     end


### PR DESCRIPTION
Without this, it's not possible to use private/protected methods inside a class than includes `Prawn::View`.

Ref: http://ruby-doc.org/core-2.1.5/Object.html#method-i-respond_to-3F
