### PR TITLE
Enforce consistent multi-line string concatenation

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,9 +14,12 @@ Encoding:
 AsciiComments:
   Enabled: false
 
-# Due to some layout constraints in our examples we want to allow this rule to
+# Due to some layout constraints in our examples we want to allow these rule to
 # be ignored in the manual.
 Style/ClosingParenthesisIndentation:
+  Exclude:
+    - manual/**/*
+LineEndConcatenation:
   Exclude:
     - manual/**/*
 
@@ -48,8 +51,6 @@ StringLiterals:
 HashSyntax:
   Enabled: false
 UselessAssignment:
-  Enabled: false
-LineEndConcatenation:
   Enabled: false
 SpaceAfterComma:
   Enabled: false

--- a/lib/prawn.rb
+++ b/lib/prawn.rb
@@ -38,7 +38,7 @@ module Prawn
     return unless debug || $DEBUG
     unless (act = Set[*actual.keys]).subset?(acc = Set[*accepted])
       raise Prawn::Errors::UnknownOption,
-            "\nDetected unknown option(s): #{(act - acc).to_a.inspect}\n" <<
+            "\nDetected unknown option(s): #{(act - acc).to_a.inspect}\n" \
             "Accepted options are: #{accepted.inspect}"
     end
     yield if block_given?

--- a/lib/prawn/document.rb
+++ b/lib/prawn/document.rb
@@ -573,18 +573,18 @@ module Prawn
     # @private
     def group(*a, &b)
       raise NotImplementedError,
-            "Document#group has been disabled because its implementation " +
-            "lead to corrupted documents whenever a page boundary was " +
-            "crossed. We will try to work on reimplementing it in a " +
+            "Document#group has been disabled because its implementation " \
+            "lead to corrupted documents whenever a page boundary was " \
+            "crossed. We will try to work on reimplementing it in a " \
             "future release"
     end
 
     # @private
     def transaction
       raise NotImplementedError,
-            "Document#transaction has been disabled because its implementation " +
-            "lead to corrupted documents whenever a page boundary was " +
-            "crossed. We will try to work on reimplementing it in a " +
+            "Document#transaction has been disabled because its implementation " \
+            "lead to corrupted documents whenever a page boundary was " \
+            "crossed. We will try to work on reimplementing it in a " \
             "future release"
     end
 

--- a/lib/prawn/font/afm.rb
+++ b/lib/prawn/font/afm.rb
@@ -104,7 +104,7 @@ module Prawn
              ::Encoding::UndefinedConversionError
 
         raise Prawn::Errors::IncompatibleStringEncoding,
-              "Your document includes text that's not compatible with the Windows-1252 character set.\n" +
+              "Your document includes text that's not compatible with the Windows-1252 character set.\n" \
               "If you need full UTF-8 support, use TTF fonts instead of PDF's built-in fonts\n."
       end
 

--- a/lib/prawn/font/ttf.rb
+++ b/lib/prawn/font/ttf.rb
@@ -169,9 +169,9 @@ module Prawn
           text.encode(::Encoding::UTF_8)
         rescue => e
           puts e
-          raise Prawn::Errors::IncompatibleStringEncoding, "Encoding " +
-            "#{text.encoding} can not be transparently converted to UTF-8. " +
-            "Please ensure the encoding of the string you are attempting " +
+          raise Prawn::Errors::IncompatibleStringEncoding, "Encoding " \
+            "#{text.encoding} can not be transparently converted to UTF-8. " \
+            "Please ensure the encoding of the string you are attempting " \
             "to use is set correctly"
         end
       end

--- a/lib/prawn/graphics.rb
+++ b/lib/prawn/graphics.rb
@@ -65,7 +65,7 @@ module Prawn
     #
     def curve_to(dest,options={})
       options[:bounds] or raise Prawn::Errors::InvalidGraphicsPath,
