### PR TITLE
Remove unnecessary method call parentheses

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -39,8 +39,6 @@ WordArray:
   Enabled: false
 SpaceAroundEqualsInParameterDefault:
   Enabled: false
-MethodCallParentheses:
-  Enabled: false
 FormatString:
   Enabled: false
 Blocks:

--- a/spec/document_spec.rb
+++ b/spec/document_spec.rb
@@ -195,7 +195,7 @@ describe "on_page_create callback" do
   end
 
   it "should be invoked for each new page" do
-    trigger = mock()
+    trigger = mock
     trigger.expects(:fire).times(5)
 
     @pdf.renderer.on_page_create { trigger.fire }
@@ -204,10 +204,10 @@ describe "on_page_create callback" do
   end
 
   it "should be replaceable" do
-      trigger1 = mock()
+      trigger1 = mock
       trigger1.expects(:fire).times(1)
 
-      trigger2 = mock()
+      trigger2 = mock
       trigger2.expects(:fire).times(1)
 
       @pdf.renderer.on_page_create { trigger1.fire }
@@ -220,7 +220,7 @@ describe "on_page_create callback" do
   end
 
   it "should be clearable by calling on_page_create without a block" do
-      trigger = mock()
+      trigger = mock
       trigger.expects(:fire).times(1)
 
       @pdf.renderer.on_page_create { trigger.fire }
@@ -479,7 +479,7 @@ describe "The render() feature" do
 
     # Verify the order: finalize -> fire callbacks -> render body
     pdf.renderer.expects(:finalize_all_page_contents).in_sequence(seq)
-    trigger = mock()
+    trigger = mock
     trigger.expects(:fire).in_sequence(seq)
 
     # Store away the render_body method to be called below

--- a/spec/graphics_spec.rb
+++ b/spec/graphics_spec.rb
@@ -541,10 +541,10 @@ describe "When using transformation matrix" do
     string = Array.new(6, "0.00000").join " "
     process = sequence "process"
 
-    @pdf.expects(:save_graphics_state).with().in_sequence(process)
+    @pdf.expects(:save_graphics_state).with.in_sequence(process)
     @pdf.renderer.expects(:add_content).with("#{string} cm").in_sequence(process)
-    @pdf.expects(:do_something).with().in_sequence(process)
-    @pdf.expects(:restore_graphics_state).with().in_sequence(process)
+    @pdf.expects(:do_something).with.in_sequence(process)
+    @pdf.expects(:restore_graphics_state).with.in_sequence(process)
     @pdf.transformation_matrix(*values) do
       @pdf.do_something
     end

--- a/spec/outline_spec.rb
+++ b/spec/outline_spec.rb
@@ -3,7 +3,7 @@ require File.join(File.expand_path(File.dirname(__FILE__)), "spec_helper")
 
 describe "Outline" do
   before(:each) do
-    @pdf = Prawn::Document.new() do
+    @pdf = Prawn::Document.new do
       text "Page 1. This is the first Chapter. "
       start_new_page
       text "Page 2. More in the first Chapter. "
@@ -369,7 +369,7 @@ describe "Outline" do
   describe "#page" do
     it "should require a title option to be set" do
       lambda do
-        @pdf = Prawn::Document.new() do
+        @pdf = Prawn::Document.new do
           text "Page 1. This is the first Chapter. "
           outline.define do
             page :destination => 1, :title => nil
@@ -382,7 +382,7 @@ end
 
 describe "foreign character encoding" do
   before(:each) do
-    pdf = Prawn::Document.new() do
+    pdf = Prawn::Document.new do
       outline.define do
         section 'La pomme croquée', :destination => 1, :closed => true
       end

--- a/spec/text_box_spec.rb
+++ b/spec/text_box_spec.rb
@@ -188,7 +188,7 @@ describe "Text::Box with :draw_text_callback" do
   before(:each) { create_pdf }
 
   it "hits the callback whenever text is drawn" do
-    draw_block = stub()
+    draw_block = stub
     draw_block.expects(:kick).with("this text is long enough to")
     draw_block.expects(:kick).with("span two lines")
 
@@ -198,7 +198,7 @@ describe "Text::Box with :draw_text_callback" do
   end
 
   it "hits the callback once per fragment for :inline_format" do
-    draw_block = stub()
+    draw_block = stub
     draw_block.expects(:kick).with("this text has ")
     draw_block.expects(:kick).with("fancy")
     draw_block.expects(:kick).with(" formatting")


### PR DESCRIPTION
This PR enforces removing unnecessary method call parentheses.