### PR TITLE
Hash cleanup

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -70,8 +70,6 @@ IndentArray:
   Enabled: false
 TrailingComma:
   Enabled: false
-IndentHash:
-  Enabled: false
 RegexpLiteral:
   Enabled: false
 MethodLength:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -150,8 +150,6 @@ Alias:
   Enabled: false
 RedundantReturn:
   Enabled: false
-DeprecatedHashMethods:
-  Enabled: false
 WhileUntilModifier:
   Enabled: false
 StringConversionInInterpolation:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -48,8 +48,6 @@ SpaceInsideBlockBraces:
   Enabled: false
 CollectionMethods:
   Enabled: false
-SpaceInsideHashLiteralBraces:
-  Enabled: false
 DotPosition:
   Enabled: false
 SingleLineBlockParams:

--- a/bench/table_bench.rb
+++ b/bench/table_bench.rb
@@ -28,7 +28,7 @@ end
 
 # Slowest case: styled table, which is very squeezed horizontally,
 #   so text has to be wrapped
-benchmark_table_generation(26,50,10, :row_colors => ['FFFFFF','F0F0FF'], :header => true, :cell_style => {:inline_format => true})
+benchmark_table_generation(26,50,10, :row_colors => ['FFFFFF','F0F0FF'], :header => true, :cell_style => { :inline_format => true })
 
 # Try building and rendering tables of different sizes
 benchmark_table_generation(10,400,5)
@@ -36,5 +36,5 @@ benchmark_table_generation(10,200,5)
 benchmark_table_generation(10,100,5)
 
 # Try different optional arguments to Prawn::Document#table
-benchmark_table_generation(10,450,5, :cell_style => {:inline_format => true})
-benchmark_table_generation(10,450,5, :row_colors => ['FFFFFF','F0F0FF'], :header => true, :cell_style => {:inline_format => true})
+benchmark_table_generation(10,450,5, :cell_style => { :inline_format => true })
+benchmark_table_generation(10,450,5, :row_colors => ['FFFFFF','F0F0FF'], :header => true, :cell_style => { :inline_format => true })

--- a/lib/prawn/document.rb
+++ b/lib/prawn/document.rb
@@ -522,7 +522,7 @@ module Prawn
       opts = options.dup
       start_count_at = opts.delete(:start_count_at).to_i
 
-      if opts.has_key?(:page_filter)
+      if opts.key?(:page_filter)
         page_filter = opts.delete(:page_filter)
       else
         page_filter = :all
@@ -531,7 +531,7 @@ module Prawn
       total_pages = opts.delete(:total_pages)
       txtcolor = opts.delete(:color)
       # An explicit height so that we can draw page numbers in the margins
-      opts[:height] = 50 unless opts.has_key?(:height)
+      opts[:height] = 50 unless opts.key?(:height)
 
       start_count = false
       pseudopage = 0

--- a/lib/prawn/document.rb
+++ b/lib/prawn/document.rb
@@ -245,9 +245,11 @@ module Prawn
         last_page_margins = last_page.margins.dup
       end
 
-      page_options = {:size => options[:size] || last_page_size,
-                      :layout  => options[:layout] || last_page_layout,
-                      :margins => last_page_margins}
+      page_options = {
+        :size    => options[:size]   || last_page_size,
+        :layout  => options[:layout] || last_page_layout,
+        :margins => last_page_margins
+      }
       if last_page
         new_graphic_state = last_page.graphic_state.dup  if last_page.graphic_state
 

--- a/lib/prawn/font/afm.rb
+++ b/lib/prawn/font/afm.rb
@@ -143,9 +143,11 @@ module Prawn
       private
 
       def register(subset)
-        font_dict = {:Type     => :Font,
-                     :Subtype  => :Type1,
-                     :BaseFont => name.to_sym}
+        font_dict = {
+          :Type     => :Font,
+          :Subtype  => :Type1,
+          :BaseFont => name.to_sym
+        }
 
         # Symbolic AFM fonts (Symbol, ZapfDingbats) have their own encodings
         font_dict.merge!(:Encoding => :WinAnsiEncoding) unless symbolic?
