### PR TITLE
Enforce correct comment indentation.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -221,8 +221,6 @@ GuardClause:
   Enabled: false
 ElseAlignment:
   Enabled: false
-CommentIndentation:
-  Enabled: false
 EachWithObject:
   Enabled: false
 BlockEndNewline:

--- a/lib/prawn/document.rb
+++ b/lib/prawn/document.rb
@@ -612,9 +612,9 @@ module Prawn
     # @private
 
     def mask(*fields)
-     # Stores the current state of the named attributes, executes the block, and
-     # then restores the original values after the block has executed.
-     # -- I will remove the nodoc if/when this feature is a little less hacky
+      # Stores the current state of the named attributes, executes the block, and
+      # then restores the original values after the block has executed.
+      # -- I will remove the nodoc if/when this feature is a little less hacky
       stored = {}
       fields.each { |f| stored[f] = send(f) }
       yield


### PR DESCRIPTION
This PR enables the CommentIndentation cop to ensure that code comments appear at the same indentation of the code they are commenting.