### PR TITLE
Delegate on_page_create method to renderer. #797

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,6 +149,20 @@ should benefit greatly from these changes.
 
 (Gregory Brown, [#793](https://github.com/prawnpdf/prawn/pull/793))
 
+### Temporarily restored the Document#on_page_create method
+
+This method was moved into PDF::Core in the Prawn 1.3.0 release, removing
+it from the `Prawn::Document` API. Although it is a low-level method not
+meant for general use, it is necessary for certain tasks that we do not
+have proper support for elsewhere.
+
+This method should still be considered part of Prawn's internals and is subject
+to change at any time, but we have restored it temporarily until we have
+a suitable replacement for it. See the discussion on [#797](https://github.com/prawnpdf/prawn/issues/797)
+for more details.
+
+(Jesse Doyle, [#797](https://github.com/prawnpdf/prawn/issues/797), [#825](https://github.com/prawnpdf/prawn/pull/825))
+
 ## PrawnPDF 1.3.0 -- September 28, 2014
 
 ### Added the Prawn::View mixin for using Prawn's DSL in your own classes.

--- a/lib/prawn/document/internals.rb
+++ b/lib/prawn/document/internals.rb
@@ -26,7 +26,8 @@ module Prawn
       # Anyway, for now it's not clear what we should do w. them.
       delegate [ :graphic_state,
                  :save_graphics_state,
-                 :restore_graphics_state ] => :renderer
+                 :restore_graphics_state,
+                 :on_page_create ] => :renderer
 
       # FIXME: This is a circular reference, because in theory Prawn should
       # be passing instances of renderer to PDF::Core::Page, but it's

--- a/spec/document_spec.rb
+++ b/spec/document_spec.rb
@@ -180,6 +180,10 @@ describe "on_page_create callback" do
     create_pdf
   end
 
+  it "should be delegated from Document to renderer" do
+    expect(@pdf.respond_to?(:on_page_create)).to be_true
+  end
+
   it "should be invoked with document" do
     called_with = nil
 


### PR DESCRIPTION
A simple patch that delegates `on_page_create` calls to `renderer.on_page_create`.