@@ -165,7 +167,7 @@ module Prawn
       end
 
       def parse_afm(file_name)
-        data    = {:glyph_widths => {}, :bounding_boxes => {}, :kern_pairs => {}, :attributes => {}}
+        data    = { :glyph_widths => {}, :bounding_boxes => {}, :kern_pairs => {}, :attributes => {} }
         section = []
 
         File.foreach(file_name) do |line|

--- a/lib/prawn/grid.rb
+++ b/lib/prawn/grid.rb
@@ -92,7 +92,7 @@ module Prawn
       end
 
       def set_gutter(options)
-        if options.has_key?(:gutter)
+        if options.key?(:gutter)
           @gutter = options[:gutter].to_f
           @row_gutter, @column_gutter = @gutter, @gutter
         else

--- a/lib/prawn/images.rb
+++ b/lib/prawn/images.rb
@@ -91,7 +91,7 @@ module Prawn
 
         # Add the image to the PDF and register it in case we see it again.
         image_obj = info.build_pdf_object(self)
-        image_registry[image_sha1] = {:obj => image_obj, :info => info}
+        image_registry[image_sha1] = { :obj => image_obj, :info => info }
       end
 
       [image_obj, info]

--- a/manual/cover.rb
+++ b/manual/cover.rb
@@ -13,14 +13,14 @@ Prawn::ManualBuilder::Example.generate(filename) do
         :scale => 0.9,
         :at => [10, cursor]
 
