### PR TITLE
Remove extraneous empty lines

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -125,8 +125,6 @@ AccessModifierIndentation:
   Enabled: false
 CaseEquality:
   Enabled: false
-EmptyLineBetweenDefs:
-  Enabled: false
 RedundantSelf:
   Enabled: false
 BlockNesting:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -93,8 +93,6 @@ SingleSpaceBeforeFirstArg:
   Enabled: false
 IndentationConsistency:
   Enabled: false
-TrailingBlankLines:
-  Enabled: false
 AndOr:
   Enabled: false
 AssignmentInCondition:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,8 +17,6 @@ HashSyntax:
   Enabled: false
 UselessAssignment:
   Enabled: false
-EmptyLines:
-  Enabled: false
 LineEndConcatenation:
   Enabled: false
 SpaceAfterComma:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -203,8 +203,6 @@ SpaceBeforeComma:
   Enabled: false
 StringLiteralsInInterpolation:
   Enabled: false
-EmptyLinesAroundModuleBody:
-  Enabled: false
 GuardClause:
   Enabled: false
 ElseAlignment:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -189,8 +189,6 @@ AbcSize:
   Enabled: false
 PerceivedComplexity:
   Enabled: false
-EmptyLinesAroundBlockBody:
-  Enabled: false
 UnusedBlockArgument:
   Enabled: false
 UnusedMethodArgument:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -187,8 +187,6 @@ SpaceBeforeComment:
   Enabled: false
 AbcSize:
   Enabled: false
-EmptyLinesAroundClassBody:
-  Enabled: false
 PerceivedComplexity:
   Enabled: false
 EmptyLinesAroundBlockBody:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -161,8 +161,6 @@ Alias:
   Enabled: false
 RedundantReturn:
   Enabled: false
-EmptyLinesAroundAccessModifier:
-  Enabled: false
 DeprecatedHashMethods:
   Enabled: false
 WhileUntilModifier:

--- a/Rakefile
+++ b/Rakefile
@@ -26,7 +26,6 @@ YARD::Rake::YardocTask.new do |t|
 end
 task :docs => :yard
 
-
 desc "Generate the 'Prawn by Example' manual"
 task :manual do
   puts "Building manual..."

--- a/bench/png_type_6_objects.rb
+++ b/bench/png_type_6_objects.rb
@@ -15,4 +15,3 @@ after = GC.stat
 total = after[:total_allocated_object] - before[:total_allocated_object]
 
 puts "allocated objects: #{total}"
-

--- a/lib/prawn/document.rb
+++ b/lib/prawn/document.rb
@@ -14,7 +14,6 @@ require_relative "document/internals"
 require_relative "document/span"
 
 module Prawn
-
   # The Prawn::Document class is how you start creating a PDF document.
   #
   # There are three basic ways you can instantiate PDF Documents in Prawn, they

--- a/lib/prawn/document.rb
+++ b/lib/prawn/document.rb
@@ -466,7 +466,6 @@ module Prawn
       move_down(y)
     end
 
-
     # Indents the specified number of PDF points for the duration of the block
     #
     #  pdf.text "some text"
@@ -644,7 +643,6 @@ module Prawn
     end
 
     private
-
 
     # setting override_settings to true ensures that a new graphic state does not end up using
     # previous settings.

--- a/lib/prawn/document/bounding_box.rb
+++ b/lib/prawn/document/bounding_box.rb
@@ -219,7 +219,6 @@ module Prawn
     # is used for.
     #
     class BoundingBox
-
       def initialize(document, parent, point, options={}) # @private
         unless options[:width]
           raise ArgumentError, "BoundingBox needs the :width option to be set"
@@ -531,8 +530,6 @@ module Prawn
         bounds.instance_variable_set("@document", document)
         bounds
       end
-
     end
-
   end
 end

--- a/lib/prawn/document/bounding_box.rb
+++ b/lib/prawn/document/bounding_box.rb
@@ -264,7 +264,6 @@ module Prawn
         0
       end
 
-
       # Temporarily adjust the @x coordinate to allow for left_padding
       #
       # Example:

--- a/lib/prawn/document/column_box.rb
+++ b/lib/prawn/document/column_box.rb
@@ -10,7 +10,6 @@ require_relative "bounding_box"
 
 module Prawn
   class Document
-
     # @group Experimental API
 
     # A column box is a bounding box with the additional property that when
@@ -53,7 +52,6 @@ module Prawn
     # work.
     #
     class ColumnBox < BoundingBox
-
       def initialize(document, parent, point, options={}) #:nodoc:
         super
         @columns = options[:columns] || 3

--- a/lib/prawn/document/internals.rb
+++ b/lib/prawn/document/internals.rb
@@ -10,7 +10,6 @@ require "forwardable"
 
 module Prawn
   class Document
-
     # This module exposes a few low-level PDF features for those who want
     # to extend Prawn's core functionality.  If you are not comfortable with
     # low level PDF functionality as defined by Adobe's specification, chances

--- a/lib/prawn/errors.rb
+++ b/lib/prawn/errors.rb
@@ -75,6 +75,5 @@ module Prawn
     # Raised when unrecognized content is provided for a table cell.
     #
     UnrecognizedTableContent = Class.new(StandardError)
-
   end
 end

--- a/lib/prawn/font.rb
+++ b/lib/prawn/font.rb
@@ -12,7 +12,6 @@ require_relative "font/dfont"
 require_relative "font_metric_cache"
 
 module Prawn
-
   class Document
     # @group Stable API
 
@@ -407,5 +406,4 @@ module Prawn
       @document.font_size
     end
   end
-
 end

--- a/lib/prawn/font.rb
+++ b/lib/prawn/font.rb
@@ -274,7 +274,6 @@ module Prawn
   # Provides font information and helper functions.
   #
   class Font
-
     # The current font name
     attr_reader :name
 
@@ -407,7 +406,6 @@ module Prawn
     def size
       @document.font_size
     end
-
   end
 
 end

--- a/lib/prawn/font/afm.rb
+++ b/lib/prawn/font/afm.rb
@@ -10,7 +10,6 @@ require_relative "../encoding"
 
 module Prawn
   class Font
-
     # @private
 
     class AFM < Font

--- a/lib/prawn/font/dfont.rb
+++ b/lib/prawn/font/dfont.rb
@@ -12,7 +12,6 @@ module Prawn
   class Font
     # @private
     class DFont < TTF
-
       # Returns a list of the names of all named fonts in the given dfont file.
       # Note that fonts are not required to be named in a dfont file, so the
       # list may be empty even if the file does contain fonts. Also, note that

--- a/lib/prawn/font/ttf.rb
+++ b/lib/prawn/font/ttf.rb
@@ -12,7 +12,6 @@ require 'ttfunk/subset_collection'
 
 module Prawn
   class Font
-
     # @private
     class TTF < Font
       attr_reader :ttf, :subsets

--- a/lib/prawn/font_metric_cache.rb
+++ b/lib/prawn/font_metric_cache.rb
@@ -8,7 +8,6 @@
 #
 
 module Prawn
-
   # Cache used internally by Prawn::Document instances to calculate the width
   # of various strings for layout purposes.
   #
@@ -40,5 +39,4 @@ module Prawn
         (@document.character_spacing * @document.font.character_count(string))
     end
   end
-
 end

--- a/lib/prawn/font_metric_cache.rb
+++ b/lib/prawn/font_metric_cache.rb
@@ -14,7 +14,6 @@ module Prawn
   #
   # @private
   class FontMetricCache
-
     CacheEntry = Struct.new( :font, :options, :string )
 
     def initialize( document )
@@ -40,7 +39,6 @@ module Prawn
       length +
         (@document.character_spacing * @document.font.character_count(string))
     end
-
   end
 
 end

--- a/lib/prawn/graphics.rb
+++ b/lib/prawn/graphics.rb
@@ -6,7 +6,6 @@
 #
 # This is free software. Please see the LICENSE and COPYING files for details.
 
-
 require_relative "graphics/color"
 require_relative "graphics/dash"
 require_relative "graphics/cap_style"
@@ -99,7 +98,6 @@ module Prawn
       x, y = point
       rounded_polygon(radius, point, [x + width, y], [x + width, y - height], [x, y - height])
     end
-
 
     ###########################################################
     #  Higher level functions: May use relative coords        #
@@ -260,7 +258,6 @@ module Prawn
       # close the path
       renderer.add_content "h"
     end
-
 
     # Creates a rounded vertex for a line segment used for building a rounded polygon
     # requires a radius to define bezier curve and three points. The first two points define

--- a/lib/prawn/graphics.rb
+++ b/lib/prawn/graphics.rb
@@ -15,7 +15,6 @@ require_relative "graphics/transformation"
 require_relative "graphics/patterns"
 
 module Prawn
