### PR TITLE
Reproducible build of the manual

### DIFF
--- a/lib/prawn/graphics/patterns.rb
+++ b/lib/prawn/graphics/patterns.rb
@@ -60,7 +60,7 @@ module Prawn
       end
 
       def gradient_registry_key(gradient)
-        if gradient[1].is_a?(Array) # axial
+        key = if gradient[1].is_a?(Array) # axial
           [
             map_to_absolute(gradient[0]),
             map_to_absolute(gradient[1]),
@@ -74,7 +74,16 @@ module Prawn
             gradient[3],
             gradient[4], gradient[5]
           ]
-        end.hash
+        end
+        unless @gradient_key_registry
+          @gradient_key_registry ||= {}
+          @gradient_key_index = 1
+        end
+        unless @gradient_key_registry.include?(key)
+          @gradient_key_registry[key] = @gradient_key_index
+          @gradient_key_index += 1
+        end
+        @gradient_key_registry[key]
       end
 
       def gradient_registry

--- a/manual/cover.rb
+++ b/manual/cover.rb
@@ -23,14 +23,17 @@ Prawn::ManualBuilder::Example.generate(filename) do
                         :size => 60}
                      ], :at => [170, cursor - 160])
 
+  last_update = Time.at(ENV['BUILD_EPOCH'].to_i) if ENV['BUILD_EPOCH']
   if Dir.exist?("#{Prawn::BASEDIR}/.git")
     commit = `git show --pretty=%h`
     git_commit = "git commit: #{commit.lines.first}"
+    last_update ||= Time.at(`git log -1 --pretty='%ct'`.to_i)
   else
     git_commit = ""
+    last_update ||= Time.now
   end
 
-  formatted_text_box([  {:text => "Last Update: #{Time.now.strftime("%Y-%m-%d")}\n"+
+  formatted_text_box([  {:text => "Last Update: #{last_update.utc.strftime('%Y-%m-%d')}\n"+
                                   "Prawn Version: #{Prawn::VERSION}\n"+
                                   git_commit,
                          :size => 12}

--- a/manual/document_and_page_options/metadata.rb
+++ b/manual/document_and_page_options/metadata.rb
@@ -7,6 +7,7 @@
 require File.expand_path(File.join(File.dirname(__FILE__),
                                    %w[.. example_helper]))
 
+creation_date = ENV['BUILD_EPOCH'] ? Time.at(ENV['BUILD_EPOCH'].to_i) : Time.now
 Prawn::Document.generate("metadata.pdf",
   :info => {
     :Title        => "My title",
@@ -15,7 +16,7 @@ Prawn::Document.generate("metadata.pdf",
     :Keywords     => "test metadata ruby pdf dry",
     :Creator      => "ACME Soft App",
     :Producer     => "Prawn",
-    :CreationDate => Time.now
+    :CreationDate => creation_date.utc
   }) do
 
   text "This is a test of setting metadata properties via the info option."


### PR DESCRIPTION
Hi,

The following two commits are contributions for the Debian reproducible builds effort
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=782890
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=782891
in order to allow reproducible builds of the Debian packages, by removing every bit that can change in a non predictable way. In particular, they allow the manual to be built (bitwise) identically accross builds, and probably also PDF generated by prawn more generally.
The contributions are:
- use deterministic keys (integers increasing by one) for gradients instead of #hash
- use BUILD_EPOCH environment variable instead of Time.now to timestamp the manual, if available.
  Thanks for considering including these changes.

Cédric
