### PR TITLE
Remove redundant braces.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -68,8 +68,6 @@ Documentation:
   Enabled: false
 IndentArray:
   Enabled: false
-BracesAroundHashParameters:
-  Enabled: false
 TrailingComma:
   Enabled: false
 IndentHash:

--- a/lib/prawn/font.rb
+++ b/lib/prawn/font.rb
@@ -169,21 +169,21 @@ module Prawn
     #
     def font_families
       @font_families ||= {}.merge!(
-        { "Courier"     => { :bold        => "Courier-Bold",
-                             :italic      => "Courier-Oblique",
-                             :bold_italic => "Courier-BoldOblique",
-                             :normal      => "Courier" },
+        "Courier"     => { :bold        => "Courier-Bold",
+                           :italic      => "Courier-Oblique",
+                           :bold_italic => "Courier-BoldOblique",
+                           :normal      => "Courier" },
 
-          "Times-Roman" => { :bold         => "Times-Bold",
-                             :italic       => "Times-Italic",
-                             :bold_italic  => "Times-BoldItalic",
-                             :normal       => "Times-Roman" },
+        "Times-Roman" => { :bold         => "Times-Bold",
+                           :italic       => "Times-Italic",
+                           :bold_italic  => "Times-BoldItalic",
+                           :normal       => "Times-Roman" },
 
-          "Helvetica"   => { :bold         => "Helvetica-Bold",
-                             :italic       => "Helvetica-Oblique",
-                             :bold_italic  => "Helvetica-BoldOblique",
-                             :normal       => "Helvetica" }
-        })
+        "Helvetica"   => { :bold         => "Helvetica-Bold",
+                           :italic       => "Helvetica-Oblique",
+                           :bold_italic  => "Helvetica-BoldOblique",
+                           :normal       => "Helvetica" }
+      )
     end
 
     # @group Experimental API

--- a/lib/prawn/graphics/patterns.rb
+++ b/lib/prawn/graphics/patterns.rb
@@ -96,15 +96,15 @@ module Prawn
         process_color color1
         process_color color2
 
-        shader = ref!({
+        shader = ref!(
           :FunctionType => 2,
           :Domain => [0.0, 1.0],
           :C0 => color1,
           :C1 => color2,
           :N => 1.0,
-        })
+        )
 
-        shading = ref!({
+        shading = ref!(
           :ShadingType => args.length == 4 ? 2 : 3, # axial : radial shading
           :ColorSpace => color_space(color1),
           :Coords => args.length == 4 ?
@@ -112,14 +112,14 @@ module Prawn
                         [0, 0, args[1], args[2].first - args[0].first, args[2].last - args[0].last, args[3]],
           :Function => shader,
           :Extend => [true, true],
-        })
+        )
 
-        ref!({
+        ref!(
           :PatternType => 2, # shading pattern
           :Shading => shading,
           :Matrix => [1, 0,
                       0, 1] + map_to_absolute(args[0]),
-        })
+        )
       end
     end
   end

--- a/lib/prawn/soft_mask.rb
+++ b/lib/prawn/soft_mask.rb
@@ -30,30 +30,30 @@ module Prawn
     def soft_mask(&block)
       renderer.min_version(1.4)
 
-      group_attrs = ref!({
+      group_attrs = ref!(
         :Type => :Group,
         :S => :Transparency,
         :CS => :DeviceRGB,
         :I => false,
         :K => false
-      })
+      )
 
-      group = ref!({
+      group = ref!(
         :Type => :XObject,
         :Subtype => :Form,
         :BBox => state.page.dimensions,
         :Group => group_attrs,
-      })
+      )
 
       state.page.stamp_stream(group, &block)
 
-      mask = ref!({
+      mask = ref!(
         :Type => :Mask,
         :S => :Luminosity,
         :G => group
-      })
+      )
 
