### PR TITLE
Prefer {} over Hash.new

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,8 +16,6 @@ AsciiComments:
 
 # This cops are candidates for enabling and doing the related cleanup and/or
 # refactoring
-Style/EmptyLiteral:
-  Enabled: false
 Style/ClosingParenthesisIndentation:
   Enabled: false
 Style/FirstParameterIndentation:

--- a/spec/font_spec.rb
+++ b/spec/font_spec.rb
@@ -22,7 +22,7 @@ describe "Font objects" do
     font1 = Prawn::Document.new.font
     font2 = Prawn::Document.new.font
 
-    hash = Hash.new
+    hash = {}
 
     hash[ font1 ] = "Original"
     hash[ font2 ] = "Overwritten"


### PR DESCRIPTION
This PR enforces a preference for {} over Hash.new. It also enforces [] over Array.new and "" over String.new.