### PR TITLE
Enforce preference for symbol to proc

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -205,8 +205,6 @@ UnusedMethodArgument:
   Enabled: false
 Next:
   Enabled: false
-SymbolProc:
-  Enabled: false
 ClassCheck:
   Enabled: false
 SpaceBeforeComma:

--- a/lib/prawn/font/afm.rb
+++ b/lib/prawn/font/afm.rb
@@ -209,7 +209,7 @@ module Prawn
           h
         end
 
-        data.each_value { |hash| hash.freeze }
+        data.each_value(&:freeze)
         data.freeze
       end
 

--- a/lib/prawn/grid.rb
+++ b/lib/prawn/grid.rb
@@ -214,7 +214,7 @@ module Prawn
       end
 
       def name
-        @bs.map {|b| b.name}.join(":")
+        @bs.map(&:name).join(":")
       end
 
       def total_height

--- a/lib/prawn/security.rb
+++ b/lib/prawn/security.rb
@@ -147,7 +147,7 @@ module Prawn
         perms.each do |key, value|
           unless PermissionsBits[key]
             raise ArgumentError, "Unknown permission :#{key}. Valid options: " +
-              PermissionsBits.keys.map { |k| k.inspect }.join(", ")
+              PermissionsBits.keys.map(&:inspect).join(", ")
           end
 
           # 0-based bit number, from LSB

--- a/lib/prawn/text/formatted/box.rb
+++ b/lib/prawn/text/formatted/box.rb
@@ -353,7 +353,7 @@ module Prawn
         end
 
         def original_text
-          @original_array.collect { |hash| hash.dup }
+          @original_array.collect(&:dup)
         end
 
         def original_text=(formatted_text)

--- a/spec/text_spec.rb
+++ b/spec/text_spec.rb
@@ -70,14 +70,14 @@ describe "#text" do
     @pdf.text "text\n\ntext"
     text = PDF::Inspector::Text.analyze(@pdf.render)
     @pdf.page_count.should == 1
-    text.strings.reject{ |s| s.empty? }.should == ["text", "text"]
+    text.strings.reject(&:empty?).should == ["text", "text"]
   end
 
   it "should correctly render empty paragraphs with :indent_paragraphs" do
     @pdf.text "text\n\ntext", :indent_paragraphs => 5
     text = PDF::Inspector::Text.analyze(@pdf.render)
     @pdf.page_count.should == 1
-    text.strings.reject{ |s| s.empty? }.should == ["text", "text"]
+    text.strings.reject(&:empty?).should == ["text", "text"]
   end
 
   it "should correctly render strings ending with empty paragraphs and " +


### PR DESCRIPTION
This PR enforces a preference for symbol to proc and enables the correct rubocop cop for that.