-
   # Implements the drawing facilities for Prawn::Document.
   # Use this to draw the most beautiful imaginable things.
   #
@@ -23,7 +22,6 @@ module Prawn
   # ruby-pdf.rubyforge.org
   #
   module Graphics
-
     include Color
     include Dash
     include CapStyle
@@ -638,6 +636,5 @@ module Prawn
       yr = y0 + p*(y1 - y0)
       [xr, yr]
     end
-
   end
 end

--- a/lib/prawn/graphics/color.rb
+++ b/lib/prawn/graphics/color.rb
@@ -228,4 +228,3 @@ module Prawn
     end
   end
 end
-

--- a/lib/prawn/graphics/color.rb
+++ b/lib/prawn/graphics/color.rb
@@ -225,7 +225,6 @@ module Prawn
       def write_color(color, operator)
         renderer.add_content "#{color} #{operator}"
       end
-
     end
   end
 end

--- a/lib/prawn/graphics/dash.rb
+++ b/lib/prawn/graphics/dash.rb
@@ -103,7 +103,6 @@ module Prawn
       def dash_setting
         graphic_state.dash_setting
       end
-
     end
   end
 end

--- a/lib/prawn/graphics/join_style.rb
+++ b/lib/prawn/graphics/join_style.rb
@@ -40,7 +40,6 @@ module Prawn
         graphic_state.join_style = style
       end
 
-
       def write_stroke_join_style
         renderer.add_content "#{JOIN_STYLES[current_join_style]} j"
       end

--- a/lib/prawn/graphics/transformation.rb
+++ b/lib/prawn/graphics/transformation.rb
@@ -151,7 +151,6 @@ module Prawn
           restore_graphics_state
         end
       end
-
     end
   end
 end

--- a/lib/prawn/graphics/transparency.rb
+++ b/lib/prawn/graphics/transparency.rb
@@ -9,7 +9,6 @@
 
 module Prawn
   module Graphics
-
     # The Prawn::Transparency module is used to place transparent
     # content on the page. It has the capacity for separate
     # transparency values for stroked content and all other content.
@@ -29,7 +28,6 @@ module Prawn
     #   end
     #
     module Transparency
-
       # @group Stable API
 
       # Sets the <tt>opacity</tt> and <tt>stroke_opacity</tt> for all
@@ -95,7 +93,6 @@ module Prawn
         page.ext_gstates.merge!(dictionary_name => dictionary)
         dictionary_name
       end
-
     end
   end
 end

--- a/lib/prawn/grid.rb
+++ b/lib/prawn/grid.rb
@@ -199,6 +199,7 @@ module Prawn
       end
 
       private
+
       def grid
         pdf.grid
       end
@@ -250,6 +251,7 @@ module Prawn
       end
 
       private
+
       def left_box
         @left_box ||= @bs.min {|a,b| a.left <=> b.left}
       end
@@ -268,6 +270,7 @@ module Prawn
     end
 
     private
+
     def single_box(i, j)
       GridBox.new(self, i, j)
     end

--- a/lib/prawn/images.rb
+++ b/lib/prawn/images.rb
@@ -9,7 +9,6 @@ require 'digest/sha1'
 require 'pathname'
 
 module Prawn
-
   module Images
     # @group Stable API
 

--- a/lib/prawn/images.rb
+++ b/lib/prawn/images.rb
@@ -70,7 +70,6 @@ module Prawn
       info
     end
 
-
     # Builds an info object (Prawn::Images::*) and a PDF reference representing
     # the given image. Return a pair: [pdf_obj, info].
     #

--- a/lib/prawn/images/jpg.rb
+++ b/lib/prawn/images/jpg.rb
@@ -85,7 +85,6 @@ module Prawn
         obj.stream.filters << :DCTDecode
         obj
       end
-
     end
   end
 end

--- a/lib/prawn/images/jpg.rb
+++ b/lib/prawn/images/jpg.rb
@@ -10,7 +10,6 @@ require 'stringio'
 
 module Prawn
   module Images
-
     # A convenience class that wraps the logic for extracting the parts
     # of a JPG image that we need to embed them in a PDF
     #

--- a/lib/prawn/measurements.rb
+++ b/lib/prawn/measurements.rb
@@ -34,7 +34,6 @@ module Prawn
       return yd*36
     end
 
-
     # ============================================================================
     # PostscriptPoint-converisons
 

--- a/lib/prawn/measurements.rb
+++ b/lib/prawn/measurements.rb
@@ -7,7 +7,6 @@ module Prawn
   # @group Stable API
 
   module Measurements
-
     # ============================================================================
     #metric conversions
     def cm2mm(cm)

--- a/lib/prawn/repeater.rb
+++ b/lib/prawn/repeater.rb
@@ -118,5 +118,3 @@ module Prawn
     end
   end
 end
-
-

--- a/lib/prawn/repeater.rb
+++ b/lib/prawn/repeater.rb
@@ -117,7 +117,6 @@ module Prawn
         end
       end
     end
-
   end
 end
 

--- a/lib/prawn/repeater.rb
+++ b/lib/prawn/repeater.rb
@@ -9,7 +9,6 @@
 # This is free software. Please see the LICENSE and COPYING files for details.
 
 module Prawn
-
   class Document
     # A list of all repeaters in the document.
     # See Document#repeat for details

--- a/lib/prawn/security.rb
+++ b/lib/prawn/security.rb
@@ -14,7 +14,6 @@ require_relative 'security/arcfour'
 
 module Prawn
   class Document
-
     # Implements PDF encryption (password protection and permissions) as
     # specified in the PDF Reference, version 1.3, section 3.5 "Encryption".
     module Security
@@ -199,7 +198,6 @@ module Prawn
       end
 
     end
-
   end
 end
 
@@ -265,7 +263,6 @@ module PDF
 
     # @private
     class Reference
-
       # Returns the object definition for the object this references, keyed from
       # +key+.
       def encrypted_object(key)
@@ -281,7 +278,6 @@ module PDF
 
         output << "endobj\n"
       end
-
     end
   end
 end

--- a/lib/prawn/security.rb
+++ b/lib/prawn/security.rb
@@ -17,7 +17,6 @@ module Prawn
     # Implements PDF encryption (password protection and permissions) as
     # specified in the PDF Reference, version 1.3, section 3.5 "Encryption".
     module Security
-
       # @group Experimental API
 
       # Encrypts the document, to protect confidential data or control
@@ -196,7 +195,6 @@ module Prawn
       def user_password_hash
         Arcfour.new(user_encryption_key).encrypt(PasswordPadding)
       end
-
     end
   end
 end

--- a/lib/prawn/security.rb
+++ b/lib/prawn/security.rb
@@ -252,7 +252,6 @@ module PDF
       end
     end
 
-
     # @private
     class Stream
       def encrypted_object(key, id, gen)

--- a/lib/prawn/soft_mask.rb
+++ b/lib/prawn/soft_mask.rb
@@ -8,7 +8,6 @@
 #
 
 module Prawn
-
   # The Prawn::SoftMask module is used to create arbitrary transparency in
   # document. Using a soft mask allows creating more visually rich documents.
   #

--- a/lib/prawn/stamp.rb
+++ b/lib/prawn/stamp.rb
@@ -7,7 +7,6 @@
 # This is free software. Please see the LICENSE and COPYING files for details.
 #
 module Prawn
-
   # The Prawn::Stamp module is used to create content that will be
   # included multiple times in a document. Using a stamp has three
   # advantages over creating content anew each time it is placed on
@@ -26,7 +25,6 @@ module Prawn
   #   pdf.stamp("my_stamp")
   #
   module Stamp
-
     # @group Stable API
 
     # Renders the stamp named <tt>name</tt> to the page
@@ -142,6 +140,5 @@ module Prawn
       write_stroke_join_style
       write_stroke_dash
     end
-
   end
 end

--- a/lib/prawn/text.rb
+++ b/lib/prawn/text.rb
@@ -15,7 +15,6 @@ require_relative "text/box"
 
 module Prawn
   module Text
-
     include PDF::Core::Text
     include Prawn::Text::Formatted
 

--- a/lib/prawn/text/box.rb
+++ b/lib/prawn/text/box.rb
@@ -125,7 +125,6 @@ module Prawn
     # consumed by the printed text
     #
     class Box < Prawn::Text::Formatted::Box
-
       def initialize(string, options={})
         super([{ :text => string }], options)
       end
@@ -134,7 +133,6 @@ module Prawn
         leftover = super(flags)
         leftover.collect { |hash| hash[:text] }.join
       end
-
     end
 
   end

