### PR TITLE
CHANGELOG.md: Fix typo in `:shrink_to_fit`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -275,7 +275,7 @@ for more information.
 ### Text box now has an option to disable wrapping by character.
 
 This feature is useful for preventing mid-word breaks when used in combination with the 
-`:shink_to_fit` overflow option. See the following example practical use case:
+`:shrink_to_fit` overflow option. See the following example practical use case:
 
 ```ruby
 # An example shared by Simon Mansfield


### PR DESCRIPTION
Fix up commit cde833ef (Add missing CHANGELOG.md file).