### PR TITLE
More cleanups

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,8 +23,6 @@ Style/ClosingParenthesisIndentation:
 
 # This cops are candidates for enabling and doing the related cleanup and/or
 # refactoring
-Style/SymbolLiteral:
-  Enabled: false
 Style/BlockDelimiters:
   Enabled: false
   EnforcedStyle: semantic

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -142,8 +142,6 @@ AccessorMethodName:
   Enabled: false
 SpaceAfterControlKeyword:
   Enabled: false
-UselessAccessModifier:
-  Enabled: false
 PredicateName:
   Enabled: false
 ConstantName:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -148,8 +148,6 @@ PredicateName:
   Enabled: false
 ConstantName:
   Enabled: false
-UnlessElse:
-  Enabled: false
 MethodName:
   Enabled: false
 Alias:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,6 +23,8 @@ Style/ClosingParenthesisIndentation:
 
 # This cops are candidates for enabling and doing the related cleanup and/or
 # refactoring
+Style/SymbolLiteral:
+  Enabled: false
 Style/BlockDelimiters:
   Enabled: false
   EnforcedStyle: semantic
@@ -135,8 +137,6 @@ CyclomaticComplexity:
 CaseIndentation:
   Enabled: false
 UnreachableCode:
-  Enabled: false
-MultilineTernaryOperator:
   Enabled: false
 AccessorMethodName:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,10 +23,6 @@ Style/ClosingParenthesisIndentation:
 
 # This cops are candidates for enabling and doing the related cleanup and/or
 # refactoring
-Style/EmptyLiteral:
-  Enabled: false
-Style/FirstParameterIndentation:
-  Enabled: false
 Style/SymbolLiteral:
   Enabled: false
 Style/BlockDelimiters:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -162,8 +162,6 @@ RedundantBegin:
   Enabled: false
 PerlBackrefs:
   Enabled: false
-CharacterLiteral:
-  Enabled: false
 ClassVars:
   Enabled: false
 ParameterLists:

--- a/lib/prawn/font/afm.rb
+++ b/lib/prawn/font/afm.rb
@@ -54,7 +54,7 @@ module Prawn
 
         file_name = @name.dup
         file_name << ".afm" unless file_name =~ /\.afm$/
-        file_name = file_name[0] == ?/ ? file_name : find_font(file_name)
+        file_name = file_name[0] == '/' ? file_name : find_font(file_name)
 
         font_data = @@font_data[file_name] ||= parse_afm(file_name)
         @glyph_widths    = font_data[:glyph_widths]

--- a/lib/prawn/graphics.rb
+++ b/lib/prawn/graphics.rb
@@ -64,14 +64,15 @@ module Prawn
     #   pdf.curve_to [100,100], :bounds => [[90,90],[75,75]]
     #
     def curve_to(dest,options={})
-       options[:bounds] or raise Prawn::Errors::InvalidGraphicsPath,
-                                 "Bounding points for bezier curve must be specified " +
-                                 "as :bounds => [[x1,y1],[x2,y2]]"
+      options[:bounds] or raise Prawn::Errors::InvalidGraphicsPath,
+                                "Bounding points for bezier curve must be specified " +
+                                "as :bounds => [[x1,y1],[x2,y2]]"
 
-       curve_points = PDF::Core.real_params(
-        (options[:bounds] << dest).flat_map { |e| map_to_absolute(e) })
+      curve_points = PDF::Core.real_params(
+        (options[:bounds] << dest).flat_map { |e| map_to_absolute(e) }
+      )
 
-       renderer.add_content("#{curve_points} c")
+      renderer.add_content("#{curve_points} c")
     end
 
     # Draws a rectangle given <tt>point</tt>, <tt>width</tt> and

--- a/lib/prawn/graphics/patterns.rb
+++ b/lib/prawn/graphics/patterns.rb
@@ -104,12 +104,16 @@ module Prawn
           :N => 1.0,
         )
 
+        if args.length == 4
+          coords = [0, 0, args[1].first - args[0].first, args[1].last - args[0].last]
+        else
+          coords = [0, 0, args[1], args[2].first - args[0].first, args[2].last - args[0].last, args[3]]
+        end
+
         shading = ref!(
           :ShadingType => args.length == 4 ? 2 : 3, # axial : radial shading
           :ColorSpace => color_space(color1),
-          :Coords => args.length == 4 ?
-                        [0, 0, args[1].first - args[0].first, args[1].last - args[0].last] :
-                        [0, 0, args[1], args[2].first - args[0].first, args[2].last - args[0].last, args[3]],
+          :Coords => coords,
           :Function => shader,
           :Extend => [true, true],
         )

--- a/lib/prawn/security.rb
+++ b/lib/prawn/security.rb
@@ -267,11 +267,11 @@ module PDF
         @on_encode.call(self) if @on_encode
 
         output = "#{@identifier} #{gen} obj\n"
-        unless @stream.empty?
+        if @stream.empty?
+          output << PDF::Core::EncryptedPdfObject(data, key, @identifier, gen) << "\n"
+        else
           output << PDF::Core::EncryptedPdfObject(data.merge(@stream.data), key, @identifier, gen) << "\n" <<
             @stream.encrypted_object(key, @identifier, gen)
-        else
-          output << PDF::Core::EncryptedPdfObject(data, key, @identifier, gen) << "\n"
         end
 
         output << "endobj\n"

--- a/lib/prawn/text.rb
+++ b/lib/prawn/text.rb
@@ -359,8 +359,11 @@ module Prawn
     end
 
     def draw_indented_formatted_line(string, options)