--- a/lib/prawn/text/box.rb
+++ b/lib/prawn/text/box.rb
@@ -134,6 +134,5 @@ module Prawn
         leftover.collect { |hash| hash[:text] }.join
       end
     end
-
   end
 end

--- a/lib/prawn/text/formatted/arranger.rb
+++ b/lib/prawn/text/formatted/arranger.rb
@@ -282,7 +282,6 @@ module Prawn
           @max_descender = [defined?(@max_descender) && @max_descender, fragment.descender].compact.max
           @max_ascender = [defined?(@max_ascender) && @max_ascender, fragment.ascender].compact.max
         end
-
       end
 
     end

--- a/lib/prawn/text/formatted/arranger.rb
+++ b/lib/prawn/text/formatted/arranger.rb
@@ -10,7 +10,6 @@
 module Prawn
   module Text
     module Formatted #:nodoc:
-
       # @private
 
       class Arranger #:nodoc:
@@ -283,7 +282,6 @@ module Prawn
           @max_ascender = [defined?(@max_ascender) && @max_ascender, fragment.ascender].compact.max
         end
       end
-
     end
   end
 end

--- a/lib/prawn/text/formatted/box.rb
+++ b/lib/prawn/text/formatted/box.rb
@@ -606,7 +606,6 @@ module Prawn
             @document.stroke_line(fragment.strikethrough_points)
           end
         end
-
       end
 
     end

--- a/lib/prawn/text/formatted/box.rb
+++ b/lib/prawn/text/formatted/box.rb
@@ -607,7 +607,6 @@ module Prawn
           end
         end
       end
-
     end
   end
 end

--- a/lib/prawn/text/formatted/fragment.rb
+++ b/lib/prawn/text/formatted/fragment.rb
@@ -10,7 +10,6 @@ module Prawn
   module Text
     module Formatted
 
-
       # Prawn::Text::Formatted::Fragment is a state store for a formatted text
       # fragment. It does not render anything.
       #

--- a/lib/prawn/text/formatted/fragment.rb
+++ b/lib/prawn/text/formatted/fragment.rb
@@ -9,7 +9,6 @@
 module Prawn
   module Text
     module Formatted
-
       # Prawn::Text::Formatted::Fragment is a state store for a formatted text
       # fragment. It does not render anything.
       #

--- a/lib/prawn/text/formatted/fragment.rb
+++ b/lib/prawn/text/formatted/fragment.rb
@@ -15,7 +15,6 @@ module Prawn
       #
       # @private
       class Fragment
-
         attr_reader :format_state, :text
         attr_writer :width
         attr_accessor :line_height, :descender, :ascender
@@ -256,7 +255,6 @@ module Prawn
             string
           end
         end
-
       end
     end
   end

--- a/lib/prawn/text/formatted/line_wrap.rb
+++ b/lib/prawn/text/formatted/line_wrap.rb
@@ -11,7 +11,6 @@
 module Prawn
   module Text
     module Formatted #:nodoc:
-
       # @private
       class LineWrap #:nodoc:
         # The width of the last wrapped line

--- a/lib/prawn/text/formatted/line_wrap.rb
+++ b/lib/prawn/text/formatted/line_wrap.rb
@@ -14,7 +14,6 @@ module Prawn
 
       # @private
       class LineWrap #:nodoc:
-
         # The width of the last wrapped line
         #
         def width

--- a/lib/prawn/text/formatted/parser.rb
+++ b/lib/prawn/text/formatted/parser.rb
@@ -11,7 +11,6 @@
 module Prawn
   module Text
     module Formatted
-
       class Parser
         # @group Extension API
 

--- a/lib/prawn/text/formatted/parser.rb
+++ b/lib/prawn/text/formatted/parser.rb
@@ -217,7 +217,6 @@ module Prawn
           end
           array
         end
-
       end
     end
   end

--- a/lib/prawn/text/formatted/wrap.rb
+++ b/lib/prawn/text/formatted/wrap.rb
@@ -15,7 +15,6 @@ module Prawn
       # @private
 
       module Wrap #:nodoc:
-
         def initialize(array, options)
           @line_wrap = Prawn::Text::Formatted::LineWrap.new
           @arranger = Prawn::Text::Formatted::Arranger.new(@document,
@@ -152,7 +151,6 @@ module Prawn
                           line_width, word_spacing)
           end
         end
-
       end
     end
   end

--- a/lib/prawn/text/formatted/wrap.rb
+++ b/lib/prawn/text/formatted/wrap.rb
@@ -23,7 +23,6 @@ module Prawn
           @disable_wrap_by_char = options[:disable_wrap_by_char]
         end
 
-
         # See the developer documentation for PDF::Core::Text#wrap
         #
         # Formatted#wrap should set the following variables:

--- a/lib/prawn/utilities.rb
+++ b/lib/prawn/utilities.rb
@@ -9,7 +9,6 @@
 require 'thread'
 
 module Prawn
-
   # Throughout the Prawn codebase, repeated calculations which can benefit from caching are made
   # In some cases, caching and reusing results can not only save CPU cycles but also greatly
   #   reduce memory requirements

--- a/lib/prawn/utilities.rb
+++ b/lib/prawn/utilities.rb
@@ -23,9 +23,11 @@ module Prawn
       @cache = {}
       @mutex = Mutex.new
     end
+
     def [](key)
       @mutex.synchronize { @cache[key] }
     end
+
     def []=(key,value)
       @mutex.synchronize { @cache[key] = value }
     end
@@ -36,9 +38,11 @@ module Prawn
     def initialize
       @cache_id = "cache_#{self.object_id}".to_sym
     end
+
     def [](key)
       (Thread.current[@cache_id] ||= {})[key]
     end
+
     def []=(key,value)
       (Thread.current[@cache_id] ||= {})[key] = value
     end

--- a/manual/basic_concepts/basic_concepts.rb
+++ b/manual/basic_concepts/basic_concepts.rb
@@ -6,9 +6,7 @@
 require_relative "../example_helper"
 
 Prawn::ManualBuilder::Example.generate("basic_concepts.pdf", :page_size => "FOLIO") do
-
   package "basic_concepts" do |p|
-
     p.example "creation", :eval_source => false, :full_source => true
     p.example "origin"
     p.example "cursor"

--- a/manual/bounding_box/bounding_box.rb
+++ b/manual/bounding_box/bounding_box.rb
@@ -6,9 +6,7 @@ require File.expand_path(File.join(File.dirname(__FILE__),
                                    %w[.. example_helper]))
 
 Prawn::ManualBuilder::Example.generate("bounding_box.pdf", :page_size => "FOLIO") do
-
   package "bounding_box" do |p|
-
     p.section "Basics" do |s|
       s.example "creation"
       s.example "bounds"
@@ -34,6 +32,5 @@ Prawn::ManualBuilder::Example.generate("bounding_box.pdf", :page_size => "FOLIO"
             "Indent blocks"
           )
     end
-
   end
 end

--- a/manual/bounding_box/russian_boxes.rb
+++ b/manual/bounding_box/russian_boxes.rb
@@ -37,4 +37,3 @@ Prawn::ManualBuilder::Example.generate(filename) do
     recurse_bounding_box
   end
 end
-

--- a/manual/bounding_box/stretchy.rb
+++ b/manual/bounding_box/stretchy.rb
@@ -27,5 +27,4 @@ Prawn::ManualBuilder::Example.generate(filename) do
 
     transparent(0.5) { stroke_bounds }
   end
-
 end

--- a/manual/contents.rb
+++ b/manual/contents.rb
@@ -8,7 +8,6 @@ Encoding.default_external = Encoding::UTF_8
 
 Prawn::ManualBuilder::Example.generate("manual.pdf",
   :skip_page_creation => true, :page_size => "FOLIO") do
-
   load_page "", "cover"
   load_page "", "how_to_read_this_manual"
 

--- a/manual/cover.rb
+++ b/manual/cover.rb
@@ -35,5 +35,4 @@ Prawn::ManualBuilder::Example.generate(filename) do
                                   git_commit,
                          :size => 12}
                     ],   :at => [390, cursor - 620])
-
 end

