### PR TITLE
Minor cleanups

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -41,6 +41,9 @@ MultilineOperationIndentation:
   Exclude:
     - manual/**/*
     - prawn.gemspec
+Style/SpaceInsideParens:
+  Exclude:
+    - manual/**/*
 
 # This file shows examples on how to instantiate a document in multiple ways,
 # it does not actually do the instantiation and isn't actually shadowing any
@@ -94,8 +97,6 @@ DotPosition:
 SingleLineBlockParams:
   Enabled: false
 PercentLiteralDelimiters:
-  Enabled: false
-SpaceInsideParens:
   Enabled: false
 Documentation:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -129,8 +129,6 @@ Eval:
   Enabled: false
 ClassLength:
   Enabled: false
-TrivialAccessors:
-  Enabled: false
 CaseEquality:
   Enabled: false
 RedundantSelf:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,6 +25,10 @@ HandleExceptions:
   Exclude:
     - lib/prawn/text/formatted/box.rb
 
+# %w() style arrays don't always look better.
+WordArray:
+  Enabled: false
+
 # Due to some layout constraints in our examples we want to allow these rule to
 # be ignored in the manual.
 Style/ClosingParenthesisIndentation:
@@ -76,8 +80,6 @@ LineLength:
 SpaceBeforeBlockBraces:
   Enabled: false
 SpaceInsideBrackets:
-  Enabled: false
-WordArray:
   Enabled: false
 SpaceAroundEqualsInParameterDefault:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,6 +19,12 @@ AsciiComments:
 IfUnlessModifier:
   Enabled: false
 
+# In this case we supress Prawn::Errors::CannotFit while trying to scale
+# text down to fit.
+HandleExceptions:
+  Exclude:
+    - lib/prawn/text/formatted/box.rb
+
 # Due to some layout constraints in our examples we want to allow these rule to
 # be ignored in the manual.
 Style/ClosingParenthesisIndentation:
@@ -112,8 +118,6 @@ ClassAndModuleChildren:
 NumericLiterals:
   Enabled: false
 SignalException:
-  Enabled: false
-HandleExceptions:
   Enabled: false
 DoubleNegation:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -44,6 +44,9 @@ MultilineOperationIndentation:
 Style/SpaceInsideParens:
   Exclude:
     - manual/**/*
+SingleSpaceBeforeFirstArg:
+  Exclude:
+    - manual/**/*
 
 # This file shows examples on how to instantiate a document in multiple ways,
 # it does not actually do the instantiation and isn't actually shadowing any
@@ -107,8 +110,6 @@ MethodLength:
 VariableInterpolation:
   Enabled: false
 AmbiguousOperator:
-  Enabled: false
-SingleSpaceBeforeFirstArg:
   Enabled: false
 AndOr:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -106,8 +106,6 @@ MethodLength:
   Enabled: false
 VariableInterpolation:
   Enabled: false
-EvenOdd:
-  Enabled: false
 AmbiguousOperator:
   Enabled: false
 SingleSpaceBeforeFirstArg:

--- a/lib/prawn/document.rb
+++ b/lib/prawn/document.rb
@@ -101,7 +101,7 @@ module Prawn
     # @group Stable Attributes
 
     attr_accessor :margin_box
-    attr_reader   :margins, :y
+    attr_reader :margins, :y
     attr_accessor :page_number
 
     # @group Extension Attributes

--- a/lib/prawn/document.rb
+++ b/lib/prawn/document.rb
@@ -703,7 +703,7 @@ module Prawn
     end
 
     def font_metric_cache #:nodoc:
-      @font_metric_cache ||= FontMetricCache.new( self )
+      @font_metric_cache ||= FontMetricCache.new(self)
     end
   end
 end

--- a/lib/prawn/document.rb
+++ b/lib/prawn/document.rb
@@ -603,9 +603,9 @@ module Prawn
       when :all
         true
       when :odd
-        page_number % 2 == 1
+        page_number.odd?
       when :even
-        page_number % 2 == 0
+        page_number.even?
       when Range, Array
         page_filter.include?(page_number)
       when Proc

--- a/lib/prawn/document/bounding_box.rb
+++ b/lib/prawn/document/bounding_box.rb
@@ -448,10 +448,7 @@ module Prawn
       end
 
       # Width of the bounding box
-      #
-      def width
-        @width
-      end
+      attr_reader :width
 
       # Height of the bounding box.  If the box is 'stretchy' (unspecified
       # height attribute), height is calculated as the distance from the top of

--- a/lib/prawn/font.rb
+++ b/lib/prawn/font.rb
@@ -263,7 +263,7 @@ module Prawn
     end
 
     def width_of_string(string, options={})