-      g_state = ref!({
+      g_state = ref!(
         :Type => :ExtGState,
         :SMask => mask,
 
@@ -63,7 +63,7 @@ module Prawn
         :op => false,
         :OPM => 1,
         :SA => true,
-      })
+      )
 
       registry_key = {
         :bbox => state.page.dimensions,

--- a/spec/document_spec.rb
+++ b/spec/document_spec.rb
@@ -566,20 +566,20 @@ describe "The number_pages method" do
 
   it "replaces the '<page>' string with the proper page number" do
     @pdf.start_new_page
-    @pdf.expects(:text_box).with("1, test", { :height => 50 })
-    @pdf.number_pages "<page>, test", {:page_filter => :all}
+    @pdf.expects(:text_box).with("1, test", :height => 50)
+    @pdf.number_pages "<page>, test", :page_filter => :all
   end
 
   it "replaces the '<total>' string with the total page count" do
     @pdf.start_new_page
-    @pdf.expects(:text_box).with("test, 1", { :height => 50 })
-    @pdf.number_pages "test, <total>", {:page_filter => :all}
+    @pdf.expects(:text_box).with("test, 1", :height => 50)
+    @pdf.number_pages "test, <total>", :page_filter => :all
   end
 
   it "must print each page if given the :all page_filter" do
     10.times { @pdf.start_new_page }
     @pdf.expects(:text_box).times(10)
-    @pdf.number_pages "test", {:page_filter => :all}
+    @pdf.number_pages "test", :page_filter => :all
   end
 
   it "must print each page if no :page_filter is specified" do
@@ -591,7 +591,7 @@ describe "The number_pages method" do
   it "must not print the page number if given a nil filter" do
     10.times { @pdf.start_new_page }
     @pdf.expects(:text_box).never
-    @pdf.number_pages "test", {:page_filter => nil}
+    @pdf.number_pages "test", :page_filter => nil
   end
 
   context "start_count_at option" do
@@ -600,8 +600,8 @@ describe "The number_pages method" do
         it "increments the pages" do
           2.times { @pdf.start_new_page }
           options = {:page_filter => :all, :start_count_at => startat}
-          @pdf.expects(:text_box).with("#{startat} 2", { :height => 50 })
-          @pdf.expects(:text_box).with("#{startat + 1} 2", { :height => 50 })
+          @pdf.expects(:text_box).with("#{startat} 2", :height => 50)
+          @pdf.expects(:text_box).with("#{startat + 1} 2", :height => 50)
           @pdf.number_pages "<page> <total>", options
         end
       end
@@ -612,9 +612,9 @@ describe "The number_pages method" do
         it "defaults to start at page 1" do
           3.times { @pdf.start_new_page }
           options = {:page_filter => :all, :start_count_at => val}
-          @pdf.expects(:text_box).with("1 3", { :height => 50 })
-          @pdf.expects(:text_box).with("2 3", { :height => 50 })
-          @pdf.expects(:text_box).with("3 3", { :height => 50 })
+          @pdf.expects(:text_box).with("1 3", :height => 50)
+          @pdf.expects(:text_box).with("2 3", :height => 50)
+          @pdf.expects(:text_box).with("3 3", :height => 50)
           @pdf.number_pages "<page> <total>", options
         end
       end
@@ -624,8 +624,8 @@ describe "The number_pages method" do
   context "total_pages option" do
     it "allows the total pages count to be overridden" do
       2.times { @pdf.start_new_page }
-      @pdf.expects(:text_box).with("1 10", { :height => 50 })
-      @pdf.expects(:text_box).with("2 10", { :height => 50 })
+      @pdf.expects(:text_box).with("1 10", :height => 50)
+      @pdf.expects(:text_box).with("2 10", :height => 50)
       @pdf.number_pages "<page> <total>", :page_filter => :all, :total_pages => 10
     end
   end
@@ -634,9 +634,9 @@ describe "The number_pages method" do
     context "such as :odd" do
       it "increments the pages" do
         3.times { @pdf.start_new_page }
-        @pdf.expects(:text_box).with("1 3", { :height => 50 })
-        @pdf.expects(:text_box).with("3 3", { :height => 50 })
-        @pdf.expects(:text_box).with("2 3", { :height => 50 }).never
+        @pdf.expects(:text_box).with("1 3", :height => 50)
+        @pdf.expects(:text_box).with("3 3", :height => 50)
+        @pdf.expects(:text_box).with("2 3", :height => 50).never
         @pdf.number_pages "<page> <total>", :page_filter => :odd
       end
     end
@@ -653,10 +653,10 @@ describe "The number_pages method" do
     context "such as :odd and 7" do
       it "increments the pages" do
         3.times { @pdf.start_new_page }
-        @pdf.expects(:text_box).with("1 3", { :height => 50 }).never
-        @pdf.expects(:text_box).with("5 3", { :height => 50 }) # page 1
-        @pdf.expects(:text_box).with("6 3", { :height => 50 }).never # page 2
-        @pdf.expects(:text_box).with("7 3", { :height => 50 }) # page 3
+        @pdf.expects(:text_box).with("1 3", :height => 50).never
+        @pdf.expects(:text_box).with("5 3", :height => 50) # page 1
+        @pdf.expects(:text_box).with("6 3", :height => 50).never # page 2
+        @pdf.expects(:text_box).with("7 3", :height => 50) # page 3
         @pdf.number_pages "<page> <total>", :page_filter => :odd, :start_count_at => 5
       end
     end
@@ -664,12 +664,12 @@ describe "The number_pages method" do
       it "increments the pages" do
         6.times { @pdf.start_new_page }
         options = {:page_filter => lambda {|p| p != 2 && p != 5}, :start_count_at => 4}
-        @pdf.expects(:text_box).with("4 6", { :height => 50 }) # page 1
-        @pdf.expects(:text_box).with("5 6", { :height => 50 }).never # page 2
-        @pdf.expects(:text_box).with("6 6", { :height => 50 }) # page 3
-        @pdf.expects(:text_box).with("7 6", { :height => 50 }) # page 4
-        @pdf.expects(:text_box).with("8 6", { :height => 50 }).never # page 5
-        @pdf.expects(:text_box).with("9 6", { :height => 50 }) # page 6
+        @pdf.expects(:text_box).with("4 6", :height => 50) # page 1
+        @pdf.expects(:text_box).with("5 6", :height => 50).never # page 2
+        @pdf.expects(:text_box).with("6 6", :height => 50) # page 3
+        @pdf.expects(:text_box).with("7 6", :height => 50) # page 4
+        @pdf.expects(:text_box).with("8 6", :height => 50).never # page 5
+        @pdf.expects(:text_box).with("9 6", :height => 50) # page 6
         @pdf.number_pages "<page> <total>", options
       end
     end
@@ -681,17 +681,17 @@ describe "The number_pages method" do
     end
 
     it "with 10 height" do
-      @pdf.expects(:text_box).with("1 1", { :height => 10 })
+      @pdf.expects(:text_box).with("1 1", :height => 10)
       @pdf.number_pages "<page> <total>", :height => 10
     end
 
     it "with nil height" do
-      @pdf.expects(:text_box).with("1 1", { :height => nil })
+      @pdf.expects(:text_box).with("1 1", :height => nil)
       @pdf.number_pages "<page> <total>", :height => nil
     end
 
     it "with no height" do
-      @pdf.expects(:text_box).with("1 1", { :height => 50 })
+      @pdf.expects(:text_box).with("1 1", :height => 50)
       @pdf.number_pages "<page> <total>"
     end
   end

--- a/spec/span_spec.rb
+++ b/spec/span_spec.rb
@@ -14,7 +14,7 @@ describe "drawing span" do
 
   it "should only accept :position as option in debug mode" do
     Prawn.debug = true
-    lambda { @pdf.span(350, {:x => 3}) {} }.should raise_error(Prawn::Errors::UnknownOption)
+    lambda { @pdf.span(350, :x => 3) {} }.should raise_error(Prawn::Errors::UnknownOption)
   end
 
   it "should have raise an error if :position is invalid" do


### PR DESCRIPTION
This PR removes redundant braces around hash parameters. This sets is up for some easier use of other alignment style guidelines and makes usage of named parameters more consistent if and when we use those. It 