--- a/manual/document_and_page_options/document_and_page_options.rb
+++ b/manual/document_and_page_options/document_and_page_options.rb
@@ -7,9 +7,7 @@ require File.expand_path(File.join(File.dirname(__FILE__),
 
 Prawn::ManualBuilder::Example.generate("document_and_page_options.pdf",
                         :page_size => "FOLIO") do
-
   package "document_and_page_options" do |p|
-
     p.example "page_size",    :eval_source => false, :full_source => true
     p.example "page_margins", :eval_source => false, :full_source => true
     p.example "background",   :eval_source => false, :full_source => true
@@ -27,6 +25,5 @@ Prawn::ManualBuilder::Example.generate("document_and_page_options.pdf",
             "How to add metadata to the generated PDF"
           )
     end
-
   end
 end

--- a/manual/document_and_page_options/metadata.rb
+++ b/manual/document_and_page_options/metadata.rb
@@ -17,7 +17,6 @@ Prawn::Document.generate("metadata.pdf",
     :Producer     => "Prawn",
     :CreationDate => Time.now
   }) do
-
   text "This is a test of setting metadata properties via the info option."
   text "While the keys are arbitrary, the above example sets common attributes."
 end

--- a/manual/document_and_page_options/page_size.rb
+++ b/manual/document_and_page_options/page_size.rb
@@ -24,7 +24,6 @@ Prawn::Document.generate("page_size.pdf",
   custom_size = [275, 326]
 
   ["A4", "TABLOID", "B7", custom_size ].each do |size|
-
     start_new_page(:size => size, :layout => :portrait)
     text "#{size} portrait page."
 

--- a/manual/graphics/graphics.rb
+++ b/manual/graphics/graphics.rb
@@ -6,9 +6,7 @@ require File.expand_path(File.join(File.dirname(__FILE__),
                                    %w[.. example_helper]))
 
 Prawn::ManualBuilder::Example.generate("graphics.pdf", :page_size => "FOLIO") do
-
   package "graphics" do |p|
-
     p.section "Basics" do |s|
       s.example "helper"
       s.example "fill_and_stroke"
@@ -53,6 +51,5 @@ Prawn::ManualBuilder::Example.generate("graphics.pdf", :page_size => "FOLIO") do
             "How to apply transformations to your drawing space"
           )
     end
-
   end
 end

--- a/manual/graphics/rotate.rb
+++ b/manual/graphics/rotate.rb
@@ -18,9 +18,7 @@ Prawn::ManualBuilder::Example.generate(filename) do
   fill_circle [250, 200], 2
 
   12.times do |i|
-
     rotate(i * 30, :origin => [250, 200]) do
-
       stroke_rectangle [350, 225], 100, 50
       draw_text "Rotated #{i * 30}°", :size => 10, :at => [360, 205]
     end

--- a/manual/graphics/soft_masks.rb
+++ b/manual/graphics/soft_masks.rb
@@ -42,5 +42,4 @@ Prawn::ManualBuilder::Example.generate(filename) do
     fill_color '61bb46'
     fill_rectangle [0, 160], 600, 20
   end
-
 end

--- a/manual/graphics/translate.rb
+++ b/manual/graphics/translate.rb
@@ -11,11 +11,9 @@ Prawn::ManualBuilder::Example.generate(filename) do
   stroke_axis
 
   1.upto(3) do |i|
-
     x = i * 50
     y = i * 100
     translate(x, y) do
-
       # Draw a point on the new origin
       fill_circle [0, 0], 2
       draw_text "New origin after translation to [#{x}, #{y}]",

--- a/manual/graphics/transparency.rb
+++ b/manual/graphics/transparency.rb
@@ -24,7 +24,6 @@ Prawn::ManualBuilder::Example.generate(filename) do
 
   base_x = 100
   [[0.5, 1], 0.5, [1, 0.5]].each do |args|
-
     transparent(*args) do
       fill_circle [base_x, 100], 50
       stroke_rectangle [base_x - 20, 100], 40, 80

--- a/manual/how_to_read_this_manual.rb
+++ b/manual/how_to_read_this_manual.rb
@@ -36,5 +36,4 @@ Prawn::ManualBuilder::Example.generate(filename) do
 
   https://github.com/prawnpdf/prawn/blob/master/lib/prawn/graphics.rb
   END_TEXT
-
 end

--- a/manual/images/images.rb
+++ b/manual/images/images.rb
@@ -6,9 +6,7 @@ require File.expand_path(File.join(File.dirname(__FILE__),
                                    %w[.. example_helper]))
 
 Prawn::ManualBuilder::Example.generate("images.pdf", :page_size => "FOLIO") do
-
   package "images" do |p|
-
     p.section "Basics" do |s|
       s.example "plain_image"
       s.example "absolute_position"
@@ -35,6 +33,5 @@ Prawn::ManualBuilder::Example.generate("images.pdf", :page_size => "FOLIO") do
             "How to configure the image dimensions by setting the width and height or by scaling it"
           )
     end
-
   end
 end

--- a/manual/layout/layout.rb
+++ b/manual/layout/layout.rb
@@ -6,9 +6,7 @@ require File.expand_path(File.join(File.dirname(__FILE__),
                                    %w[.. example_helper]))
 
 Prawn::ManualBuilder::Example.generate("layout.pdf", :page_size => "FOLIO") do
-
   package "layout" do |p|
-
     p.example "simple_grid"
     p.example "boxes"
     p.example "content"
@@ -23,6 +21,5 @@ Prawn::ManualBuilder::Example.generate("layout.pdf", :page_size => "FOLIO") do
             "How to create boxes according to the grid"
           )
     end
-
   end
 end

--- a/manual/outline/outline.rb
+++ b/manual/outline/outline.rb
@@ -6,9 +6,7 @@ require File.expand_path(File.join(File.dirname(__FILE__),
                                    %w[.. example_helper]))
 
 Prawn::ManualBuilder::Example.generate("outline.pdf", :page_size => "FOLIO") do
-
   package "outline" do |p|
-
     p.section "Basics" do |s|
       s.example "sections_and_pages", :eval_source => false
     end
@@ -27,6 +25,5 @@ Prawn::ManualBuilder::Example.generate("outline.pdf", :page_size => "FOLIO") do
             "How to insert sections and/or pages to a previously defined outline structure"
           )
     end
-
   end
 end

--- a/manual/repeatable_content/repeatable_content.rb
+++ b/manual/repeatable_content/repeatable_content.rb
@@ -6,9 +6,7 @@ require File.expand_path(File.join(File.dirname(__FILE__),
                                    %w[.. example_helper]))
 
 Prawn::ManualBuilder::Example.generate("repeatable_content.pdf", :page_size => "FOLIO") do
-
   package "repeatable_content" do |p|
-
     p.example "repeater",       :eval_source => false
     p.example "stamp"
     p.example "page_numbering", :eval_source => false
@@ -27,6 +25,5 @@ Prawn::ManualBuilder::Example.generate("repeatable_content.pdf", :page_size => "
             "How to number the document pages with one simple call"
           )
     end
-
   end
 end

--- a/manual/security/encryption.rb
+++ b/manual/security/encryption.rb
@@ -16,13 +16,11 @@
 require File.expand_path(File.join(File.dirname(__FILE__),
                                    %w[.. example_helper]))
 
-
 # Bare encryption. No password needed.
 Prawn::ManualBuilder::Example.generate("bare_encryption.pdf") do
   text "See, no password was asked but the document is still encrypted."
   encrypt_document
 end
-
 
 # Simple password. All permissions granted.
 Prawn::ManualBuilder::Example.generate("simple_password.pdf") do

--- a/manual/security/permissions.rb
+++ b/manual/security/permissions.rb
@@ -18,14 +18,12 @@
 require File.expand_path(File.join(File.dirname(__FILE__),
                                    %w[.. example_helper]))
 
-
 # User cannot print the document.
 Prawn::ManualBuilder::Example.generate("cannot_print.pdf") do
   text "If you used the user password you won't be able to print the doc."
   encrypt_document(:user_password => 'foo', :owner_password => 'bar',
                    :permissions => { :print_document => false })
 end
-
 
 # All permissions revoked and owner password set to random
 Prawn::ManualBuilder::Example.generate("no_permissions.pdf") do

--- a/manual/security/security.rb
+++ b/manual/security/security.rb
@@ -6,9 +6,7 @@ require File.expand_path(File.join(File.dirname(__FILE__),
                                    %w[.. example_helper]))
 
 Prawn::ManualBuilder::Example.generate("security.pdf", :page_size => "FOLIO") do
-
   package "security" do |p|
-
     p.example "encryption",  :eval_source => false, :full_source => true
     p.example "permissions", :eval_source => false, :full_source => true
 
@@ -23,6 +21,5 @@ Prawn::ManualBuilder::Example.generate("security.pdf", :page_size => "FOLIO") do
             "How to set a owner password that bypass the document permissions"
           )
     end
-
   end
 end

--- a/manual/text/color.rb
+++ b/manual/text/color.rb
@@ -21,4 +21,3 @@ Prawn::ManualBuilder::Example.generate(filename) do
        :color => "0000FF",
        :inline_format => true
 end
-

