### PR TITLE
Prefer be_nil instead of == nil.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -82,8 +82,6 @@ SpaceInsideParens:
   Enabled: false
 IfUnlessModifier:
   Enabled: false
-NilComparison:
-  Enabled: false
 Documentation:
   Enabled: false
 IndentArray:

--- a/spec/font_spec.rb
+++ b/spec/font_spec.rb
@@ -322,7 +322,7 @@ describe "AFM fonts" do
   it "should omit /Encoding for symbolic fonts" do
     zapf = @pdf.find_font "ZapfDingbats"
     font_dict = zapf.send(:register, nil)
-    font_dict.data[:Encoding].should == nil
+    font_dict.data[:Encoding].should be_nil
   end
 end
 

--- a/spec/outline_spec.rb
+++ b/spec/outline_spec.rb
@@ -371,7 +371,7 @@ describe "foreign character encoding" do
 
   it "should handle other encodings for the title" do
     object = find_by_title('La pomme croquée')
-    object.should_not == nil
+    object.should_not be_nil
   end
 end
 


### PR DESCRIPTION
Prefer the rspec idiomatic `be_nil` instead of comparing with `== nil`