-  formatted_text_box([ {:text => "Prawn\n",
-                        :styles => [:bold],
-                        :size => 100}
+  formatted_text_box([ { :text => "Prawn\n",
+                         :styles => [:bold],
+                         :size => 100 }
                      ], :at => [170, cursor - 50])
 
-  formatted_text_box([ {:text => "by example",
-                        :font => 'Courier',
-                        :size => 60}
+  formatted_text_box([ { :text => "by example",
+                         :font => 'Courier',
+                         :size => 60 }
                      ], :at => [170, cursor - 160])
 
   if Dir.exist?("#{Prawn::BASEDIR}/.git")
@@ -30,9 +30,9 @@ Prawn::ManualBuilder::Example.generate(filename) do
     git_commit = ""
   end
 
-  formatted_text_box([  {:text => "Last Update: #{Time.now.strftime("%Y-%m-%d")}\n" +
-                                  "Prawn Version: #{Prawn::VERSION}\n" +
-                                  git_commit,
-                         :size => 12}
-                    ],   :at => [390, cursor - 620])
+  formatted_text_box([  { :text => "Last Update: #{Time.now.strftime("%Y-%m-%d")}\n" +
+                                   "Prawn Version: #{Prawn::VERSION}\n" +
+                                   git_commit,
+                          :size => 12 }
+                    ], :at => [390, cursor - 620])
 end

--- a/manual/text/registering_families.rb
+++ b/manual/text/registering_families.rb
@@ -14,9 +14,11 @@ require File.expand_path(File.join(File.dirname(__FILE__),
 filename = File.basename(__FILE__).gsub('.rb', '.pdf')
 Prawn::ManualBuilder::Example.generate(filename) do
   # Registering a single TTF font
-  font_families.update("DejaVu Sans" => {
-    :normal => "#{Prawn::DATADIR}/fonts/DejaVuSans.ttf"
-  })
+  font_families.update(
+    "DejaVu Sans" => {
+      :normal => "#{Prawn::DATADIR}/fonts/DejaVuSans.ttf"
+    }
+  )
 
   font("DejaVu Sans") do
     text "Using the DejaVu Sans font providing only its name to the font method"
@@ -25,12 +27,14 @@ Prawn::ManualBuilder::Example.generate(filename) do
 
   # Registering a DFONT package
   font_path = "#{Prawn::DATADIR}/fonts/Panic+Sans.dfont"
-  font_families.update("Panic Sans" => {
-    :normal      => { :file => font_path, :font => "PanicSans" },
-    :italic      => { :file => font_path, :font => "PanicSans-Italic" },
-    :bold        => { :file => font_path, :font => "PanicSans-Bold" },
-    :bold_italic => { :file => font_path, :font => "PanicSans-BoldItalic" }
-  })
+  font_families.update(
+    "Panic Sans" => {
+      :normal      => { :file => font_path, :font => "PanicSans" },
+      :italic      => { :file => font_path, :font => "PanicSans-Italic" },
+      :bold        => { :file => font_path, :font => "PanicSans-Bold" },
+      :bold_italic => { :file => font_path, :font => "PanicSans-BoldItalic" }
+    }
+  )
 
   font "Panic Sans"
   text "Also using Panic Sans by providing only its name"

--- a/spec/document_spec.rb
+++ b/spec/document_spec.rb
@@ -5,9 +5,9 @@ require File.join(File.expand_path(File.dirname(__FILE__)), "spec_helper")
 
 describe "Prawn::Document.new" do
   it "should not modify its argument" do
-    options = {:page_layout => :landscape}
+    options = { :page_layout => :landscape }
     Prawn::Document.new(options)
-    options.should == {:page_layout => :landscape}
+    options.should == { :page_layout => :landscape }
   end
 end
 
@@ -261,7 +261,7 @@ end
 
 describe "Document metadata" do
   it "should output strings as UTF-16 with a byte order mark" do
-    pdf = Prawn::Document.new(:info => {:Author => "Lóránt"})
+    pdf = Prawn::Document.new(:info => { :Author => "Lóránt" })
     pdf.state.store.info.object.should =~
       # UTF-16:     BOM L   ó   r   á   n   t
       %r{/Author\s*<feff004c00f3007200e1006e0074>}i
@@ -599,7 +599,7 @@ describe "The number_pages method" do
       context "equal to #{startat}" do
         it "increments the pages" do
           2.times { @pdf.start_new_page }
-          options = {:page_filter => :all, :start_count_at => startat}
+          options = { :page_filter => :all, :start_count_at => startat }
           @pdf.expects(:text_box).with("#{startat} 2", :height => 50)
           @pdf.expects(:text_box).with("#{startat + 1} 2", :height => 50)
           @pdf.number_pages "<page> <total>", options
@@ -611,7 +611,7 @@ describe "The number_pages method" do
       context "equal to #{val}" do
         it "defaults to start at page 1" do
           3.times { @pdf.start_new_page }
-          options = {:page_filter => :all, :start_count_at => val}
+          options = { :page_filter => :all, :start_count_at => val }
           @pdf.expects(:text_box).with("1 3", :height => 50)
           @pdf.expects(:text_box).with("2 3", :height => 50)
           @pdf.expects(:text_box).with("3 3", :height => 50)
@@ -663,7 +663,7 @@ describe "The number_pages method" do
     context "some crazy proc and 2" do
       it "increments the pages" do
         6.times { @pdf.start_new_page }
-        options = {:page_filter => lambda {|p| p != 2 && p != 5}, :start_count_at => 4}
+        options = { :page_filter => lambda {|p| p != 2 && p != 5}, :start_count_at => 4 }
         @pdf.expects(:text_box).with("4 6", :height => 50) # page 1
         @pdf.expects(:text_box).with("5 6", :height => 50).never # page 2
         @pdf.expects(:text_box).with("6 6", :height => 50) # page 3

--- a/spec/formatted_text_arranger_spec.rb
+++ b/spec/formatted_text_arranger_spec.rb
@@ -85,13 +85,13 @@ describe "Core::Text::Formatted::Arranger#next_string" do
     while string = arranger.next_string
       case counter
       when 0
-        arranger.current_format_state.should == { }
+        arranger.current_format_state.should == {}
       when 1
         arranger.current_format_state.should == { :styles => [:bold] }
       when 2
         arranger.current_format_state.should == { :styles => [:bold, :italic] }
       when 3
-        arranger.current_format_state.should == { }
+        arranger.current_format_state.should == {}
       end
       counter += 1
     end
@@ -298,7 +298,7 @@ describe "Core::Text::Formatted::Arranger#line_width with character_spacing > 0"
 
     array = [{ :text => "hello " },
              { :text => "world", :styles => [:bold],
-               :character_spacing => 7}]
+               :character_spacing => 7 }]
     arranger.format_array = array
     while string = arranger.next_string
     end

--- a/spec/formatted_text_box_spec.rb
+++ b/spec/formatted_text_box_spec.rb
@@ -9,10 +9,10 @@ describe "Text::Formatted::Box wrapping" do
 
   it "should not wrap between two fragments" do
     texts = [
-      {:text => "Hello "},
-      {:text => "World"},
-      {:text => "2", :styles => [:superscript]},
-      ]
+      { :text => "Hello " },
+      { :text => "World" },
+      { :text => "2", :styles => [:superscript] },
+    ]
     text_box = Prawn::Text::Formatted::Box.new(texts, :document => @pdf, :width => @pdf.width_of("Hello World"))
     text_box.render
     text_box.text.should == "Hello\nWorld2"
@@ -27,7 +27,7 @@ describe "Text::Formatted::Box wrapping" do
 
     texts = [
       { :text => "Hello " },
-      { :text => "再见", :font => "Kai"},
+      { :text => "再见", :font => "Kai" },
       { :text => "World" }
     ]
     text_box = Prawn::Text::Formatted::Box.new(texts, :document => @pdf, :width => @pdf.width_of("Hello World"))
@@ -37,19 +37,19 @@ describe "Text::Formatted::Box wrapping" do
 
   it "should wrap between two fragments when the preceding fragment ends with white space" do
     texts = [
-      {:text => "Hello "},
-      {:text => "World "},
-      {:text => "2", :styles => [:superscript]},
-      ]
+      { :text => "Hello " },
+      { :text => "World " },
+      { :text => "2", :styles => [:superscript] },
+    ]
     text_box = Prawn::Text::Formatted::Box.new(texts, :document => @pdf, :width => @pdf.width_of("Hello World"))
     text_box.render
     text_box.text.should == "Hello World\n2"
 
     texts = [
-      {:text => "Hello "},
-      {:text => "World\n"},
-      {:text => "2", :styles => [:superscript]},
-      ]
+      { :text => "Hello " },
+      { :text => "World\n" },
+      { :text => "2", :styles => [:superscript] },
+    ]
     text_box = Prawn::Text::Formatted::Box.new(texts, :document => @pdf, :width => @pdf.width_of("Hello World"))
     text_box.render
     text_box.text.should == "Hello World\n2"
@@ -57,19 +57,19 @@ describe "Text::Formatted::Box wrapping" do
 
   it "should wrap between two fragments when the final fragment begins with white space" do
     texts = [
-      {:text => "Hello "},
-      {:text => "World"},
-      {:text => " 2", :styles => [:superscript]},
-      ]
+      { :text => "Hello " },
+      { :text => "World" },
+      { :text => " 2", :styles => [:superscript] },
+    ]
     text_box = Prawn::Text::Formatted::Box.new(texts, :document => @pdf, :width => @pdf.width_of("Hello World"))
     text_box.render
     text_box.text.should == "Hello World\n2"
 
     texts = [
-      {:text => "Hello "},
-      {:text => "World"},
-      {:text => "\n2", :styles => [:superscript]},
-      ]
+      { :text => "Hello " },
+      { :text => "World" },
+      { :text => "\n2", :styles => [:superscript] },
+    ]
     text_box = Prawn::Text::Formatted::Box.new(texts, :document => @pdf, :width => @pdf.width_of("Hello World"))
     text_box.render
     text_box.text.should == "Hello World\n2"