--- a/manual/text/column_box.rb
+++ b/manual/text/column_box.rb
@@ -29,4 +29,3 @@ Prawn::ManualBuilder::Example.generate(filename) do
     END
   end
 end
-

--- a/manual/text/paragraph_indentation.rb
+++ b/manual/text/paragraph_indentation.rb
@@ -30,5 +30,4 @@ Prawn::ManualBuilder::Example.generate(filename) do
   text "This paragraph will be indented. " * 10 +
         "\n" + "This one will too. " * 10,
         :indent_paragraphs => 60, :direction => :rtl
-
 end

--- a/manual/text/rotation.rb
+++ b/manual/text/rotation.rb
@@ -30,7 +30,6 @@ Prawn::ManualBuilder::Example.generate(filename) do
 
   [:lower_left, :upper_left,
    :lower_right, :upper_right].each_with_index do |corner, index|
-
     y = y - 100 if index == 2
     stroke_rectangle [x + (index % 2) * 200, y], width, height
     text_box("This text was rotated around the #{corner} corner.",

--- a/manual/text/text.rb
+++ b/manual/text/text.rb
@@ -6,9 +6,7 @@ require File.expand_path(File.join(File.dirname(__FILE__),
                                    %w[.. example_helper]))
 
 Prawn::ManualBuilder::Example.generate("text.pdf", :page_size => "FOLIO") do
-
   package "text" do |p|
-
     p.section "Basics" do |s|
       s.example "free_flowing_text"
       s.example "positioned_text"
@@ -68,6 +66,5 @@ Prawn::ManualBuilder::Example.generate("text.pdf", :page_size => "FOLIO") do
             "What happens when rendering text in different languages"
           )
     end
-
   end
 end

--- a/spec/acceptance/png.rb
+++ b/spec/acceptance/png.rb
@@ -22,4 +22,3 @@ Prawn::Document.generate("png_types.pdf", :page_size => "A5") do
     image file, :at => [50,450]
   end
 end
-

--- a/spec/annotations_spec.rb
+++ b/spec/annotations_spec.rb
@@ -3,7 +3,6 @@
 require File.join(File.expand_path(File.dirname(__FILE__)), "spec_helper")
 
 describe "When creating annotations" do
-
   before(:each) { create_pdf }
 
   it "should append annotation to current page" do
@@ -21,11 +20,9 @@ describe "When creating annotations" do
     opts = @pdf.annotate(:Type => :Bogus, :Rect => [0,0,10,10], :Subtype => :Text, :Contents => "Hello world!")
     opts[:Type].should == :Annot
   end
-
 end
 
 describe "When creating text annotations" do
-
   before(:each) do
     @rect = [0,0,10,10]
     @content = "Hello, world!"
@@ -45,11 +42,9 @@ describe "When creating text annotations" do
     opts[:Subtype].should == :Text
     opts[:Open].should == true
   end
-
 end
 
 describe "When creating link annotations" do
-
   before(:each) do
     @rect = [0,0,10,10]
     @dest = "home"
@@ -69,5 +64,4 @@ describe "When creating link annotations" do
     opts[:Subtype].should == :Link
     opts[:Dest].should == @dest
   end
-
 end

--- a/spec/annotations_spec.rb
+++ b/spec/annotations_spec.rb
@@ -2,7 +2,6 @@
 
 require File.join(File.expand_path(File.dirname(__FILE__)), "spec_helper")
 
-
 describe "When creating annotations" do
 
   before(:each) { create_pdf }

--- a/spec/bounding_box_spec.rb
+++ b/spec/bounding_box_spec.rb
@@ -3,7 +3,6 @@
 require File.join(File.expand_path(File.dirname(__FILE__)), "spec_helper")
 
 describe "A bounding box" do
-
   before(:each) do
     @x      = 100
     @y      = 125
@@ -93,11 +92,9 @@ describe "A bounding box" do
       pdf.bounding_box([0, 0], :width => 200)
     end.should raise_error(ArgumentError)
   end
-
 end
 
 describe "drawing bounding boxes" do
-
   before(:each) { create_pdf }
 
   it "should not stomp on the arguments to bounding_box" do
@@ -127,7 +124,6 @@ describe "drawing bounding boxes" do
 
   it "should restore the parent bounding box when calls are nested" do
     @pdf.bounding_box [100,500], :width => 300, :height => 300 do
-
       @pdf.bounds.absolute_top.should  == 500 + @pdf.margin_box.absolute_bottom
       @pdf.bounds.absolute_left.should == 100 + @pdf.margin_box.absolute_left
 
@@ -140,7 +136,6 @@ describe "drawing bounding boxes" do
 
       @pdf.bounds.absolute_top.should  == 500 + @pdf.margin_box.absolute_bottom
       @pdf.bounds.absolute_left.should == 100 + @pdf.margin_box.absolute_left
-
     end
   end
 
@@ -197,7 +192,6 @@ describe "drawing bounding boxes" do
       @pdf.margin_box.absolute_top - @pdf.height_of("hello")
     )
   end
-
 end
 
 describe "Indentation" do
@@ -394,7 +388,6 @@ describe "A canvas" do
 
     doc.y.should == original_ypos
   end
-
 end
 
 describe "Deep-copying" do
@@ -473,7 +466,6 @@ describe "Prawn::Document#reference_bounds" do
       end
     end
   end
-
 end
 
 describe "BoundingBox#move_past_bottom" do

--- a/spec/column_box_spec.rb
+++ b/spec/column_box_spec.rb
@@ -38,7 +38,6 @@ describe "A column box" do
     init_column_top = @pdf.cursor
     @pdf.column_box [0, @pdf.cursor], :width => 500,
       :height => 200, :columns => 2 do
-
         @pdf.bounds.move_past_bottom
         @pdf.bounds.move_past_bottom
 
@@ -54,7 +53,6 @@ describe "A column box" do
     init_column_top = @pdf.cursor
     @pdf.column_box [0, @pdf.cursor], :width => 500, :reflow_margins => true,
       :height => 200, :columns => 2 do
-
         @pdf.bounds.move_past_bottom
         @pdf.bounds.move_past_bottom
 

--- a/spec/destinations_spec.rb
+++ b/spec/destinations_spec.rb
@@ -3,7 +3,6 @@
 require File.join(File.expand_path(File.dirname(__FILE__)), "spec_helper")
 
 describe "When creating destinations" do
-
   before(:each) { create_pdf }
 
   it "should add entry to Dests name tree" do
@@ -11,5 +10,4 @@ describe "When creating destinations" do
     @pdf.add_dest "candy", "chocolate"
     @pdf.dests.data.size.should == 1
   end
-
 end

--- a/spec/document_spec.rb
+++ b/spec/document_spec.rb
@@ -86,11 +86,9 @@ describe "when generating a document from a subclass" do
     custom_document.new.respond_to?(:test_extensions1).should be_true
     custom_document.new.respond_to?(:test_extensions2).should be_true
   end
-
 end
 
 describe "When creating multi-page documents" do
-
   before(:each) { create_pdf }
 
   it "should initialize with a single page" do
@@ -107,7 +105,6 @@ describe "When creating multi-page documents" do
     page_counter.pages.size.should == 4
     @pdf.page_count.should == 4
   end
-
 end
 
 describe "When beginning each new page" do
@@ -171,7 +168,6 @@ describe "The page_number method" do
     pdf.go_to_page 3
     pdf.page_number.should == 3
   end
-
 end
 
 describe "on_page_create callback" do
@@ -230,13 +226,10 @@ describe "on_page_create callback" do
 
       @pdf.start_new_page
   end
-
 end
 
 describe "Document compression" do
-
   it "should not compress the page content stream if compression is disabled" do
-
     pdf = Prawn::Document.new(:compress => false)
     pdf.page.content.stream.stubs(:compress!).returns(true)
     pdf.page.content.stream.expects(:compress!).never
@@ -246,7 +239,6 @@ describe "Document compression" do
   end
 
   it "should compress the page content stream if compression is enabled" do
-
     pdf = Prawn::Document.new(:compress => true)
     pdf.page.content.stream.stubs(:compress!).returns(true)
     pdf.page.content.stream.expects(:compress!).once
@@ -265,7 +257,6 @@ describe "Document compression" do
 
     doc_compressed.render.length.should be < doc_uncompressed.render.length
   end
-
 end
 
 describe "Document metadata" do
@@ -332,7 +323,6 @@ describe "When reopening pages" do
       bounds.width.should == page1_bounds.width
       bounds.height.should == page1_bounds.height
     end
-
   end
 end
 
@@ -365,7 +355,6 @@ describe "When setting page size" do
       page[:size].should == PDF::Core::PageGeometry::SIZES["LEGAL"]
     end
   end
