### PR TITLE
Comment cleanup

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -182,8 +182,6 @@ ClassVars:
   Enabled: false
 ParameterLists:
   Enabled: false
-BlockComments:
-  Enabled: false
 MultilineOperationIndentation:
   Enabled: false
 AbcSize:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,15 @@ Encoding:
     - lib/prawn/images.rb
     - spec/png_spec.rb
 
+# These cops need to remain disabled for valid reasons on this code base
+
+# We need to reference non-ascii characters when testing and explaining
+# behavior related to win-1252, UTF-8 and UTF-16 encodings for example.
+AsciiComments:
+  Enabled: false
+
+# This cops are candidates for enabling and doing the related cleanup and/or
+# refactoring
 Void:
   Enabled: false
 StringLiterals:
@@ -98,8 +107,6 @@ AssignmentInCondition:
 ClassAndModuleChildren:
   Enabled: false
 NumericLiterals:
-  Enabled: false
-AsciiComments:
   Enabled: false
 SignalException:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -61,8 +61,6 @@ NilComparison:
   Enabled: false
 Semicolon:
   Enabled: false
-LeadingCommentSpace:
-  Enabled: false
 Documentation:
   Enabled: false
 AlignArray:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -186,8 +186,6 @@ BlockComments:
   Enabled: false
 MultilineOperationIndentation:
   Enabled: false
-SpaceBeforeComment:
-  Enabled: false
 AbcSize:
   Enabled: false
 PerceivedComplexity:

--- a/lib/prawn/document.rb
+++ b/lib/prawn/document.rb
@@ -250,8 +250,10 @@ module Prawn
                       :margins => last_page_margins}
       if last_page
         new_graphic_state = last_page.graphic_state.dup  if last_page.graphic_state
-        #erase the color space so that it gets reset on new page for fussy pdf-readers
+
+        # erase the color space so that it gets reset on new page for fussy pdf-readers
         new_graphic_state.color_space = {} if new_graphic_state
+
         page_options.merge!(:graphic_state => new_graphic_state)
       end
 

--- a/lib/prawn/measurements.rb
+++ b/lib/prawn/measurements.rb
@@ -7,7 +7,6 @@ module Prawn
   # @group Stable API
 
   module Measurements
-    # ============================================================================
     #metric conversions
     def cm2mm(cm)
       return cm*10
@@ -21,10 +20,8 @@ module Prawn
       return m*1000
     end
 
-    # ============================================================================
     # imperial conversions
     # from http://en.wikipedia.org/wiki/Imperial_units
-
     def ft2in(ft)
       return ft * 12
     end
@@ -33,9 +30,7 @@ module Prawn
       return yd*36
     end
 
-    # ============================================================================
     # PostscriptPoint-converisons
-
     def pt2pt(pt)
       return pt
     end

--- a/lib/prawn/measurements.rb
+++ b/lib/prawn/measurements.rb
@@ -64,7 +64,7 @@ module Prawn
     end
 
     def pt2mm(pt)
-      return pt * 1 / mm2pt(1)# (25.4 / 72)
+      return pt * 1 / mm2pt(1) # (25.4 / 72)
     end
   end
 end

--- a/lib/prawn/measurements.rb
+++ b/lib/prawn/measurements.rb
@@ -7,7 +7,7 @@ module Prawn
   # @group Stable API
 
   module Measurements
-    #metric conversions
+    # metric conversions
     def cm2mm(cm)
       return cm*10
     end

--- a/spec/font_spec.rb
+++ b/spec/font_spec.rb
@@ -267,7 +267,7 @@ describe "AFM fonts" do
   end
 
   it "should calculate string width taking into account accented characters" do
-    input = win1252_string("\xE9")# é in win-1252
+    input = win1252_string("\xE9") # é in win-1252
     @times.compute_width_of(input, :size => 12).should == @times.compute_width_of("e", :size => 12)
   end
 

--- a/spec/graphics_spec.rb
+++ b/spec/graphics_spec.rb
@@ -238,15 +238,9 @@ describe "When setting colors" do
 
   it "should reset the colors on each new page if they have been defined" do
     @pdf.fill_color "ccff00"
-    #colors = PDF::Inspector::Graphics::Color.analyze(@pdf.render)
 
-    # colors.fill_color_count.should == 2
-    # colors.stroke_color_count.should == 1
     @pdf.start_new_page
     @pdf.stroke_color "ff00cc"
-
-    #colors = PDF::Inspector::Graphics::Color.analyze(@pdf.render)
-    # colors.fill_color_count.should == 3
 
     @pdf.start_new_page
     colors = PDF::Inspector::Graphics::Color.analyze(@pdf.render)

--- a/spec/grid_spec.rb
+++ b/spec/grid_spec.rb
@@ -78,7 +78,6 @@ describe "A document's grid" do
 
       # Hardcoded default color as I haven't been able to come up with a stable converter
       # between fill_color without lots code.
-      #colors.fill_color.should   == [0.0,0.0,0.0]
       colors.stroke_color.should == [0.0,0.0,0.0]
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,7 +17,6 @@ require_relative "../lib/prawn"
 Prawn.debug = true
 Prawn::Font::AFM.hide_m17n_warning = true
 
-#require "test/spec"
 require "rspec"
 require "mocha/api"
 require "pdf/reader"


### PR DESCRIPTION
This PR does a few things related to cleaning up comments.

- Removes some Unneeded comments
- Ensures there is a leading space after the comment
- Ensures a space precedes a comment
- Enforces preference not to use block comments