@@ -285,7 +285,7 @@ end
 describe "Text::Formatted::Box#render" do
   it "should handle newlines" do
     create_pdf
-    array = [{ :text => "hello\nworld"}]
+    array = [{ :text => "hello\nworld" }]
     options = { :document => @pdf }
     text_box = Prawn::Text::Formatted::Box.new(array, options)
     text_box.render
@@ -293,7 +293,7 @@ describe "Text::Formatted::Box#render" do
   end
   it "should omit spaces from the beginning of the line" do
     create_pdf
-    array = [{ :text => " hello\n world"}]
+    array = [{ :text => " hello\n world" }]
     options = { :document => @pdf }
     text_box = Prawn::Text::Formatted::Box.new(array, options)
     text_box.render
@@ -301,16 +301,16 @@ describe "Text::Formatted::Box#render" do
   end
   it "should be okay printing a line of whitespace" do
     create_pdf
-    array = [{ :text => "hello\n    \nworld"}]
+    array = [{ :text => "hello\n    \nworld" }]
     options = { :document => @pdf }
     text_box = Prawn::Text::Formatted::Box.new(array, options)
     text_box.render
     text_box.text.should == "hello\n\nworld"
 
-    array = [{ :text => "hello" + " " * 500},
+    array = [{ :text => "hello" + " " * 500 },
              { :text => " " * 500 },
-             { :text => " " * 500 + "\n"},
-             { :text => "world"}]
+             { :text => " " * 500 + "\n" },
+             { :text => "world" }]
     options = { :document => @pdf }
     text_box = Prawn::Text::Formatted::Box.new(array, options)
     text_box.render