-      font_metric_cache.width_of( string, options )
+      font_metric_cache.width_of(string, options)
     end
   end
 
@@ -386,7 +386,7 @@ module Prawn
 
     # Compliments the #hash implementation above
     #
-    def eql?( other ) #:nodoc:
+    def eql?(other) #:nodoc:
       self.class == other.class && self.name == other.name &&
         self.family == other.family && size == other.send(:size)
     end

--- a/lib/prawn/font_metric_cache.rb
+++ b/lib/prawn/font_metric_cache.rb
@@ -13,15 +13,15 @@ module Prawn
   #
   # @private
   class FontMetricCache
-    CacheEntry = Struct.new( :font, :options, :string )
+    CacheEntry = Struct.new(:font, :options, :string)
 
-    def initialize( document )
+    def initialize(document)
       @document = document
 
       @cache = {}
     end
 
-    def width_of( string, options )
+    def width_of(string, options)
       f = if options[:style]
             # override style with :style => :bold
             @document.find_font(@document.font.family, :style => options[:style])
@@ -29,7 +29,7 @@ module Prawn
             @document.font
           end
 
-      key = CacheEntry.new( f, options, string )
+      key = CacheEntry.new(f, options, string)
 
       unless length = @cache[ key ]
         length = @cache[ key ] = f.compute_width_of(string, options)

--- a/lib/prawn/graphics.rb
+++ b/lib/prawn/graphics.rb
@@ -263,7 +263,7 @@ module Prawn
     # the line segment and the third point helps define the curve for the vertex.
     def rounded_vertex(radius, *points)
       radial_point_1 = point_on_line(radius, points[0], points[1])
-      bezier_point_1 = point_on_line((radius - radius * KAPPA), points[0], points[1] )
+      bezier_point_1 = point_on_line((radius - radius * KAPPA), points[0], points[1])
       radial_point_2 = point_on_line(radius, points[2], points[1])
       bezier_point_2 = point_on_line((radius - radius * KAPPA), points[2], points[1])
       line_to(radial_point_1)

--- a/lib/prawn/text.rb
+++ b/lib/prawn/text.rb
@@ -338,7 +338,7 @@ module Prawn
       process_final_gap_option(options)
       box = Text::Formatted::Box.new(
         array,
-        options.merge( :height => 100000000, :document => self)
+        options.merge(:height => 100000000, :document => self)
       )
       box.render(:dry_run => true)
 

--- a/lib/prawn/text/formatted/line_wrap.rb
+++ b/lib/prawn/text/formatted/line_wrap.rb
@@ -150,13 +150,8 @@ module Prawn
           "-"
         end
 
-        def soft_hyphen
-          @soft_hyphen
-        end
-
-        def zero_width_space
-          @zero_width_space
-        end
+        attr_reader :soft_hyphen
+        attr_reader :zero_width_space
 
         def line_empty?
           @line_empty && @accumulated_width == 0

--- a/spec/bounding_box_spec.rb
+++ b/spec/bounding_box_spec.rb
@@ -12,7 +12,7 @@ describe "A bounding box" do
                                             nil,
                                             [@x,@y],
                                             :width  => @width,
-                                            :height => @height )
+                                            :height => @height)
   end
 
   it "should have an anchor at (x, y - height)" do

--- a/spec/document_spec.rb
+++ b/spec/document_spec.rb
@@ -719,7 +719,7 @@ describe "The page_match? method" do
   end
 
   it "must provide an :odd filter" do
-    odd, even = (1..@pdf.page_count).partition { |e| e % 2 == 1 }
+    odd, even = (1..@pdf.page_count).partition(&:odd?)
     odd.all? { |i| @pdf.page_match?(:odd, i) }.should be_true
     even.any? { |i| @pdf.page_match?(:odd, i) }.should be_false
   end

--- a/spec/document_spec.rb
+++ b/spec/document_spec.rb
@@ -346,7 +346,7 @@ describe "When setting page size" do
   end
 
   it "should allow custom page size" do
-    @pdf = Prawn::Document.new(:page_size => [1920, 1080] )
+    @pdf = Prawn::Document.new(:page_size => [1920, 1080])
     pages = PDF::Inspector::Page.analyze(@pdf.render).pages
     pages.first[:size].should == [1920, 1080]
   end

--- a/spec/font_metric_cache_spec.rb
+++ b/spec/font_metric_cache_spec.rb
@@ -6,30 +6,30 @@ require 'pathname'
 describe "Font metrics caching" do
   let(:document) { Prawn::Document.new }
 
-  subject { Prawn::FontMetricCache.new( document ) }
+  subject { Prawn::FontMetricCache.new(document) }
 
   it "should start with an empty cache" do