-                                "Bounding points for bezier curve must be specified " +
+                                "Bounding points for bezier curve must be specified " \
                                 "as :bounds => [[x1,y1],[x2,y2]]"
 
       curve_points = PDF::Core.real_params(

--- a/lib/prawn/images/png.rb
+++ b/lib/prawn/images/png.rb
@@ -69,7 +69,7 @@ module Prawn
             case @color_type
             when 3
               raise Errors::UnsupportedImageType,
-                    "Pallete-based transparency in PNG is not currently supported.\n" +
+                    "Pallete-based transparency in PNG is not currently supported.\n" \
                     "See https://github.com/prawnpdf/prawn/issues/783"
             when 0
               # Greyscale. Corresponding to entries in the PLTE chunk.

--- a/lib/prawn/text.rb
+++ b/lib/prawn/text.rb
@@ -287,10 +287,10 @@ module Prawn
     #
     def draw_text!(text, options)
       unless font.unicode? || font.class.hide_m17n_warning || text.ascii_only?
-        warn "PDF's built-in fonts have very limited support for " +
-             "internationalized text.\nIf you need full UTF-8 support, " +
-             "consider using a TTF font instead.\n\nTo disable this " +
-             "warning, add the following line to your code:\n" +
+        warn "PDF's built-in fonts have very limited support for " \
+             "internationalized text.\nIf you need full UTF-8 support, " \
+             "consider using a TTF font instead.\n\nTo disable this " \
+             "warning, add the following line to your code:\n" \
              "Prawn::Font::AFM.hide_m17n_warning = true\n"
 
         font.class.hide_m17n_warning = true
@@ -332,7 +332,7 @@ module Prawn
     #
     def height_of_formatted(array, options={})
       if options[:indent_paragraphs]
-        raise NotImplementedError, ":indent_paragraphs option not available" +
+        raise NotImplementedError, ":indent_paragraphs option not available" \
           "with height_of"
       end
       process_final_gap_option(options)
@@ -409,7 +409,7 @@ module Prawn
 
     def inspect_options_for_text(options)
       if options[:at]
-        raise ArgumentError, ":at is no longer a valid option with text." +
+        raise ArgumentError, ":at is no longer a valid option with text." \
                              "use draw_text or text_box instead"
       end
       process_final_gap_option(options)

--- a/lib/prawn/text/formatted/line_wrap.rb
+++ b/lib/prawn/text/formatted/line_wrap.rb
@@ -120,11 +120,11 @@ module Prawn
         # The pattern used to determine chunks of text to place on a given line
         #
         def scan_pattern
-          pattern = "[^#{break_chars}]+#{soft_hyphen}|" +
-            "[^#{break_chars}]+#{hyphen}+|" +
-            "[^#{break_chars}]+|" +
-            "[#{whitespace}]+|" +
-            "#{hyphen}+[^#{break_chars}]*|" +
+          pattern = "[^#{break_chars}]+#{soft_hyphen}|" \
+            "[^#{break_chars}]+#{hyphen}+|" \
+            "[^#{break_chars}]+|" \
+            "[#{whitespace}]+|" \
+            "#{hyphen}+[^#{break_chars}]*|" \
             "#{soft_hyphen}"
 
           Regexp.new(pattern)

--- a/lib/prawn/text/formatted/parser.rb
+++ b/lib/prawn/text/formatted/parser.rb
@@ -15,19 +15,19 @@ module Prawn
         # @group Extension API
 
         PARSER_REGEX = begin
-          regex_string = "\n|" +
-                         "<b>|</b>|" +
-                         "<i>|</i>|" +
-                         "<u>|</u>|" +
-                         "<strikethrough>|</strikethrough>|" +
-                         "<sub>|</sub>|" +
-                         "<sup>|</sup>|" +
-                         "<link[^>]*>|</link>|" +
-                         "<color[^>]*>|</color>|" +
-                         "<font[^>]*>|</font>|" +
-                         "<strong>|</strong>|" +
-                         "<em>|</em>|" +
-                         "<a[^>]*>|</a>|" +
+          regex_string = "\n|" \
+                         "<b>|</b>|" \
+                         "<i>|</i>|" \
+                         "<u>|</u>|" \
+                         "<strikethrough>|</strikethrough>|" \
+                         "<sub>|</sub>|" \
+                         "<sup>|</sup>|" \
+                         "<link[^>]*>|</link>|" \
+                         "<color[^>]*>|</color>|" \
+                         "<font[^>]*>|</font>|" \
+                         "<strong>|</strong>|" \
+                         "<em>|</em>|" \
+                         "<a[^>]*>|</a>|" \
                          "[^<\n]+"
           Regexp.new(regex_string, Regexp::MULTILINE)
         end
@@ -81,9 +81,9 @@ module Prawn
 
             if hash[:color]
               if hash[:color].kind_of?(Array)
-                prefix = prefix + "<color c='#{hash[:color][0]}'" +
-                                        " m='#{hash[:color][1]}'" +
-                                        " y='#{hash[:color][2]}'" +
+                prefix = prefix + "<color c='#{hash[:color][0]}'" \
+                                        " m='#{hash[:color][1]}'" \
+                                        " y='#{hash[:color][2]}'" \
                                         " k='#{hash[:color][3]}'>"
               else
                 prefix = prefix + "<color rgb='#{hash[:color]}'>"

--- a/spec/bounding_box_spec.rb
+++ b/spec/bounding_box_spec.rb
@@ -176,7 +176,7 @@ describe "drawing bounding boxes" do
     @pdf.y.should be_within(0.001).of(orig_y - @pdf.height_of("hello"))
   end
 
-  it "should not advance y-position of a stretchy bbox if it would stretch " +
+  it "should not advance y-position of a stretchy bbox if it would stretch " \
      "the bbox further" do
     bottom = @pdf.y = @pdf.margin_box.absolute_bottom
     @pdf.bounding_box [0, @pdf.margin_box.top], :width => @pdf.bounds.width do

--- a/spec/formatted_text_arranger_spec.rb
+++ b/spec/formatted_text_arranger_spec.rb
@@ -56,7 +56,7 @@ describe "Core::Text::Formatted::Arranger#next_string" do
              { :text => " you?" }]
     @arranger.format_array = array
   end