-      gap = options.fetch(:direction, text_direction) == :ltr ?
-              [@indent_paragraphs, 0] : [0, @indent_paragraphs]
+      if options.fetch(:direction, text_direction) == :ltr
+        gap = [@indent_paragraphs, 0]
+      else
+        gap = [0, @indent_paragraphs]
+      end
 
       indent(*gap) do
         fill_formatted_text_box(string, options.dup.merge(:single_line => true))

--- a/lib/prawn/text/formatted/parser.rb
+++ b/lib/prawn/text/formatted/parser.rb
@@ -117,8 +117,6 @@ module Prawn
           paragraphs
         end
 
-        private
-
         def self.array_from_tokens(tokens)
           array = []
           styles = []

--- a/spec/formatted_text_box_spec.rb
+++ b/spec/formatted_text_box_spec.rb
@@ -338,12 +338,13 @@ end
 describe "Text::Formatted::Box#render" do
   it "should be able to perform fragment callbacks" do
     create_pdf
-    callback_object = TestFragmentCallback.new("something", 7,
-                                               :document => @pdf)
+    callback_object = TestFragmentCallback.new("something", 7, :document => @pdf)
     callback_object.expects(:render_behind).with(
-                                      kind_of(Prawn::Text::Formatted::Fragment))
+      kind_of(Prawn::Text::Formatted::Fragment)
+    )
     callback_object.expects(:render_in_front).with(
-                                      kind_of(Prawn::Text::Formatted::Fragment))
+      kind_of(Prawn::Text::Formatted::Fragment)
+    )
     array = [{ :text => "hello world " },
              { :text => "callback now",
                :callback => callback_object }]
@@ -353,19 +354,21 @@ describe "Text::Formatted::Box#render" do
   it "should be able to perform fragment callbacks on multiple objects" do
     create_pdf
 
-    callback_object = TestFragmentCallback.new("something", 7,
-                                               :document => @pdf)
+    callback_object = TestFragmentCallback.new("something", 7, :document => @pdf)
     callback_object.expects(:render_behind).with(
-                                      kind_of(Prawn::Text::Formatted::Fragment))
+      kind_of(Prawn::Text::Formatted::Fragment)
+    )
     callback_object.expects(:render_in_front).with(
-                                      kind_of(Prawn::Text::Formatted::Fragment))
+      kind_of(Prawn::Text::Formatted::Fragment)
+    )
 
-    callback_object2 = TestFragmentCallback.new("something else", 14,
-                                                :document => @pdf)
+    callback_object2 = TestFragmentCallback.new("something else", 14, :document => @pdf)
     callback_object2.expects(:render_behind).with(
-                                      kind_of(Prawn::Text::Formatted::Fragment))
+      kind_of(Prawn::Text::Formatted::Fragment)
+    )
     callback_object2.expects(:render_in_front).with(
-                                      kind_of(Prawn::Text::Formatted::Fragment))
+      kind_of(Prawn::Text::Formatted::Fragment)
+    )
 
     array = [{ :text => "hello world " },
              { :text => "callback now",

--- a/spec/formatted_text_box_spec.rb
+++ b/spec/formatted_text_box_spec.rb
@@ -101,10 +101,10 @@ describe "Text::Formatted::Box with :fallback_fonts option that includes" +
 
     fonts_used = text.font_settings.map { |e| e[:name] }
     fonts_used.length.should == 4
-    fonts_used[0].should == :"Helvetica"
+    fonts_used[0].should == :Helvetica
     fonts_used[1].to_s.should =~ /GBZenKai-Medium/
     fonts_used[2].to_s.should =~ /GBZenKai-Medium/
-    fonts_used[3].should == :"Helvetica"
+    fonts_used[3].should == :Helvetica
 
     text.strings[0].should == "hello"
     text.strings[1].should == "你好"
@@ -133,7 +133,7 @@ describe "Text::Formatted::Box with :fallback_fonts option that includes" +
     fonts_used[0].to_s.should =~ /GBZenKai-Medium/
     fonts_used[1].to_s.should =~ /GBZenKai-Medium/
     fonts_used[2].to_s.should =~ /GBZenKai-Medium/
-    fonts_used[3].should == :"Helvetica"
+    fonts_used[3].should == :Helvetica
 
     text.strings[0].should == "hello"
     text.strings[1].should == "你好"
@@ -164,7 +164,7 @@ describe "Text::Formatted::Box with :fallback_fonts option and fragment " +
 
     fonts_used = text.font_settings.map { |e| e[:name] }
     fonts_used.length.should == 4
-    fonts_used[0].should == :"Helvetica"
+    fonts_used[0].should == :Helvetica
     fonts_used[1].to_s.should =~ /GBZenKai-Medium/
     fonts_used[2].to_s.should =~ /GBZenKai-Medium/
     fonts_used[3].should == :"Times-Roman"
@@ -203,7 +203,7 @@ describe "Text::Formatted::Box" do
 
     fonts_used = text.font_settings.map { |e| e[:name] }
     fonts_used.length.should == 2
-    fonts_used[0].should == :"Helvetica"
+    fonts_used[0].should == :Helvetica
     fonts_used[1].to_s.should =~ /GBZenKai-Medium/
   end
   it "should be able to override document-wide fallback_fonts" do
@@ -214,7 +214,7 @@ describe "Text::Formatted::Box" do
 
     fonts_used = text.font_settings.map { |e| e[:name] }
     fonts_used.length.should == 2
-    fonts_used[0].should == :"Helvetica"
+    fonts_used[0].should == :Helvetica
     fonts_used[1].should =~ /Kai/
   end
   it "should omit the fallback fonts overhead when passing an empty array " +


### PR DESCRIPTION
Various cleanups related to indentation, symbol quoting, multi-line ternary statements, unless/else rewrites, removing character literals and removing useless private modifier.