--- a/spec/formatted_text_box_spec.rb
+++ b/spec/formatted_text_box_spec.rb
@@ -630,12 +630,12 @@ describe "Text::Formatted::Box#render with :valign => :center" do
     y = 450
     array = [{ :text => 'Vertical Align' }]
     options = {
-     :document => @pdf,
-     :valign => :center,
-     :at => [0,y],
-     :width => 100,
-     :height => box_height,
-     :size => 16
+      :document => @pdf,
+      :valign => :center,
+      :at => [0,y],
+      :width => 100,
+      :height => box_height,
+      :size => 16
     }
     text_box = Prawn::Text::Formatted::Box.new(array, options)
     text_box.render
@@ -653,12 +653,12 @@ describe "Text::Formatted::Box#render with :valign => :bottom" do
     y = 450
     array = [{ :text => 'Vertical Align' }]
     options = {
-     :document => @pdf,
-     :valign => :bottom,
-     :at => [0,y],
-     :width => 100,
-     :height => box_height,
-     :size => 16
+      :document => @pdf,
+      :valign => :bottom,
+      :at => [0,y],
+      :width => 100,
+      :height => box_height,
+      :size => 16
     }
     text_box = Prawn::Text::Formatted::Box.new(array, options)
     text_box.render

--- a/spec/formatted_text_fragment_spec.rb
+++ b/spec/formatted_text_fragment_spec.rb
@@ -5,7 +5,7 @@ require File.join(File.expand_path(File.dirname(__FILE__)), "spec_helper")
 describe "Text::Formatted::Fragment#space_count" do
   it "should return the number of spaces in the fragment" do
     create_pdf
-    format_state = { }
+    format_state = {}
     fragment = Prawn::Text::Formatted::Fragment.new("hello world ",
                                                     format_state,
                                                     @pdf)
@@ -38,7 +38,7 @@ end
 describe "Text::Formatted::Fragment#text" do
   it "should return the fragment text" do
     create_pdf
-    format_state = { }
+    format_state = {}
     fragment = Prawn::Text::Formatted::Fragment.new("hello world ",
                                                     format_state,
                                                     @pdf)
@@ -278,7 +278,7 @@ describe "Text::Formatted::Fragment default_direction=" do
   it "should set the direction if there is no fragment level direction " +
      "specification" do
     create_pdf
-    format_state = { }
+    format_state = {}
     fragment = Prawn::Text::Formatted::Fragment.new("hello world",
                                                     format_state,
                                                     @pdf)

--- a/spec/graphics_spec.rb
+++ b/spec/graphics_spec.rb
@@ -399,7 +399,7 @@ describe "When using graphics states" do
     @pdf.stroke_color 0, 0, 0, 0
     @pdf.restore_graphics_state
     @pdf.stroke_color 0, 0, 100, 0
-    @pdf.graphic_state.color_space.should == {:stroke => :DeviceCMYK}
+    @pdf.graphic_state.color_space.should == { :stroke => :DeviceCMYK }
     colors = PDF::Inspector::Graphics::Color.analyze(@pdf.render)
     colors.color_space.should == :DeviceCMYK
     colors.stroke_color_space_count[:DeviceCMYK].should == 2