-  it "should raise_error an error if called after a line was finalized and" +
+  it "should raise_error an error if called after a line was finalized and" \
      " before a new line was initialized" do
     @arranger.finalize_line
     lambda do
@@ -113,7 +113,7 @@ describe "Core::Text::Formatted::Arranger#retrieve_fragment" do
       arranger.retrieve_fragment
     end.should raise_error(RuntimeError)
   end
-  it "should return the consumed fragments in order of consumption" +
+  it "should return the consumed fragments in order of consumption" \
      " and update" do
     create_pdf
     arranger = Prawn::Text::Formatted::Arranger.new(@pdf)
@@ -167,7 +167,7 @@ describe "Core::Text::Formatted::Arranger#retrieve_fragment" do
 end
 
 describe "Core::Text::Formatted::Arranger#update_last_string" do
-  it "should update the last retrieved string with what actually fit on" +
+  it "should update the last retrieved string with what actually fit on" \
      "the line and the list of unconsumed with what did not" do
     create_pdf
     arranger = Prawn::Text::Formatted::Arranger.new(@pdf)
@@ -237,7 +237,7 @@ describe "Core::Text::Formatted::Arranger#space_count" do
   end
 end
 describe "Core::Text::Formatted::Arranger#finalize_line" do
-  it "should make it so that all trailing white space fragments " +
+  it "should make it so that all trailing white space fragments " \
      "exclude trailing white space" do
     create_pdf
     arranger = Prawn::Text::Formatted::Arranger.new(@pdf)

--- a/spec/formatted_text_box_spec.rb
+++ b/spec/formatted_text_box_spec.rb
@@ -85,7 +85,7 @@ describe "Text::Formatted::Box wrapping" do
   end
 end
 
-describe "Text::Formatted::Box with :fallback_fonts option that includes" +
+describe "Text::Formatted::Box with :fallback_fonts option that includes" \
   "a Chinese font and set of Chinese glyphs not in the current font" do
   it "should change the font to the Chinese font for the Chinese glyphs" do
     create_pdf
@@ -113,7 +113,7 @@ describe "Text::Formatted::Box with :fallback_fonts option that includes" +
   end
 end
 
-describe "Text::Formatted::Box with :fallback_fonts option that includes" +
+describe "Text::Formatted::Box with :fallback_fonts option that includes" \
   "an AFM font and Win-Ansi glyph not in the current Chinese font" do
   it "should change the font to the AFM font for the Win-Ansi glyph" do
     create_pdf
@@ -142,7 +142,7 @@ describe "Text::Formatted::Box with :fallback_fonts option that includes" +
   end
 end
 
-describe "Text::Formatted::Box with :fallback_fonts option and fragment " +
+describe "Text::Formatted::Box with :fallback_fonts option and fragment " \
   "level font" do
   it "should use the fragment level font except for glyphs not in that font" do
     create_pdf
@@ -217,7 +217,7 @@ describe "Text::Formatted::Box" do
     fonts_used[0].should == :Helvetica
     fonts_used[1].should =~ /Kai/
   end