-
 end
 
 describe "When setting page layout" do
@@ -459,7 +448,6 @@ describe "The group() feature" do
     pages.size.should == 2
     pages[1][:strings].first.should == '0'
   end
-
 end
 
 describe "The render() feature" do

--- a/spec/document_spec.rb
+++ b/spec/document_spec.rb
@@ -89,7 +89,6 @@ describe "when generating a document from a subclass" do
 
 end
 
-
 describe "When creating multi-page documents" do
 
   before(:each) { create_pdf }
@@ -357,7 +356,6 @@ describe "When setting page size" do
     pages = PDF::Inspector::Page.analyze(@pdf.render).pages
     pages.first[:size].should == [1920, 1080]
   end
-
 
   it "should retain page size by default when starting a new page" do
     @pdf = Prawn::Document.new(:page_size => "LEGAL")

--- a/spec/extensions/mocha.rb
+++ b/spec/extensions/mocha.rb
@@ -31,7 +31,6 @@ class Mocha::Expectation
   end
 end
 
-
 # Equivalent to expects(method_name).at_least(0). More useful when combined
 # with parameter matchers to ignore certain calls for the sake of parameter
 # matching.

--- a/spec/font_spec.rb
+++ b/spec/font_spec.rb
@@ -4,16 +4,13 @@ require File.join(File.expand_path(File.dirname(__FILE__)), "spec_helper")
 require 'pathname'
 
 describe "Font behavior" do
-
   it "should default to Helvetica if no font is specified" do
     @pdf = Prawn::Document.new
     @pdf.font.name.should == "Helvetica"
   end
-
 end
 
 describe "Font objects" do
-
   it "should be equal" do
     font1 = Prawn::Document.new.font
     font2 = Prawn::Document.new.font
@@ -35,7 +32,6 @@ describe "Font objects" do
     hash[ font1 ].should == "Overwritten"
     hash[ font2 ].should == "Overwritten"
   end
-
 end
 
 describe "#width_of" do
@@ -231,7 +227,6 @@ describe "Transactional font handling" do
 
     @pdf.font_size.should == 12
   end
-
 end
 
 describe "Document#page_fonts" do
@@ -263,11 +258,9 @@ describe "Document#page_fonts" do
   def page_should_not_include_font(font)
     page_includes_font?(font).should be_false
   end
-
 end
 
 describe "AFM fonts" do
-
   before do
     create_pdf
     @times = @pdf.find_font "Times-Roman"
@@ -304,7 +297,6 @@ describe "AFM fonts" do
   end
 
   describe "when normalizing encoding" do
-
     it "should not modify the original string when normalize_encoding() is used" do
       original = "Foo"
       normalized = @times.normalize_encoding(original)
@@ -316,7 +308,6 @@ describe "AFM fonts" do
       normalized = @times.normalize_encoding!(original)
       original.equal?(normalized).should be_true
     end
-
   end
 
   it "should omit /Encoding for symbolic fonts" do
@@ -324,7 +315,6 @@ describe "AFM fonts" do
     font_dict = zapf.send(:register, nil)
     font_dict.data[:Encoding].should == nil
   end
-
 end
 
 describe "#glyph_present" do
@@ -355,7 +345,6 @@ describe "#glyph_present" do
 end
 
 describe "TTF fonts" do
-
   before do
     create_pdf
     @font = @pdf.find_font "#{Prawn::DATADIR}/fonts/DejaVuSans.ttf"
@@ -416,7 +405,6 @@ describe "TTF fonts" do
       normalized = @font.normalize_encoding!(original)
       original.equal?(normalized).should be_true
     end
-
   end
 end
 

--- a/spec/formatted_text_arranger_spec.rb
+++ b/spec/formatted_text_arranger_spec.rb
@@ -296,7 +296,6 @@ describe "Core::Text::Formatted::Arranger#line_width with character_spacing > 0"
 
     base_line_width = arranger.line_width
 
-
     array = [{ :text => "hello " },
              { :text => "world", :styles => [:bold],
                :character_spacing => 7}]

--- a/spec/formatted_text_box_spec.rb
+++ b/spec/formatted_text_box_spec.rb
@@ -241,7 +241,6 @@ end
 
 describe "Text::Formatted::Box with :fallback_fonts option " +
   "with glyphs not in the primary or the fallback fonts" do
-
   it "should raise an exception" do
    file = "#{Prawn::DATADIR}/fonts/gkai00mp.ttf"
     create_pdf

--- a/spec/formatted_text_box_spec.rb
+++ b/spec/formatted_text_box_spec.rb
@@ -187,7 +187,6 @@ describe "Text::Formatted::Box" do
       :normal => { :file => file }
     }
 
-
     @formatted_text = [{ :text => "hello你好" }]
     @pdf.fallback_fonts(["Kai"])
     @pdf.fallback_fonts = ["Kai"]
@@ -306,7 +305,6 @@ describe "Text::Formatted::Box#render" do
     text_box = Prawn::Text::Formatted::Box.new(array, options)
     text_box.render
     text_box.text.should == "hello\n\nworld"