@@ -441,8 +441,8 @@ describe "When using graphics states" do
     @pdf.graphic_state.join_style.should == :miter
     @pdf.graphic_state.fill_color.should == [0, 0, 100, 0]
     @pdf.graphic_state.cap_style.should == :round
-    @pdf.graphic_state.color_space.should == {:fill => :DeviceCMYK, :stroke => :DeviceRGB}
-    @pdf.graphic_state.dash.should == {:space => 5, :phase => 0, :dash => 5}
+    @pdf.graphic_state.color_space.should == { :fill => :DeviceCMYK, :stroke => :DeviceRGB }
+    @pdf.graphic_state.dash.should == { :space => 5, :phase => 0, :dash => 5 }
     @pdf.graphic_state.line_width.should == 1
   end
 

--- a/spec/inline_formatted_text_parser_spec.rb
+++ b/spec/inline_formatted_text_parser_spec.rb
@@ -549,10 +549,10 @@ describe "Text::Formatted::Parser#array_paragraphs" do
              { :text => "how" },
              { :text => "are" },
              { :text => "you" }]
-    target = [[{ :text => "\n"}],
+    target = [[{ :text => "\n" }],
               [{ :text => "hello" }],
               [{ :text => "world" }],
-              [{ :text => "\n"}],
+              [{ :text => "\n" }],
               [{ :text => "how" },
                { :text => "are" },
                { :text => "you" }]]

--- a/spec/line_wrap_spec.rb
+++ b/spec/line_wrap_spec.rb
@@ -133,8 +133,8 @@ describe "Core::Text::Formatted::LineWrap#wrap_line" do
     string1 = @pdf.font.normalize_encoding(hyphen_string * 5)
     string2 = @pdf.font.normalize_encoding("Hyphenations " * 3 + hyphen_string)
 
-    array1 = [{text: string1}]
-    array2 = [{text: string2}]
+    array1 = [{ text: string1 }]
+    array2 = [{ text: string2 }]
 
     @arranger.format_array = array1
 

--- a/spec/security_spec.rb
+++ b/spec/security_spec.rb
@@ -117,7 +117,7 @@ describe "Document encryption" do
     end
 
     it "should properly handle compound types" do
-      PDF::Core::EncryptedPdfObject({:Bar => "foo"}, "12345", 123, 0).should ==
+      PDF::Core::EncryptedPdfObject({ :Bar => "foo" }, "12345", 123, 0).should ==
         "<< /Bar <4ad6e3>\n>>"
       PDF::Core::EncryptedPdfObject(["foo", "bar"], "12345", 123, 0).should ==
         "[<4ad6e3> <4ed8fe>]"

--- a/spec/text_at_spec.rb
+++ b/spec/text_at_spec.rb
@@ -6,7 +6,7 @@ describe "#draw_text" do
   before(:each) { create_pdf }
 
   it "should raise_error ArgumentError if :at option omitted" do
-    lambda { @pdf.draw_text("hai", { }) }.should raise_error(ArgumentError)
+    lambda { @pdf.draw_text("hai", {}) }.should raise_error(ArgumentError)
   end
 
   it "should raise_error ArgumentError if :align option included" do

--- a/spec/text_spec.rb
+++ b/spec/text_spec.rb
@@ -524,12 +524,14 @@ describe "#text" do
 
   def add_unicode_fonts(pdf)
     dejavu = "#{::Prawn::BASEDIR}/data/fonts/DejaVuSans.ttf"
-    pdf.font_families.update("dejavu" => {
-      :normal      => dejavu,
-      :italic      => dejavu,
-      :bold        => dejavu,
-      :bold_italic => dejavu
-    })
+    pdf.font_families.update(
+      "dejavu" => {
+        :normal      => dejavu,
+        :italic      => dejavu,
+        :bold        => dejavu,
+        :bold_italic => dejavu
+      }
+    )
     pdf.fallback_fonts = ["dejavu"]
   end
 


### PR DESCRIPTION
This PR enforces a few styles related to hashes

- It enforces correct key indentation
- Removes use of deprecated Hash#has_key? method
- Enforces correct spacing inside hash braces.