### PR TITLE
manual/text/positioned_text.rb: Improve wording

### DIFF
--- a/manual/text/positioned_text.rb
+++ b/manual/text/positioned_text.rb
@@ -15,7 +15,7 @@
 # accordingly. Even if you don't provide a <code>:width</code> option the text
 # will flow to a new line if it reaches the right border.
 #
-# Given that said, <code>text_box</code> is the better option available.
+# Given that, <code>text_box</code> is the better option available.
 #
 require File.expand_path(File.join(File.dirname(__FILE__),
                                    %w[.. example_helper]))


### PR DESCRIPTION
Fix up commit c709a25f (Added positioned text examples.) by replacing
*Given that said, …* by *Given that, …*.

*That said, …* would have been fine too.