-
 
     array = [{ :text => "hello" + " " * 500},
              { :text => " " * 500 },

--- a/spec/graphics_spec.rb
+++ b/spec/graphics_spec.rb
@@ -122,7 +122,6 @@ describe "When drawing a curve" do
     curve.coords.should == [100.0, 100.0, 20.0, 90.0, 90.0, 75.0, 50.0, 50.0]
   end
 
-
 end
 
 describe "When drawing a rounded rectangle" do
@@ -154,7 +153,6 @@ describe "When drawing a rounded rectangle" do
   it "should start and end with the same point" do
     @original_point.should == @all_coords.last
   end
-
 
 end
 
@@ -460,8 +458,6 @@ describe "When using graphics states" do
     @pdf.graphic_state.line_width.should == 1
   end
 
-
-
   it "should not add extra graphic space closings when rendering multiple times" do
     @pdf.render
     state = PDF::Inspector::Graphics::State.analyze(@pdf.render)
@@ -484,7 +480,6 @@ describe "When using graphics states" do
     state.save_graphics_state_count.should == 2
     state.restore_graphics_state_count.should == 2
   end
-
 
   it "should raise_error error if closing an empty graphic stack" do
     lambda {

--- a/spec/graphics_spec.rb
+++ b/spec/graphics_spec.rb
@@ -3,7 +3,6 @@
 require File.join(File.expand_path(File.dirname(__FILE__)), "spec_helper")
 
 describe "When drawing a line" do
-
   before(:each) { create_pdf }
 
   it "should draw a line from (100,600) to (100,500)" do
@@ -71,11 +70,9 @@ describe "When drawing a line" do
         should raise_error(ArgumentError)
     end
   end
-
 end
 
 describe "When drawing a polygon" do
-
   before(:each) { create_pdf }
 
   it "should draw each line passed to polygon()" do
@@ -84,11 +81,9 @@ describe "When drawing a polygon" do
     line_drawing = PDF::Inspector::Graphics::Line.analyze(@pdf.render)
     line_drawing.points.should == [[100,500],[100,400],[200,400],[100,500]]
   end
-
 end
 
 describe "When drawing a rectangle" do
-
   before(:each) { create_pdf }
 
   it "should use a point, width, and height for coords" do
@@ -100,13 +95,10 @@ describe "When drawing a rectangle" do
     rectangles[0][:point].should  == [200,100]
     rectangles[0][:width].should  == 50
     rectangles[0][:height].should == 100
-
   end
-
 end
 
 describe "When drawing a curve" do
-
   before(:each) { create_pdf }
 
   it "should draw a bezier curve from 50,50 to 100,100" do
@@ -121,7 +113,6 @@ describe "When drawing a curve" do
     curve = PDF::Inspector::Graphics::Curve.analyze(@pdf.render)
     curve.coords.should == [100.0, 100.0, 20.0, 90.0, 90.0, 75.0, 50.0, 50.0]
   end
-
 end
 
 describe "When drawing a rounded rectangle" do
@@ -153,7 +144,6 @@ describe "When drawing a rounded rectangle" do
   it "should start and end with the same point" do
     @original_point.should == @all_coords.last
   end
-
 end
 
 describe "When drawing an ellipse" do
@@ -189,7 +179,6 @@ describe "When drawing an ellipse" do
   it "should move the pointer to the center of the ellipse after drawing" do
     @curve.coords[-2..-1].should == [100,100]
   end
-
 end
 
 describe "When drawing a circle" do
@@ -231,7 +220,6 @@ describe "When filling" do
 end
 
 describe "When setting colors" do
-
   before(:each) { create_pdf }
 
   it "should set stroke colors" do
@@ -544,7 +532,6 @@ describe "When using transformation matrix" do
       @pdf.do_something
     end
   end
-
 end
 
 describe "When using transformations shortcuts" do

--- a/spec/image_handler_spec.rb
+++ b/spec/image_handler_spec.rb
@@ -50,5 +50,4 @@ describe "ImageHandler" do
     expect { image_handler.find("arbitrary blob") }.
        to(raise_error(Prawn::Errors::UnsupportedImageType))
   end
-
 end

--- a/spec/images_spec.rb
+++ b/spec/images_spec.rb
@@ -164,4 +164,3 @@ describe "the image() function" do
     end
   end
 end
-

--- a/spec/images_spec.rb
+++ b/spec/images_spec.rb
@@ -5,7 +5,6 @@ require 'set'
 require 'pathname'
 
 describe "the image() function" do
-
   before(:each) do
     @filename = "#{Prawn::DATADIR}/images/pigs.jpg"
     create_pdf
@@ -164,6 +163,5 @@ describe "the image() function" do
       info.scaled_width.should  == 300.0
     end
   end
-
 end
 

--- a/spec/inline_formatted_text_parser_spec.rb
+++ b/spec/inline_formatted_text_parser_spec.rb
@@ -350,7 +350,6 @@ describe "Text::Formatted::Parser#format" do
   end
 end
 
-
 describe "Text::Formatted::Parser#to_string" do
   it "should handle sup" do
     string = "<sup>superscript</sup>"

--- a/spec/jpg_spec.rb
+++ b/spec/jpg_spec.rb
@@ -21,4 +21,3 @@ describe "When reading a JPEG file" do
     jpg.channels.should == 3
   end
 end
-

--- a/spec/jpg_spec.rb
+++ b/spec/jpg_spec.rb
@@ -7,7 +7,6 @@
 require File.join(File.expand_path(File.dirname(__FILE__)), "spec_helper")
 
 describe "When reading a JPEG file" do
-
   before(:each) do
     @filename = "#{Prawn::DATADIR}/images/pigs.jpg"
     @img_data = File.open(@filename, "rb") { |f| f.read }

--- a/spec/line_wrap_spec.rb
+++ b/spec/line_wrap_spec.rb
@@ -364,4 +364,3 @@ describe "Core::Text::Formatted::LineWrap#paragraph_finished?" do
     @line_wrap.paragraph_finished?.should == true
   end
 end
-

--- a/spec/measurement_units_spec.rb
+++ b/spec/measurement_units_spec.rb
@@ -4,7 +4,6 @@ require File.join(File.expand_path(File.dirname(__FILE__)), "spec_helper")
 require "prawn/measurement_extensions"
 
 describe "Measurement units" do
-
   it "should convert units to PostScriptPoints" do
     1.mm.should be_within(0.000000001).of(2.834645669)
     1.mm.should == (72 / 25.4)
@@ -20,6 +19,5 @@ describe "Measurement units" do
     1.yd.should == 72 * 12 * 3
     1.pt.should == 1
   end
-
 end
 

--- a/spec/measurement_units_spec.rb
+++ b/spec/measurement_units_spec.rb
@@ -20,4 +20,3 @@ describe "Measurement units" do
     1.pt.should == 1
   end
 end
-

--- a/spec/outline_spec.rb
+++ b/spec/outline_spec.rb
@@ -67,24 +67,19 @@ describe "Outline" do
     end
 
     describe "#increase_count" do
-
       it "should add the count of all descendant items" do
         @outline_root[:Count].should == 3
         @section_1[:Count].abs.should == 2
         @page_1[:Count].should == 0
         @page_2[:Count].should == 0
       end
-
     end
 
     describe "closed option" do
-
       it "should set the item's integer count to negative" do
         @section_1[:Count].should == -2
       end
-
     end
-
   end
 
   describe "adding a custom destination" do
@@ -106,7 +101,6 @@ describe "Outline" do
     it "should reference the custom destination" do
       referenced_object(@custom_dest[:Dest].first).should == referenced_object(@pages.last)
     end
-
   end
 
   describe "addding a section later with outline#section" do
@@ -141,12 +135,10 @@ describe "Outline" do
     it "should increase the count of root outline dictionary" do
       @outline_root[:Count].should == 5
     end
-
   end
 
   describe "#outline.add_subsection_to" do
     context "positioned last" do
-
       before(:each) do
         @pdf.start_new_page
         @pdf.text "Page 3. An added subsection "
@@ -188,11 +180,9 @@ describe "Outline" do
       it "should increase the count of root outline dictionary" do
         @outline_root[:Count].should == 5
       end
-
     end
 
     context "positioned first" do
-
       before(:each) do
         @pdf.start_new_page
         @pdf.text "Page 3. An added subsection "
@@ -234,7 +224,6 @@ describe "Outline" do
       it "should increase the count of root outline dictionary" do
         @outline_root[:Count].should == 5
       end
-
     end
 
     it "should require an existing title" do
@@ -277,7 +266,6 @@ describe "Outline" do
       end
 
       describe "#adjust_relations" do
-
         it "should reset the sibling relations of adjoining items to inserted item" do
           render_and_find_objects
           referenced_object(@page_1[:Next]).should == @inserted_page
@@ -295,7 +283,6 @@ describe "Outline" do
           referenced_object(@section_1[:First]).should == @page_1
           referenced_object(@section_1[:Last]).should == @page_2
         end
-
       end
 
       context "when adding another section afterwards" do
@@ -312,11 +299,9 @@ describe "Outline" do
           referenced_object(@section_1[:Next]).should == @section_2
         end
       end
-
    end
 
     describe "inserting at the end of another section" do
-
       before(:each) do
         @pdf.go_to_page 2
          @pdf.start_new_page
@@ -330,7 +315,6 @@ describe "Outline" do
       end
 
       describe "#adjust_relations" do
-
         it "should reset the sibling relations of adjoining item to inserted item" do
            referenced_object(@page_2[:Next]).should == @inserted_page
         end
@@ -343,7 +327,6 @@ describe "Outline" do
         it "should adjust the last relation of parent item" do
           referenced_object(@section_1[:Last]).should == @inserted_page
         end
-
       end
     end
 
@@ -360,7 +343,6 @@ describe "Outline" do
         render_and_find_objects
       end.should raise_error(Prawn::Errors::UnknownOutlineTitle)
     end
-
   end
 
   describe "#page" do

--- a/spec/outline_spec.rb
+++ b/spec/outline_spec.rb
@@ -173,7 +173,6 @@ describe "Outline" do
         referenced_object(@subsection[:Prev]).should == @page_2
       end
 
-
       it "the subsection should become the next relation for its parent's old last item" do
          referenced_object(@page_2[:Next]).should == @subsection
        end
@@ -299,7 +298,6 @@ describe "Outline" do
 
       end
 
-
       context "when adding another section afterwards" do
         it "should have reset the root position so that a new section is added at the end of root sections" do
           @pdf.start_new_page
@@ -316,7 +314,6 @@ describe "Outline" do
       end
 
    end
-
 
     describe "inserting at the end of another section" do
 

--- a/spec/png_spec.rb
+++ b/spec/png_spec.rb
@@ -10,7 +10,6 @@
 require File.join(File.expand_path(File.dirname(__FILE__)), "spec_helper")
 
 describe "When reading a greyscale PNG file (color type 0)" do
-
   before(:each) do
     @filename = "#{Prawn::DATADIR}/images/web-links.png"
     @data_filename = "#{Prawn::DATADIR}/images/web-links.dat"
@@ -37,7 +36,6 @@ describe "When reading a greyscale PNG file (color type 0)" do
 end
 
 describe "When reading a greyscale PNG file with transparency (color type 0)" do
-
   before(:each) do
     @filename = "#{Prawn::DATADIR}/images/ruport_type0.png"
     @img_data = File.binread(@filename)
@@ -54,7 +52,6 @@ describe "When reading a greyscale PNG file with transparency (color type 0)" do
 end
 
 describe "When reading an RGB PNG file (color type 2)" do
-
   before(:each) do
     @filename = "#{Prawn::DATADIR}/images/ruport.png"
     @data_filename = "#{Prawn::DATADIR}/images/ruport_data.dat"
@@ -81,7 +78,6 @@ describe "When reading an RGB PNG file (color type 2)" do
 end
 
 describe "When reading an RGB PNG file with transparency (color type 2)" do
-
   before(:each) do
     @filename = "#{Prawn::DATADIR}/images/arrow2.png"
     @img_data = File.binread(@filename)
@@ -100,7 +96,6 @@ end
 
 describe "When reading an indexed color PNG file "+
          "wiih transparency (color type 3)" do
-
   it "raises a not supported error" do
     bin = File.binread("#{Prawn::DATADIR}/images/pal_bk.png")
     expect { Prawn::Images::PNG.new(bin)}.to(
@@ -109,7 +104,6 @@ describe "When reading an indexed color PNG file "+
 end
 
 describe "When reading an indexed color PNG file (color type 3)" do
-
   before(:each) do
     @filename = "#{Prawn::DATADIR}/images/indexed_color.png"
     @data_filename = "#{Prawn::DATADIR}/images/indexed_color.dat"
@@ -136,7 +130,6 @@ describe "When reading an indexed color PNG file (color type 3)" do
 end
 
 describe "When reading a greyscale+alpha PNG file (color type 4)" do
-
   before(:each) do
     @filename = "#{Prawn::DATADIR}/images/page_white_text.png"
     @color_data_filename = "#{Prawn::DATADIR}/images/page_white_text.color"
@@ -172,7 +165,6 @@ describe "When reading a greyscale+alpha PNG file (color type 4)" do
 end
 
 describe "When reading an RGB+alpha PNG file (color type 6)" do
-
   before(:each) do
     @filename = "#{Prawn::DATADIR}/images/dice.png"
     @color_data_filename = "#{Prawn::DATADIR}/images/dice.color"
@@ -208,7 +200,6 @@ describe "When reading an RGB+alpha PNG file (color type 6)" do
 end
 
 describe "When reading a 16bit RGB+alpha PNG file (color type 6)" do
-
   before(:each) do
     @filename = "#{Prawn::DATADIR}/images/16bit.png"
     @color_data_filename = "#{Prawn::DATADIR}/images/16bit.color"

--- a/spec/repeater_spec.rb
+++ b/spec/repeater_spec.rb
@@ -3,7 +3,6 @@
 require File.join(File.expand_path(File.dirname(__FILE__)), "spec_helper")
 
 describe "Repeaters" do
-
   it "creates a stamp and increments Prawn::Repeater.count on initialize" do
     orig_count = Prawn::Repeater.count
 
@@ -126,7 +125,6 @@ describe "Repeaters" do
   end
 
   context "graphic state" do
-
     it "should not alter the graphic state stack color space" do
       create_pdf
       starting_color_space = @pdf.state.page.graphic_state.color_space.dup
@@ -137,7 +135,6 @@ describe "Repeaters" do
     end
 
     context "dynamic repeaters" do
-
       it "should preserve the graphic state at creation time" do
         create_pdf
         @pdf.repeat :all, :dynamic => true do
@@ -152,9 +149,6 @@ describe "Repeaters" do
         text.strings.include?("cap_style: round").should == false
         text.strings.include?("cap_style: butt").should == true
       end
-
     end
-
   end
-
 end

--- a/spec/security_spec.rb
+++ b/spec/security_spec.rb
@@ -4,9 +4,7 @@ require "tempfile"
 require File.join(File.expand_path(File.dirname(__FILE__)), "spec_helper")
 
 describe "Document encryption" do
-
   describe "Password padding" do
-
     include Prawn::Document::Security
 
     it "should truncate long passwords" do
@@ -29,11 +27,9 @@ describe "Document encryption" do
       padded.length.should == 32
       padded.should == Prawn::Document::Security::PasswordPadding
     end
-
   end
 
   describe "Setting permissions" do
-
     def doc_with_permissions(permissions)
       pdf = Prawn::Document.new
 
@@ -71,7 +67,6 @@ describe "Document encryption" do
         doc_with_permissions(:modify_document => false)
       }.should raise_error(ArgumentError)
     end
-
   end
 
   describe "Encryption keys" do
@@ -99,11 +94,9 @@ describe "Document encryption" do
     it "should calculate the correct user_encryption_key" do
       @pdf.user_encryption_key.unpack("H*").first.upcase.should == "B100AB6429"
     end
-
   end
 
   describe "EncryptedPdfObject" do
-
     it "should delegate to PdfObject for simple types" do
       PDF::Core::EncryptedPdfObject(true, nil, nil, nil).should == "true"
       PDF::Core::EncryptedPdfObject(42, nil, nil, nil).should == "42"
@@ -128,7 +121,6 @@ describe "Document encryption" do
       PDF::Core::EncryptedPdfObject(["foo", "bar"], "12345", 123, 0).should ==
         "[<4ad6e3> <4ed8fe>]"
     end
-
   end
 
   describe "Reference#encrypted_object" do
@@ -153,5 +145,4 @@ describe "Document encryption" do
       stream.encrypted_object(nil, 1, 0).should == result
     end
   end
-
 end

--- a/spec/security_spec.rb
+++ b/spec/security_spec.rb
@@ -100,7 +100,6 @@ describe "Document encryption" do
       @pdf.user_encryption_key.unpack("H*").first.upcase.should == "B100AB6429"
     end
 
-
   end
 
   describe "EncryptedPdfObject" do

--- a/spec/soft_mask_spec.rb
+++ b/spec/soft_mask_spec.rb
@@ -21,7 +21,6 @@ module SoftMaskHelper
 end
 
 describe "Document with soft masks" do
-
   include SoftMaskHelper
 
   it "should have PDF version at least 1.4" do

--- a/spec/span_spec.rb
+++ b/spec/span_spec.rb
@@ -3,7 +3,6 @@
 require File.join(File.expand_path(File.dirname(__FILE__)), "spec_helper")
 
 describe "drawing span" do
-
   before do
     Prawn.debug = false
     create_pdf

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -51,4 +51,3 @@ end
 module Prawn::Graphics
   public :map_to_absolute
 end
-

--- a/spec/stroke_styles_spec.rb
+++ b/spec/stroke_styles_spec.rb
@@ -179,7 +179,6 @@ describe "Dashes" do
   end
 
   describe "#dashed?" do
-
     it "an initial document should not be dashed" do
       @pdf.dashed?.should == false
     end
@@ -205,7 +204,5 @@ describe "Dashes" do
       @pdf.restore_graphics_state
       @pdf.dashed?.should == true
     end
-
   end
-
 end

--- a/spec/text_box_spec.rb
+++ b/spec/text_box_spec.rb
@@ -821,7 +821,6 @@ describe "Text::Box with a solid block of Chinese characters" do
   end
 end
 
-
 describe "drawing bounding boxes" do
   before(:each) { create_pdf }
 
@@ -834,7 +833,6 @@ describe "drawing bounding boxes" do
 
   end
 end
-
 
 describe "Text::Box#render with :character_spacing option" do
   it "should draw the character spacing to the document" do

--- a/spec/text_box_spec.rb
+++ b/spec/text_box_spec.rb
@@ -96,7 +96,6 @@ describe "Text::Box" do
 end
 
 describe "Text::Box" do
-
   it "should be able to set leading document-wide" do
     create_pdf
     @pdf.default_leading(7)
@@ -116,7 +115,6 @@ describe "Text::Box" do
   end
   it "should default to document-wide leading if no" +
     "leading option is provided" do
-
   end
 end
 
@@ -524,7 +522,6 @@ describe "Text::Box default height" do
       end
     end
   end
-
 end
 
 describe "Text::Box default at" do
@@ -830,7 +827,6 @@ describe "drawing bounding boxes" do
     @pdf.text_box "Oh hai text box. " * 11, :height => @pdf.font.height * 10
 
     @pdf.bounds.should == margin_box
-
   end
 end
 

--- a/spec/text_spec.rb
+++ b/spec/text_spec.rb
@@ -351,7 +351,6 @@ describe "#text" do
       text.strings[4].should == ("hello " * 21).strip
     end
 
-
     it "should indent from right side when using :rtl direction" do
       para1 = "The rain in spain falls mainly on the plains " * 3
       para2 = "The rain in spain falls mainly on the plains " * 3
@@ -523,7 +522,6 @@ describe "#text" do
       end
     end
   end
-
 
   def add_unicode_fonts(pdf)
     dejavu = "#{::Prawn::BASEDIR}/data/fonts/DejaVuSans.ttf"

--- a/spec/text_spec.rb
+++ b/spec/text_spec.rb
@@ -551,5 +551,4 @@ describe "#text" do
       text.strings[0].should == "hello"
     end
   end
-
 end

--- a/spec/view_spec.rb
+++ b/spec/view_spec.rb
@@ -40,4 +40,3 @@ describe "Prawn::View" do
     view_object.save_as("foo.pdf")
   end
 end
-


### PR DESCRIPTION
This PR enforces various styles regarding empty lines including
- No consecutive empty lines
- No blank lines at the end of a file
- Requires a blank line between method definitions
- Requires a blank line around access modifiers like `private`
- No blank lines just inside class body definitions
- No blank lines just inside block bodies
- No blank lines just inside module bodies.