-  it "should omit the fallback fonts overhead when passing an empty array " +
+  it "should omit the fallback fonts overhead when passing an empty array " \
     "as the :fallback_fonts" do
     @pdf.font("Kai")
 
@@ -241,7 +241,7 @@ describe "Text::Formatted::Box" do
   end
 end
 
-describe "Text::Formatted::Box with :fallback_fonts option " +
+describe "Text::Formatted::Box with :fallback_fonts option " \
   "with glyphs not in the primary or the fallback fonts" do
   it "should raise an exception" do
    file = "#{Prawn::DATADIR}/fonts/gkai00mp.ttf"
@@ -263,7 +263,7 @@ describe "Text::Formatted::Box#extensions" do
     text = PDF::Inspector::Text.analyze(@pdf.render)
     text.strings[0].should == "all your base are belong to us"
   end
-  it "overriding Text::Formatted::Box line wrapping should not affect " +
+  it "overriding Text::Formatted::Box line wrapping should not affect " \
      "Text::Box wrapping" do
     create_pdf
     Prawn::Text::Formatted::Box.extensions << TestFormattedWrapOverride

--- a/spec/formatted_text_fragment_spec.rb
+++ b/spec/formatted_text_fragment_spec.rb
@@ -11,7 +11,7 @@ describe "Text::Formatted::Fragment#space_count" do
                                                     @pdf)
     fragment.space_count.should == 2
   end
-  it "should exclude trailing spaces from the count when " +
+  it "should exclude trailing spaces from the count when " \
     ":exclude_trailing_white_space => true" do
     create_pdf
     format_state = { :exclude_trailing_white_space => true }
@@ -44,7 +44,7 @@ describe "Text::Formatted::Fragment#text" do
                                                     @pdf)
     fragment.text.should == "hello world "
   end
-  it "should return the fragment text without trailing spaces when " +
+  it "should return the fragment text without trailing spaces when " \
     ":exclude_trailing_white_space => true" do
     create_pdf
     format_state = { :exclude_trailing_white_space => true }
@@ -179,7 +179,7 @@ describe "Text::Formatted::Fragment" do
   end
 
   describe "#absolute_bounding_box" do
-    it "should return the bounding box surrounding the fragment" +
+    it "should return the bounding box surrounding the fragment" \
        " in absolute coordinates" do
       target_box = [50, 193, 150, 217]
         target_box[0] += @pdf.bounds.absolute_left
@@ -275,7 +275,7 @@ describe "Text::Formatted::Fragment with :direction => :rtl" do
 end
 
 describe "Text::Formatted::Fragment default_direction=" do
-  it "should set the direction if there is no fragment level direction " +
+  it "should set the direction if there is no fragment level direction " \
      "specification" do
     create_pdf
     format_state = {}
@@ -285,7 +285,7 @@ describe "Text::Formatted::Fragment default_direction=" do
     fragment.default_direction = :rtl
     fragment.direction.should == :rtl
   end
-  it "should not set the direction if there is a fragment level direction " +
+  it "should not set the direction if there is a fragment level direction " \
      "specification" do
     create_pdf
     format_state = { :direction => :rtl }

--- a/spec/graphics_spec.rb
+++ b/spec/graphics_spec.rb
@@ -13,7 +13,7 @@ describe "When drawing a line" do
     line_drawing.points.should == [[100,600],[100,500]]
   end
 
-  it "should draw two lines at (100,600) to (100,500) " +
+  it "should draw two lines at (100,600) to (100,500) " \
      "and (75,100) to (50,125)" do
     @pdf.line(100,600,100,500)
     @pdf.line(75,100,50,125)

--- a/spec/inline_formatted_text_parser_spec.rb
+++ b/spec/inline_formatted_text_parser_spec.rb
@@ -491,8 +491,7 @@ describe "Text::Formatted::Parser#to_string" do
     string = "hello <b>&lt;, &gt;, and &amp;</b>"
     Prawn::Text::Formatted::Parser.to_string(array).should == string
   end