-    subject.instance_variable_get( :@cache ).should be_empty
+    subject.instance_variable_get(:@cache).should be_empty
   end
 
   it "should cache the width of the provided string" do
     subject.width_of('M', {})
 
-    subject.instance_variable_get( :@cache ).should have(1).entry
+    subject.instance_variable_get(:@cache).should have(1).entry
   end
 
   it "should only cache a single copy of the same string" do
     subject.width_of('M', {})
     subject.width_of('M', {})
 
-    subject.instance_variable_get( :@cache ).should have(1).entry
+    subject.instance_variable_get(:@cache).should have(1).entry
   end
 
   it "should cache different copies for different strings" do
     subject.width_of('M', {})
     subject.width_of('W', {})
 
-    subject.instance_variable_get( :@cache ).should have(2).entries
+    subject.instance_variable_get(:@cache).should have(2).entries
   end
 
   it "should cache different copies of the same string with different font sizes" do
@@ -38,7 +38,7 @@ describe "Font metrics caching" do
     document.font_size 24
     subject.width_of('M', {})
 
-    subject.instance_variable_get( :@cache ).should have(2).entries
+    subject.instance_variable_get(:@cache).should have(2).entries
   end
 
   it "should cache different copies of the same string with different fonts" do
@@ -47,6 +47,6 @@ describe "Font metrics caching" do
     document.font 'Courier'
     subject.width_of('M', {})
 
-    subject.instance_variable_get( :@cache ).should have(2).entries
+    subject.instance_variable_get(:@cache).should have(2).entries
   end
 end

--- a/spec/font_spec.rb
+++ b/spec/font_spec.rb
@@ -15,7 +15,7 @@ describe "Font objects" do
     font1 = Prawn::Document.new.font
     font2 = Prawn::Document.new.font
 
-    font1.should eql( font2 )
+    font1.should eql(font2)
   end
 
   it "should always be the same key" do
@@ -169,7 +169,7 @@ describe "font style support" do
   end
 
   it "should accept Pathname objects for font files" do
-    file = Pathname.new( "#{Prawn::DATADIR}/fonts/DejaVuSans.ttf" )
+    file = Pathname.new("#{Prawn::DATADIR}/fonts/DejaVuSans.ttf")
     @pdf.font_families["DejaVu Sans"] = {
       :normal => file
     }

--- a/spec/graphics_spec.rb
+++ b/spec/graphics_spec.rb
@@ -101,7 +101,7 @@ describe "When drawing a curve" do
   before(:each) { create_pdf }
 
   it "should draw a bezier curve from 50,50 to 100,100" do
-    @pdf.move_to  [50,50]
+    @pdf.move_to [50,50]
     @pdf.curve_to [100,100],:bounds => [[20,90], [90,70]]
     curve = PDF::Inspector::Graphics::Curve.analyze(@pdf.render)
     curve.coords.should == [50.0, 50.0, 20.0, 90.0, 90.0, 70.0, 100.0, 100.0]

--- a/spec/grid_spec.rb
+++ b/spec/grid_spec.rb
@@ -48,9 +48,9 @@ describe "A document's grid" do
 
     it "should give the edges of a grid box" do
       grid_width = (@pdf.bounds.width.to_f -
-        (@gutter * (@num_columns - 1).to_f )) / @num_columns.to_f
+        (@gutter * (@num_columns - 1).to_f)) / @num_columns.to_f
       grid_height = (@pdf.bounds.height.to_f -
-        (@gutter * (@num_rows - 1).to_f )) / @num_rows.to_f
+        (@gutter * (@num_rows - 1).to_f)) / @num_rows.to_f
 
       exp_tl_x = (grid_width + @gutter.to_f) * 4.0
       exp_tl_y = @pdf.bounds.height.to_f - (grid_height + @gutter.to_f)

--- a/spec/repeater_spec.rb
+++ b/spec/repeater_spec.rb
@@ -25,7 +25,7 @@ describe "Repeaters" do
     doc = sample_document
     r = repeater(doc, :odd) { :do_nothing }
 
-    odd, even = (1..doc.page_count).partition { |e| e % 2 == 1 }
+    odd, even = (1..doc.page_count).partition(&:odd?)
 
     odd.all? { |i| r.match?(i) }.should be_true
     even.any? { |i| r.match?(i) }.should be_false


### PR DESCRIPTION
This PR
- makes a few cops disabled with explanations
- enforces no spaces inside parenthesis
- enforces a preference for calling #even? and #odd? over modulo 2 operations
- enforces a single space before the first method argument
- enforces a preference for attr_reader for trivial accessors. 