-  it "should construct an HTML-esque string from a formatted" +
-    " text array" do
+  it "should construct an HTML-esque string from a formatted text array" do
     array = [
              { :text => "hello ",
                :styles => [],

--- a/spec/line_wrap_spec.rb
+++ b/spec/line_wrap_spec.rb
@@ -18,8 +18,8 @@ describe "Core::Text::Formatted::LineWrap#wrap_line" do
                                   :document => @pdf)
     string.should == "hello world, goodbye"
   end
-  it "should strip trailing spaces when a white-space-only fragment was" +
-     " successfully pushed onto the end of a line but no other non-white" +
+  it "should strip trailing spaces when a white-space-only fragment was" \
+     " successfully pushed onto the end of a line but no other non-white" \
      " space fragment fits after it" do
     array = [{ :text => "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa " },
              { :text => "  ", :style => [:bold] },
@@ -88,7 +88,7 @@ describe "Core::Text::Formatted::LineWrap#wrap_line" do
     string.should == "hello-"
   end
 
-  it "should not break after a hyphen that follows white space and" +
+  it "should not break after a hyphen that follows white space and" \
      "precedes a word" do
     array = [{ :text => "hello -" }]
     @arranger.format_array = array
@@ -152,7 +152,7 @@ describe "Core::Text::Formatted::LineWrap#wrap_line" do
     res1.should == res2
   end
 
-  it "should not display soft hyphens except at the end of a line " +
+  it "should not display soft hyphens except at the end of a line " \
      "for more than one element in format_array", :issue => 347 do
     @pdf.font("#{Prawn::DATADIR}/fonts/DejaVuSans.ttf")
     @line_wrap = Prawn::Text::Formatted::LineWrap.new
@@ -203,7 +203,7 @@ describe "Core::Text::Formatted::LineWrap#wrap_line" do
     string.should == "hello"
   end
 
-  it "should not break after a hard hyphen that follows a soft hyphen and" +
+  it "should not break after a hard hyphen that follows a soft hyphen and" \
     "precedes a word" do
     string = @pdf.font.normalize_encoding("hello#{Prawn::Text::SHY}-")
     array = [{ :text => string }]
@@ -296,7 +296,7 @@ describe "Core::Text::Formatted::LineWrap" do
     @arranger.format_array = array
     @line_wrap = Prawn::Text::Formatted::LineWrap.new
   end
-  it "should only return an empty string if nothing fit or there" +
+  it "should only return an empty string if nothing fit or there" \
      "was nothing to wrap" do
     8.times do
       line = @line_wrap.wrap_line(:arranger => @arranger,

--- a/spec/png_spec.rb
+++ b/spec/png_spec.rb
@@ -94,8 +94,7 @@ describe "When reading an RGB PNG file with transparency (color type 2)" do
   end
 end
 
-describe "When reading an indexed color PNG file " +
-         "wiih transparency (color type 3)" do
+describe "When reading an indexed color PNG file with transparency (color type 3)" do
   it "raises a not supported error" do
     bin = File.binread("#{Prawn::DATADIR}/images/pal_bk.png")
     expect { Prawn::Images::PNG.new(bin)}.to(

--- a/spec/stamp_spec.rb
+++ b/spec/stamp_spec.rb
@@ -36,7 +36,7 @@ describe "#stamp_at" do
 end
 
 describe "Document with a stamp" do
-  it "should raise_error NameTaken error when attempt to create stamp " +
+  it "should raise_error NameTaken error when attempt to create stamp " \
      "with same name as an existing stamp" do
     create_pdf
     @pdf.create_stamp("MyStamp")
@@ -45,7 +45,7 @@ describe "Document with a stamp" do
     }.should raise_error(Prawn::Errors::NameTaken)
   end
 
-  it "should raise_error InvalidName error when attempt to create " +
+  it "should raise_error InvalidName error when attempt to create " \
      "stamp with a blank name" do
     create_pdf
     lambda {
@@ -65,7 +65,7 @@ describe "Document with a stamp" do
     xobjects.length.should == 2
   end
 
-  it "calling stamp with a name that does not match an existing stamp " +
+  it "calling stamp with a name that does not match an existing stamp " \
      "should raise_error UndefinedObjectName" do
     create_pdf
     @pdf.create_stamp("MyStamp")
@@ -106,7 +106,7 @@ describe "Document with a stamp" do
     end
   end
 
-  it "resources added during stamp creation should be added to the " +
+  it "resources added during stamp creation should be added to the " \
      "stamp XObject, not the page" do
     create_pdf
     @pdf.create_stamp("MyStamp") do

--- a/spec/text_at_spec.rb
+++ b/spec/text_at_spec.rb
@@ -91,8 +91,7 @@ describe "#draw_text" do
     text.font_settings[1][:size].should == 12
   end
 
-  it "should allow manual setting the font size " +
-    "when in a font size block" do
+  it "should allow manual setting the font size when in a font size block" do
     @pdf.font_size(16) do
       @pdf.draw_text('Foo', :at => [0, 0])
       @pdf.draw_text('Blah', :size => 11, :at => [0, 0])

--- a/spec/text_box_spec.rb
+++ b/spec/text_box_spec.rb
@@ -44,7 +44,7 @@ describe "Text::Box#everything_printed?" do
 end
 
 describe "Text::Box#line_gap" do
-  it "should == the line gap of the font when using a single " +
+  it "should == the line gap of the font when using a single " \
     "font and font size" do
     create_pdf
     string = "Hello world, how are you?\nI'm fine, thank you."
@@ -113,7 +113,7 @@ describe "Text::Box" do
                                     :leading => 20)
     text_box.leading.should == 20
   end
-  it "should default to document-wide leading if no" +
+  it "should default to document-wide leading if no" \
     "leading option is provided" do
   end
 end
@@ -140,7 +140,7 @@ describe "Text::Box#render with :align => :justify" do
 end
 
 describe "Text::Box" do
-  it "should only require enough space for the descender and the ascender " +
+  it "should only require enough space for the descender and the ascender " \
      "when determining whether a line can fit" do
     create_pdf
     text = "Oh hai text rect"
@@ -158,7 +158,7 @@ describe "Text::Box" do
 end
 
 describe "Text::Box#height without leading" do
-  it "should == the sum of the height of each line, " +
+  it "should == the sum of the height of each line, " \
     "not including the space below the last line" do
     create_pdf
     text = "Oh hai text rect.\nOh hai text rect."
@@ -170,7 +170,7 @@ describe "Text::Box#height without leading" do
 end
 
 describe "Text::Box#height with leading" do
-  it "should == the sum of the height of each line plus leading, " +
+  it "should == the sum of the height of each line plus leading, " \
     "but not including the space below the last line" do
     create_pdf
     text = "Oh hai text rect.\nOh hai text rect."
@@ -499,7 +499,7 @@ describe "Text::Box default height" do
     end
   end
 
-  it "should use the parent-box bottom if in a stretchy bbox and " +
+  it "should use the parent-box bottom if in a stretchy bbox and " \
     "overflow is :expand, even with an explicit height"do
     @pdf.bounding_box([0, @pdf.cursor], :width => @pdf.bounds.width) do
       target_height = @pdf.y - @pdf.bounds.bottom
@@ -548,8 +548,8 @@ describe "Text::Box with text than can fit in the box" do
     }
   end
 
-  it "printed text should match requested text, except that preceding and " +
-    "trailing white space will be stripped from each line, and newlines may " +
+  it "printed text should match requested text, except that preceding and " \
+    "trailing white space will be stripped from each line, and newlines may " \
     "be inserted" do
     text_box = Prawn::Text::Box.new("  " + @text, @options)
     text_box.render
@@ -724,8 +724,8 @@ describe "Text::Box with more text than can fit in the box" do
 
   context "truncated with text and size taken from the manual" do
     it "should return the right text" do
-      @text = "This is the beginning of the text. It will be cut somewhere and " +
-        "the rest of the text will procede to be rendered this time by " +
+      @text = "This is the beginning of the text. It will be cut somewhere and " \
+        "the rest of the text will procede to be rendered this time by " \
         "calling another method." + " . " * 50
       @options[:width] = 300
       @options[:height] = 50
@@ -782,7 +782,7 @@ describe "Text::Box with more text than can fit in the box" do
   end
 end
 
-describe "Text::Box with enough space to fit the text but using the " +
+describe "Text::Box with enough space to fit the text but using the " \
   "shrink_to_fit overflow" do
   it "should not shrink the text when there is no need to" do
     create_pdf
@@ -877,7 +877,7 @@ describe "Text::Box wrapping" do
   # for other characters, so wrapping "hello hello" resulted in
   # "hello\n\nhello", rather than "hello\nhello"
   #
-  it "white space at beginning of line should not be taken into account when" +
+  it "white space at beginning of line should not be taken into account when" \
     " computing line width" do
     text = "hello hello"
     expect = "hello\nhello"

--- a/spec/text_rendering_mode_spec.rb
+++ b/spec/text_rendering_mode_spec.rb
@@ -11,7 +11,7 @@ describe "#text_rendering_mode" do
     contents = PDF::Inspector::Text.analyze(@pdf.render)
     contents.text_rendering_mode.first.should == 1
   end
-  it "should not draw the text rendering mode to the document" +
+  it "should not draw the text rendering mode to the document" \
     " when the new mode matches the old" do
     create_pdf
     @pdf.text_rendering_mode(:fill) do

--- a/spec/text_spacing_spec.rb
+++ b/spec/text_spacing_spec.rb
@@ -11,7 +11,7 @@ describe "#character_spacing" do
     contents = PDF::Inspector::Text.analyze(@pdf.render)
     contents.character_spacing.first.should == 10.5556
   end
-  it "should not draw the character spacing to the document" +
+  it "should not draw the character spacing to the document" \
     " when the new character spacing matches the old" do
     create_pdf
     @pdf.character_spacing(0) do
@@ -65,7 +65,7 @@ describe "#word_spacing" do
     contents = PDF::Inspector::Text.analyze(@pdf.render)
     contents.word_spacing.first.should == 10.5556
   end
-  it "should draw the word spacing to the document" +
+  it "should draw the word spacing to the document" \
     " when the new word spacing matches the old" do
     create_pdf
     @pdf.word_spacing(0) do

--- a/spec/text_spec.rb
+++ b/spec/text_spec.rb
@@ -11,7 +11,7 @@ end
 describe "#height_of" do
   before(:each) { create_pdf }
 
-  it "should return the height that would be required to print a" +
+  it "should return the height that would be required to print a" \
     "particular string of text" do
     original_y = @pdf.y
     @pdf.text("Foo")
@@ -19,7 +19,7 @@ describe "#height_of" do
     @pdf.height_of("Foo").should be_within(0.0001).of(original_y - new_y)
   end
 
-  it "should omit the gap below the last descender if :final_gap => false " +
+  it "should omit the gap below the last descender if :final_gap => false " \
     "is given" do
     original_y = @pdf.y
     @pdf.text("Foo", :final_gap => false)
@@ -80,7 +80,7 @@ describe "#text" do
     text.strings.reject(&:empty?).should == ["text", "text"]
   end
 
-  it "should correctly render strings ending with empty paragraphs and " +
+  it "should correctly render strings ending with empty paragraphs and " \
      ":inline_format and :indent_paragraphs" do
     @pdf.text "text\n\n", :inline_format => true, :indent_paragraphs => 5
     text = PDF::Inspector::Text.analyze(@pdf.render)
@@ -130,8 +130,7 @@ describe "#text" do
     @pdf.y.should be_within(0.0001).of(position - 3 * @pdf.font.height)
   end
 
-  it "should advance down the document based on font_height" +
-    " with size option" do
+  it "should advance down the document based on font_height with size option" do
     position = @pdf.y
     @pdf.text "Foo", :size => 15
 
@@ -143,8 +142,7 @@ describe "#text" do
     @pdf.y.should be_within(0.0001).of(position - 3 * @pdf.font.height)
   end
 
-  it "should advance down the document based on font_height" +
-    " with leading option" do
+  it "should advance down the document based on font_height with leading option" do
     position = @pdf.y
     leading = 2
     @pdf.text "Foo", :leading => leading
@@ -156,8 +154,7 @@ describe "#text" do
     @pdf.y.should be_within(0.0001).of(position - 3 * @pdf.font.height)
   end
 
-  it "should advance only to the bottom of the final descender " +
-    "if final_gap is false" do
+  it "should advance only to the bottom of the final descender if final_gap is false" do
     position = @pdf.y
     @pdf.text "Foo", :final_gap => false
 
@@ -218,8 +215,7 @@ describe "#text" do
     text.font_settings[1][:size].should == 12
   end
 
-  it "should allow manual setting the font size " +
-    "when in a font size block" do
+  it "should allow manual setting the font size when in a font size block" do
     @pdf.font_size(16) do
       @pdf.text 'Foo'
       @pdf.text 'Blah', :size => 11
@@ -279,8 +275,7 @@ describe "#text" do
     text.strings.first.should == str
   end
 
-  it "subsets mixed low-ASCII and non-ASCII characters when they can be " +
-     "subsetted together" do
+  it "subsets mixed low-ASCII and non-ASCII characters when they can be subsetted together" do
     str = "It’s super effective!"
     @pdf.font "#{Prawn::DATADIR}/fonts/DejaVuSans.ttf"
     @pdf.text str
@@ -289,8 +284,7 @@ describe "#text" do
     text.strings.first.should == str
   end
 
-  it "should correctly render a string with higher bit characters across" +
-     " a page break when using a built-in font" do
+  it "should correctly render a string with higher bit characters across a page break when using a built-in font" do
     str = "©"
     @pdf.move_cursor_to(@pdf.font.height)
     @pdf.text(str + "\n" + str)
@@ -301,7 +295,7 @@ describe "#text" do
     pages[1][:strings].should == [str]
   end
 
-  it "should correctly render a string with higher bit characters across" +
+  it "should correctly render a string with higher bit characters across" \
     " a page break when using a built-in font and :indent_paragraphs option" do
     str = "©"
     @pdf.move_cursor_to(@pdf.font.height)
@@ -328,7 +322,7 @@ describe "#text" do
     @pdf.text(sjis_str)
   end
 
-  it "should call move_past_bottom when printing more text than can fit" +
+  it "should call move_past_bottom when printing more text than can fit" \
      " between the current document.y and bounds.bottom" do
     @pdf.y = @pdf.font.height
     @pdf.text "Hello"
@@ -451,8 +445,8 @@ describe "#text" do
       x_positions[3].should == 0
     end
 
-    describe "when wrap to new page, and first line of new page" +
-             " is not the start of a new paragraph, that line should" +
+    describe "when wrap to new page, and first line of new page" \
+             " is not the start of a new paragraph, that line should" \
              " not be indented" do
       it "should indent the paragraphs" do
         hello = "hello " * 50
@@ -466,8 +460,8 @@ describe "#text" do
         text.strings[4].should == ("hello " * 21).strip
       end
     end
-    describe "when wrap to new page, and first line of new page" +
-             " is the start of a new paragraph, that line should" +
+    describe "when wrap to new page, and first line of new page" \
+             " is the start of a new paragraph, that line should" \
              " be indented" do
       it "should indent the paragraphs" do
         hello = "hello " * 50

--- a/spec/text_with_inline_formatting_spec.rb
+++ b/spec/text_with_inline_formatting_spec.rb
@@ -17,7 +17,7 @@ end
 describe "#text with inline styling" do
   before(:each) { create_pdf }
 
-  it "should automatically move to a new page if the tallest fragment" +
+  it "should automatically move to a new page if the tallest fragment" \
      " on the next line won't fit in the available space" do
     create_pdf
     @pdf.move_cursor_to(@pdf.font.height)

--- a/spec/transparency_spec.rb
+++ b/spec/transparency_spec.rb
@@ -20,7 +20,7 @@ describe "Document with transparency" do
     str[0,8].should == "%PDF-1.4"
   end
 
-  it "a new extended graphics state should be created for " +
+  it "a new extended graphics state should be created for " \
      "each unique transparency setting" do
     create_pdf
     make_transparent(0.5, 0.2) do
@@ -30,7 +30,7 @@ describe "Document with transparency" do
     extgstates.length.should == 2
   end
 
-  it "a new extended graphics state should not be created for " +
+  it "a new extended graphics state should not be created for " \
      "each duplicate transparency setting" do
     create_pdf
     make_transparent(0.5, 0.75) do
@@ -40,7 +40,7 @@ describe "Document with transparency" do
     extgstates.length.should == 1
   end
 
-  it "setting the transparency with only one parameter sets the transparency" +
+  it "setting the transparency with only one parameter sets the transparency" \
      " for both the fill and the stroke" do
     create_pdf
     make_transparent(0.5)
@@ -49,8 +49,8 @@ describe "Document with transparency" do
     extgstate[:stroke_opacity].should == 0.5
   end
 
-  it "setting the transparency with a numerical parameter and " +
-     "a :stroke should set the fill transparency to the numerical parameter " +
+  it "setting the transparency with a numerical parameter and " \
+     "a :stroke should set the fill transparency to the numerical parameter " \
      "and the stroke transparency to the option" do
     create_pdf
     make_transparent(0.5, 0.2)


### PR DESCRIPTION
This PR enforces consistent multi-line string concatenation prefering to use `\` instead of the previously used `>>` and `+`.