### PR TITLE
Convert specs to RSpec 2.14.8 syntax with Transpec

### DIFF
--- a/spec/annotations_spec.rb
+++ b/spec/annotations_spec.rb
@@ -9,16 +9,16 @@ describe "When creating annotations" do
     @pdf.start_new_page
     @pdf.annotate(:Rect => [0,0,10,10], :Subtype => :Text, :Contents => "Hello world!")
     PDF::Reader.open(StringIO.new(@pdf.render)) do |pdf|
-      pdf.page(1).attributes[:Annots].should be_nil
-      pdf.page(2).attributes[:Annots].size.should == 1
+      expect(pdf.page(1).attributes[:Annots]).to be_nil
+      expect(pdf.page(2).attributes[:Annots].size).to eq(1)
     end
   end
 
   it "should force :Type to be :Annot" do
     opts = @pdf.annotate(:Rect => [0,0,10,10], :Subtype => :Text, :Contents => "Hello world!")
-    opts[:Type].should == :Annot
+    expect(opts[:Type]).to eq(:Annot)
     opts = @pdf.annotate(:Type => :Bogus, :Rect => [0,0,10,10], :Subtype => :Text, :Contents => "Hello world!")
-    opts[:Type].should == :Annot
+    expect(opts[:Type]).to eq(:Annot)
   end
 end
 
@@ -31,16 +31,16 @@ describe "When creating text annotations" do
 
   it "should build appropriate annotation" do
     opts = @pdf.text_annotation(@rect, @content)
-    opts[:Type].should == :Annot
-    opts[:Subtype].should == :Text
-    opts[:Rect].should == @rect
-    opts[:Contents].should == @content
+    expect(opts[:Type]).to eq(:Annot)
+    expect(opts[:Subtype]).to eq(:Text)
+    expect(opts[:Rect]).to eq(@rect)
+    expect(opts[:Contents]).to eq(@content)
   end
 
   it "should merge extra options" do
     opts = @pdf.text_annotation(@rect, @content, :Open => true, :Subtype => :Bogus)
-    opts[:Subtype].should == :Text
-    opts[:Open].should == true
+    expect(opts[:Subtype]).to eq(:Text)
+    expect(opts[:Open]).to eq(true)
   end
 end
 
@@ -53,15 +53,15 @@ describe "When creating link annotations" do
 
   it "should build appropriate annotation" do
     opts = @pdf.link_annotation(@rect, :Dest => @dest)
-    opts[:Type].should == :Annot
-    opts[:Subtype].should == :Link
-    opts[:Rect].should == @rect
-    opts[:Dest].should == @dest
+    expect(opts[:Type]).to eq(:Annot)
+    expect(opts[:Subtype]).to eq(:Link)
+    expect(opts[:Rect]).to eq(@rect)
+    expect(opts[:Dest]).to eq(@dest)
   end
 
   it "should merge extra options" do
     opts = @pdf.link_annotation(@rect, :Dest => @dest, :Subtype => :Bogus)
-    opts[:Subtype].should == :Link
-    opts[:Dest].should == @dest
+    expect(opts[:Subtype]).to eq(:Link)
+    expect(opts[:Dest]).to eq(@dest)
   end
 end

--- a/spec/bounding_box_spec.rb
+++ b/spec/bounding_box_spec.rb
@@ -16,84 +16,84 @@ describe "A bounding box" do
   end
 
   it "should have an anchor at (x, y - height)" do
-    @box.anchor.should == [@x,@y - @height]
+    expect(@box.anchor).to eq([@x,@y - @height])
   end
 
   it "should have a left boundary of 0" do
-    @box.left.should == 0
+    expect(@box.left).to eq(0)
   end
 
   it "should have a right boundary equal to the width" do
-    @box.right.should == @width
+    expect(@box.right).to eq(@width)
   end
 
   it "should have a top boundary of height" do
-    @box.top.should == @height
+    expect(@box.top).to eq(@height)
   end
 
   it "should have a bottom boundary of 0" do
-    @box.bottom.should == 0
+    expect(@box.bottom).to eq(0)
   end
 
   it "should have a top-left of [0,height]" do
-    @box.top_left.should == [0,@height]
+    expect(@box.top_left).to eq([0,@height])
   end
 
   it "should have a top-right of [width,height]" do
-    @box.top_right.should == [@width,@height]
+    expect(@box.top_right).to eq([@width,@height])
   end
 
   it "should have a bottom-left of [0,0]" do
-    @box.bottom_left.should == [0,0]
+    expect(@box.bottom_left).to eq([0,0])
   end
 
   it "should have a bottom-right of [width,0]" do
-    @box.bottom_right.should == [@width,0]
+    expect(@box.bottom_right).to eq([@width,0])
   end
 
   it "should have an absolute left boundary of x" do
-    @box.absolute_left.should == @x
+    expect(@box.absolute_left).to eq(@x)
   end
 
   it "should have an absolute right boundary of x + width" do
-    @box.absolute_right.should == @x + @width
+    expect(@box.absolute_right).to eq(@x + @width)
   end
 
   it "should have an absolute top boundary of y" do
-    @box.absolute_top.should == @y
+    expect(@box.absolute_top).to eq(@y)
   end
 
   it "should have an absolute bottom boundary of y - height" do
-    @box.absolute_bottom.should == @y - @height
+    expect(@box.absolute_bottom).to eq(@y - @height)
   end
 
   it "should have an absolute bottom-left of [x,y-height]" do
-    @box.absolute_bottom_left.should == [@x, @y - @height]
+    expect(@box.absolute_bottom_left).to eq([@x, @y - @height])
   end
 
   it "should have an absolute bottom-right of [x+width,y-height]" do
-    @box.absolute_bottom_right.should == [@x + @width , @y - @height]
+    expect(@box.absolute_bottom_right).to eq([@x + @width , @y - @height])
   end
 
   it "should have an absolute top-left of [x,y]" do
-    @box.absolute_top_left.should == [@x, @y]
+    expect(@box.absolute_top_left).to eq([@x, @y])
   end
 
   it "should have an absolute top-right of [x+width,y]" do
-    @box.absolute_top_right.should == [@x + @width, @y]
+    expect(@box.absolute_top_right).to eq([@x + @width, @y])
   end
 
   it "should require width to be set" do
-    lambda do
+    expect do
       Prawn::Document::BoundingBox.new(nil, nil, [100,100])
-    end.should raise_error(ArgumentError)
+    end.to raise_error(ArgumentError)
   end
 
   it "should raise_error an ArgumentError if a block is not passed" do
     pdf = Prawn::Document.new
-    lambda do
+    expect do
       pdf.bounding_box([0, 0], :width => 200)
-    end.should raise_error(ArgumentError)
+    end.to raise_error(ArgumentError)
   end
 end
 
@@ -106,7 +106,7 @@ describe "drawing bounding boxes" do
     pdf.bounding_box x, :width => 100 do
       pdf.text "bork-bork-bork"
     end
-    x.should == [100, 500]
+    expect(x).to eq([100, 500])
   end
 
   it "should restore Document#bounds to the correct margin box on exit" do
@@ -121,24 +121,24 @@ describe "drawing bounding boxes" do
 
     x_min, y_min, x_max, y_max = pdf.page.dimensions
 
-    pdf.bounds.absolute_top_left.should == [x_min, y_max]
-    pdf.bounds.absolute_bottom_right.should == [x_max, y_min]
+    expect(pdf.bounds.absolute_top_left).to eq([x_min, y_max])
+    expect(pdf.bounds.absolute_bottom_right).to eq([x_max, y_min])
   end
 
   it "should restore the parent bounding box when calls are nested" do
     @pdf.bounding_box [100,500], :width => 300, :height => 300 do
-      @pdf.bounds.absolute_top.should == 500 + @pdf.margin_box.absolute_bottom
-      @pdf.bounds.absolute_left.should == 100 + @pdf.margin_box.absolute_left
+      expect(@pdf.bounds.absolute_top).to eq(500 + @pdf.margin_box.absolute_bottom)
+      expect(@pdf.bounds.absolute_left).to eq(100 + @pdf.margin_box.absolute_left)
 
       parent_box = @pdf.bounds
 
       @pdf.bounding_box [50,200], :width => 100, :height => 100 do
-        @pdf.bounds.absolute_top.should == 200 + parent_box.absolute_bottom
-        @pdf.bounds.absolute_left.should == 50 + parent_box.absolute_left
+        expect(@pdf.bounds.absolute_top).to eq(200 + parent_box.absolute_bottom)
+        expect(@pdf.bounds.absolute_left).to eq(50 + parent_box.absolute_left)
       end
 
-      @pdf.bounds.absolute_top.should == 500 + @pdf.margin_box.absolute_bottom
-      @pdf.bounds.absolute_left.should == 100 + @pdf.margin_box.absolute_left
+      expect(@pdf.bounds.absolute_top).to eq(500 + @pdf.margin_box.absolute_bottom)
+      expect(@pdf.bounds.absolute_left).to eq(100 + @pdf.margin_box.absolute_left)
     end
   end
 
@@ -147,7 +147,7 @@ describe "drawing bounding boxes" do
       @pdf.text "The rain in Spain falls mainly on the plains."
     end
 
-    @pdf.y.should be_within(0.001).of(458.384)
+    expect(@pdf.y).to be_within(0.001).of(458.384)
   end
 
   it "should keep track of the max height the box was stretched to" do
@@ -156,7 +156,7 @@ describe "drawing bounding boxes" do
       @pdf.move_up 15
     end
 
-    box.height.should == 100
+    expect(box.height).to eq(100)
   end
 
   it "should advance the y-position by bbox.height by default" do
@@ -164,7 +164,7 @@ describe "drawing bounding boxes" do
     @pdf.bounding_box [0, @pdf.cursor], :width => @pdf.bounds.width, :height => 30 do
       @pdf.text "hello"
     end
-    @pdf.y.should be_within(0.001).of(orig_y - 30)
+    expect(@pdf.y).to be_within(0.001).of(orig_y - 30)
   end
 
   it "should not advance y-position if passed :hold_position => true" do
@@ -173,7 +173,7 @@ describe "drawing bounding boxes" do
       @pdf.text "hello"
     end
     # y only advances by height of one line ("hello")
-    @pdf.y.should be_within(0.001).of(orig_y - @pdf.height_of("hello"))
+    expect(@pdf.y).to be_within(0.001).of(orig_y - @pdf.height_of("hello"))
   end
 
   it "should not advance y-position of a stretchy bbox if it would stretch " \
@@ -183,13 +183,13 @@ describe "drawing bounding boxes" do
       @pdf.y = bottom
       @pdf.text "hello" # starts a new page
     end
-    @pdf.page_count.should == 2
+    expect(@pdf.page_count).to eq(2)
 
     # Restoring the position (to the absolute bottom) would stretch the bbox to
     # the bottom of the page, which we don't want. This should be equivalent to
     # a bbox with :hold_position => true, where we only advance by the amount
     # that was actually drawn.
-    @pdf.y.should be_within(0.001).of(
+    expect(@pdf.y).to be_within(0.001).of(
       @pdf.margin_box.absolute_top - @pdf.height_of("hello")
     )
   end
@@ -201,8 +201,8 @@ describe "Indentation" do
   it "should temporarily shift the x coordinate and width" do
     @pdf.bounding_box([100,100], :width => 200) do
       @pdf.indent(20) do
-        @pdf.bounds.absolute_left.should == 120
-        @pdf.bounds.width.should == 180
+        expect(@pdf.bounds.absolute_left).to eq(120)
+        expect(@pdf.bounds.width).to eq(180)
       end
     end
   end
@@ -212,8 +212,8 @@ describe "Indentation" do
       @pdf.indent(20) do
         # no-op
       end
-      @pdf.bounds.absolute_left.should == 100
-      @pdf.bounds.width.should == 200
+      expect(@pdf.bounds.absolute_left).to eq(100)
+      expect(@pdf.bounds.width).to eq(200)
     end
   end
 
@@ -222,8 +222,8 @@ describe "Indentation" do
       begin
         @pdf.indent(20) { raise }
       rescue
-        @pdf.bounds.absolute_left.should == 100
-        @pdf.bounds.width.should == 200
+        expect(@pdf.bounds.absolute_left).to eq(100)
+        expect(@pdf.bounds.width).to eq(200)
       end
     end
   end
@@ -232,34 +232,34 @@ describe "Indentation" do
     original_left = @pdf.bounds.absolute_left
 
     @pdf.indent(20) do
-      @pdf.bounds.absolute_left.should == original_left + 20
+      expect(@pdf.bounds.absolute_left).to eq(original_left + 20)
       @pdf.start_new_page
-      @pdf.bounds.absolute_left.should == original_left + 20
+      expect(@pdf.bounds.absolute_left).to eq(original_left + 20)
     end
 
-    @pdf.bounds.absolute_left.should == original_left
+    expect(@pdf.bounds.absolute_left).to eq(original_left)
   end
 
   it "should maintain right indentation across a page break" do
     original_width = @pdf.bounds.width
 
     @pdf.indent(0, 20) do
-      @pdf.bounds.width.should == original_width - 20
+      expect(@pdf.bounds.width).to eq(original_width - 20)
       @pdf.start_new_page
-      @pdf.bounds.width.should == original_width - 20
+      expect(@pdf.bounds.width).to eq(original_width - 20)
     end
 
-    @pdf.bounds.width.should == original_width
+    expect(@pdf.bounds.width).to eq(original_width)
   end
 
   it "optionally allows adjustment of the right bound as well" do
     @pdf.bounding_box([100,100], :width => 200) do
       @pdf.indent(20, 30) do
-        @pdf.bounds.absolute_left.should == 120
-        @pdf.bounds.width.should == 150
+        expect(@pdf.bounds.absolute_left).to eq(120)
+        expect(@pdf.bounds.width).to eq(150)
       end
-      @pdf.bounds.absolute_left.should == 100
-      @pdf.bounds.width.should == 200
+      expect(@pdf.bounds.absolute_left).to eq(100)
+      expect(@pdf.bounds.width).to eq(200)
     end
   end
 
@@ -268,7 +268,7 @@ describe "Indentation" do
       @pdf.column_box([0, @pdf.cursor], :width => @pdf.bounds.width, :height => 200, :columns => 2, :spacer => 20) do
         width = @pdf.bounds.width
         @pdf.indent(20) do
-          @pdf.bounds.width.should be_within(0.01).of(width - 20)
+          expect(@pdf.bounds.width).to be_within(0.01).of(width - 20)
         end
       end
     end
@@ -277,7 +277,7 @@ describe "Indentation" do
       @pdf.column_box([0, @pdf.cursor], :width => @pdf.bounds.width, :height => 200, :columns => 2, :spacer => 20) do
         width = @pdf.bounds.width
         @pdf.indent(20, 30) do
-          @pdf.bounds.width.should be_within(0.01).of(width - 50)
+          expect(@pdf.bounds.width).to be_within(0.01).of(width - 50)
         end
       end
     end
@@ -287,7 +287,7 @@ describe "Indentation" do
         3.times do |column|
           x = @pdf.bounds.left_side
           @pdf.indent(20) do
-            @pdf.bounds.left_side.should == x + 20
+            expect(@pdf.bounds.left_side).to eq(x + 20)
           end
           @pdf.bounds.move_past_bottom
         end
@@ -299,7 +299,7 @@ describe "Indentation" do
         3.times do |column|
           x = @pdf.bounds.right_side
           @pdf.indent(20) do
-            @pdf.bounds.right_side.should == x
+            expect(@pdf.bounds.right_side).to eq(x)
           end
           @pdf.bounds.move_past_bottom
         end
@@ -311,7 +311,7 @@ describe "Indentation" do
         3.times do |column|
           x = @pdf.bounds.right_side
           @pdf.indent(20, 10) do
-            @pdf.bounds.right_side.should == x - 10
+            expect(@pdf.bounds.right_side).to eq(x - 10)
           end
           @pdf.bounds.move_past_bottom
         end
@@ -327,7 +327,7 @@ describe "Indentation" do
             # ...and no right indent here...
             @pdf.indent(20) do
               # right indent is inherited from the parent!
-              @pdf.bounds.right_side.should == x
+              expect(@pdf.bounds.right_side).to eq(x)
             end
           end
           @pdf.bounds.move_past_bottom
@@ -343,7 +343,7 @@ describe "Indentation" do
             # requesting a negative right-indent of equivalent size...
             @pdf.indent(20, -10) do
               # ...resets the right margin to that of the column!
-              @pdf.bounds.right_side.should == x
+              expect(@pdf.bounds.right_side).to eq(x)
             end
           end
           @pdf.bounds.move_past_bottom
@@ -357,7 +357,7 @@ describe "Indentation" do
           w = @pdf.bounds.width
           @pdf.indent(20, 10) do
             @pdf.indent(20, 10) do
-              @pdf.bounds.width.should == w - 60
+              expect(@pdf.bounds.width).to eq(w - 60)
             end
           end
           @pdf.bounds.move_past_bottom
@@ -374,7 +374,7 @@ describe "A canvas" do
     @pdf.canvas do
       @pdf.bounding_box([100,500],:width => 200) { @pdf.move_down 50 }
     end
-    @pdf.y.should == 450
+    expect(@pdf.y).to eq(450)
   end
 
   it "should restore the original ypos after execution", :issue => 523 do
@@ -385,7 +385,7 @@ describe "A canvas" do
 
     doc.canvas {}
 
-    doc.y.should == original_ypos
+    expect(doc.y).to eq(original_ypos)
   end
 end
 
@@ -395,8 +395,8 @@ describe "Deep-copying" do
       orig = pdf.bounds
       copy = orig.deep_copy
 
-      copy.should_not == pdf.bounds
-      copy.document.should be_nil
+      expect(copy).not_to eq(pdf.bounds)
+      expect(copy.document).to be_nil
     end
   end
 
@@ -407,11 +407,11 @@ describe "Deep-copying" do
         copy = pdf.bounds.deep_copy
 
         # the parent bounds should have the same parameters
-        copy.parent.width.should == outside.width
-        copy.parent.height.should == outside.height
+        expect(copy.parent.width).to eq(outside.width)
+        expect(copy.parent.height).to eq(outside.height)
 
         # but should not be the same object
-        copy.parent.should_not == outside
+        expect(copy.parent).not_to eq(outside)
       end
     end
   end
@@ -422,7 +422,7 @@ describe "Prawn::Document#reference_bounds" do
 
   it "should return self for non-stretchy bounds" do
     @pdf.bounding_box([0, @pdf.cursor], :width => 100, :height => 100) do
-      @pdf.reference_bounds.should == @pdf.bounds
+      expect(@pdf.reference_bounds).to eq(@pdf.bounds)
     end
   end
 
@@ -430,7 +430,7 @@ describe "Prawn::Document#reference_bounds" do
     @pdf.bounding_box([0, @pdf.cursor], :width => 100, :height => 100) do
       correct_bounds = @pdf.bounds
       @pdf.bounding_box([0, @pdf.cursor], :width => 100) do
-        @pdf.reference_bounds.should == correct_bounds
+        expect(@pdf.reference_bounds).to eq(correct_bounds)
       end
     end
   end
@@ -440,17 +440,17 @@ describe "Prawn::Document#reference_bounds" do
       correct_bounds = @pdf.bounds
       @pdf.bounding_box([0, @pdf.cursor], :width => 100) do
         @pdf.bounding_box([0, @pdf.cursor], :width => 100) do
-          @pdf.reference_bounds.should == correct_bounds
+          expect(@pdf.reference_bounds).to eq(correct_bounds)
         end
       end
     end
   end
 
   it "should return the margin box if there's no explicit bbox" do
-    @pdf.reference_bounds.should == @pdf.margin_box
+    expect(@pdf.reference_bounds).to eq(@pdf.margin_box)
 
     @pdf.bounding_box([0, @pdf.cursor], :width => 100) do
-      @pdf.reference_bounds.should == @pdf.margin_box
+      expect(@pdf.reference_bounds).to eq(@pdf.margin_box)
     end
   end
 
@@ -458,10 +458,10 @@ describe "Prawn::Document#reference_bounds" do
     @pdf.canvas do
       canvas_box = @pdf.bounds
 
-      @pdf.reference_bounds.should == canvas_box
+      expect(@pdf.reference_bounds).to eq(canvas_box)
 
       @pdf.bounding_box([0, @pdf.cursor], :width => 100) do
-        @pdf.reference_bounds.should == canvas_box
+        expect(@pdf.reference_bounds).to eq(canvas_box)
       end
     end
   end
@@ -475,9 +475,9 @@ describe "BoundingBox#move_past_bottom" do
     @pdf.text "Foo"
 
     pages = PDF::Inspector::Page.analyze(@pdf.render).pages
-    pages.size.should == 2
-    pages[0][:strings].should == []
-    pages[1][:strings].should == ["Foo"]
+    expect(pages.size).to eq(2)
+    expect(pages[0][:strings]).to eq([])
+    expect(pages[1][:strings]).to eq(["Foo"])
   end
 
   it "should move to the top of the next page if it exists already" do
@@ -490,12 +490,12 @@ describe "BoundingBox#move_past_bottom" do
     @pdf.text "Foo"
 
     @pdf.bounds.move_past_bottom
-    @pdf.y.should be_within(0.001).of(top_y)
+    expect(@pdf.y).to be_within(0.001).of(top_y)
     @pdf.text "Bar"
 
     pages = PDF::Inspector::Page.analyze(@pdf.render).pages
-    pages.size.should == 2
-    pages[0][:strings].should == ["Foo"]
-    pages[1][:strings].should == ["Bar"]
+    expect(pages.size).to eq(2)
+    expect(pages[0][:strings]).to eq(["Foo"])
+    expect(pages[1][:strings]).to eq(["Bar"])
   end
 end

--- a/spec/column_box_spec.rb
+++ b/spec/column_box_spec.rb
@@ -11,21 +11,21 @@ describe "A column box" do
 
       @pdf.bounds.move_past_bottom # next column
 
-      @pdf.bounds.left.should be > left
-      @pdf.bounds.left.should be > right
-      @pdf.bounds.right.should be > @pdf.bounds.left
+      expect(@pdf.bounds.left).to be > left
+      expect(@pdf.bounds.left).to be > right
+      expect(@pdf.bounds.right).to be > @pdf.bounds.left
     end
   end
 
   it "includes spacers between columns but not at the end" do
     create_pdf
     @pdf.column_box [0, @pdf.cursor], :width => 500, :height => 200, :columns => 3, :spacer => 25 do
-      @pdf.bounds.width.should == 150 # (500 - (25 * 2)) / 3
+      expect(@pdf.bounds.width).to eq(150) # (500 - (25 * 2)) / 3
 
       @pdf.bounds.move_past_bottom
       @pdf.bounds.move_past_bottom
 
-      @pdf.bounds.right.should == 500
+      expect(@pdf.bounds.right).to eq(500)
     end
   end
 
@@ -38,8 +38,8 @@ describe "A column box" do
       @pdf.bounds.move_past_bottom
       @pdf.bounds.move_past_bottom
 
-      @pdf.bounds.absolute_top.should == init_column_top
-      @pdf.bounds.absolute_top.should_not == page_top
+      expect(@pdf.bounds.absolute_top).to eq(init_column_top)
+      expect(@pdf.bounds.absolute_top).not_to eq(page_top)
     end
   end
 
@@ -52,8 +52,8 @@ describe "A column box" do
       @pdf.bounds.move_past_bottom
       @pdf.bounds.move_past_bottom
 
-      @pdf.bounds.absolute_top.should == page_top
-      @pdf.bounds.absolute_top.should_not == init_column_top
+      expect(@pdf.bounds.absolute_top).to eq(page_top)
+      expect(@pdf.bounds.absolute_top).not_to eq(init_column_top)
     end
   end
 end

--- a/spec/destinations_spec.rb
+++ b/spec/destinations_spec.rb
@@ -6,8 +6,8 @@ describe "When creating destinations" do
   before(:each) { create_pdf }
 
   it "should add entry to Dests name tree" do
-    @pdf.dests.data.empty?.should == true
+    expect(@pdf.dests.data.empty?).to eq(true)
     @pdf.add_dest "candy", "chocolate"
-    @pdf.dests.data.size.should == 1
+    expect(@pdf.dests.data.size).to eq(1)
   end
 end

--- a/spec/document_spec.rb
+++ b/spec/document_spec.rb
@@ -7,25 +7,25 @@ describe "Prawn::Document.new" do
   it "should not modify its argument" do
     options = { :page_layout => :landscape }
     Prawn::Document.new(options)
-    options.should == { :page_layout => :landscape }
+    expect(options).to eq(:page_layout => :landscape)
   end
 end
 
 describe "The cursor" do
   it "should == pdf.y - bounds.absolute_bottom" do
     pdf = Prawn::Document.new
-    pdf.cursor.should == pdf.bounds.top
+    expect(pdf.cursor).to eq(pdf.bounds.top)
 
     pdf.y = 300
-    pdf.cursor.should == pdf.y - pdf.bounds.absolute_bottom
+    expect(pdf.cursor).to eq(pdf.y - pdf.bounds.absolute_bottom)
   end
 
   it "should be able to move relative to the bottom margin" do
     pdf = Prawn::Document.new
     pdf.move_cursor_to(10)
 
-    pdf.cursor.should == 10
-    pdf.y.should == pdf.cursor + pdf.bounds.absolute_bottom
+    expect(pdf.cursor).to eq(10)
+    expect(pdf.y).to eq(pdf.cursor + pdf.bounds.absolute_bottom)
   end
 end
 
@@ -51,7 +51,7 @@ describe "when generating a document with a custom text formatter" do
     pdf = Prawn::Document.new text_formatter: TestTextFormatter
     pdf.text "Dr. Who?", inline_format: true
     text = PDF::Inspector::Text.analyze(pdf.render)
-    text.strings.first.should == "Just 'The Doctor'."
+    expect(text.strings.first).to eq("Just 'The Doctor'.")
   end
 end
 
@@ -59,8 +59,8 @@ describe "when generating a document from a subclass" do
   it "should be an instance of the subclass" do
     custom_document = Class.new(Prawn::Document)
     custom_document.generate(Tempfile.new("generate_test").path) do |e|
-      e.class.should == custom_document
-      e.should be_a_kind_of(Prawn::Document)
+      expect(e.class).to eq(custom_document)
+      expect(e).to be_a_kind_of(Prawn::Document)
     end
   end
 
@@ -71,20 +71,20 @@ describe "when generating a document from a subclass" do
     Prawn::Document.extensions << mod1 << mod2
 
     custom_document = Class.new(Prawn::Document)
-    custom_document.extensions.should == [mod1, mod2]
+    expect(custom_document.extensions).to eq([mod1, mod2])
 
     # remove the extensions we added to prawn document
     Prawn::Document.extensions.delete(mod1)
     Prawn::Document.extensions.delete(mod2)
 
-    Prawn::Document.new.respond_to?(:test_extensions1).should be_false
-    Prawn::Document.new.respond_to?(:test_extensions2).should be_false
+    expect(Prawn::Document.new.respond_to?(:test_extensions1)).to be_false
+    expect(Prawn::Document.new.respond_to?(:test_extensions2)).to be_false
 
     # verify these still exist on custom class
-    custom_document.extensions.should == [mod1, mod2]
+    expect(custom_document.extensions).to eq([mod1, mod2])
 
-    custom_document.new.respond_to?(:test_extensions1).should be_true
-    custom_document.new.respond_to?(:test_extensions2).should be_true
+    expect(custom_document.new.respond_to?(:test_extensions1)).to be_true
+    expect(custom_document.new.respond_to?(:test_extensions2)).to be_true
   end
 end
 
@@ -94,16 +94,16 @@ describe "When creating multi-page documents" do
   it "should initialize with a single page" do
     page_counter = PDF::Inspector::Page.analyze(@pdf.render)
 
-    page_counter.pages.size.should == 1
-    @pdf.page_count.should == 1
+    expect(page_counter.pages.size).to eq(1)
+    expect(@pdf.page_count).to eq(1)
   end
 
   it "should provide an accurate page_count" do
     3.times { @pdf.start_new_page }
     page_counter = PDF::Inspector::Page.analyze(@pdf.render)
 
-    page_counter.pages.size.should == 4
-    @pdf.page_count.should == 4
+    expect(page_counter.pages.size).to eq(4)
+    expect(@pdf.page_count).to eq(4)
   end
 end
 
@@ -117,11 +117,11 @@ describe "When beginning each new page" do
       output = @pdf.render
       images = PDF::Inspector::XObject.analyze(output)
       # there should be 2 images in the page resources
-      images.page_xobjects.first.size.should == 1
+      expect(images.page_xobjects.first.size).to eq(1)
     end
     it "should place a background image if it is in options block" do
-      @pdf.instance_variable_defined?(:@background).should == true
-      @pdf.instance_variable_get(:@background).should == @filename
+      expect(@pdf.instance_variable_defined?(:@background)).to eq(true)
+      expect(@pdf.instance_variable_get(:@background)).to eq(@filename)
     end
   end
 end
@@ -131,7 +131,7 @@ describe "Prawn::Document#float" do
     create_pdf
     orig_y = @pdf.y
     @pdf.float { @pdf.text "Foo" }
-    @pdf.y.should == orig_y
+    expect(@pdf.y).to eq(orig_y)
   end
 
   it "should teleport across pages if necessary" do
@@ -145,28 +145,28 @@ describe "Prawn::Document#float" do
     @pdf.text "Baz"
 
     pages = PDF::Inspector::Page.analyze(@pdf.render).pages
-    pages.size.should == 2
-    pages[0][:strings].should == ["Foo", "Baz"]
-    pages[1][:strings].should == ["Bar"]
+    expect(pages.size).to eq(2)
+    expect(pages[0][:strings]).to eq(["Foo", "Baz"])
+    expect(pages[1][:strings]).to eq(["Bar"])
   end
 end
 
 describe "The page_number method" do
   it "should be 1 for a new document" do
     pdf = Prawn::Document.new
-    pdf.page_number.should == 1
+    expect(pdf.page_number).to eq(1)
   end
 
   it "should be 0 for documents with no pages" do
     pdf = Prawn::Document.new(:skip_page_creation => true)
-    pdf.page_number.should == 0
+    expect(pdf.page_number).to eq(0)
   end
 
   it "should be changed by go_to_page" do
     pdf = Prawn::Document.new
     10.times { pdf.start_new_page }
     pdf.go_to_page 3
-    pdf.page_number.should == 3
+    expect(pdf.page_number).to eq(3)
   end
 end
 
@@ -186,7 +186,7 @@ describe "on_page_create callback" do
 
     @pdf.start_new_page
 
-    called_with.should == [@pdf]
+    expect(called_with).to eq([@pdf])
   end
 
   it "should be invoked for each new page" do
@@ -255,16 +255,17 @@ describe "Document compression" do
       pdf.text "更可怕的是，同质化竞争对手可以按照URL中后面这个ID来遍历" * 10
     end
 
-    doc_compressed.render.length.should be < doc_uncompressed.render.length
+    expect(doc_compressed.render.length).to be < doc_uncompressed.render.length
   end
 end
 
 describe "Document metadata" do
   it "should output strings as UTF-16 with a byte order mark" do
     pdf = Prawn::Document.new(:info => { :Author => "Lóránt" })
-    pdf.state.store.info.object.should =~
+    expect(pdf.state.store.info.object).to match(
       # UTF-16:     BOM L   ó   r   á   n   t
       %r{/Author\s*<feff004c00f3007200e1006e0074>}i
+    )
   end
 end
 
@@ -294,12 +295,12 @@ describe "When reopening pages" do
     pdf.start_new_page
     pdf.text "New page 2"
 
-    pdf.page_number.should == 2
+    expect(pdf.page_number).to eq(2)
 
     pages = PDF::Inspector::Page.analyze(pdf.render).pages
-    pages.size.should == 5
-    pages[1][:strings].should == ["New page 2"]
-    pages[2][:strings].should == ["Old page 2"]
+    expect(pages.size).to eq(5)
+    expect(pages[1][:strings]).to eq(["New page 2"])
+    expect(pages[2][:strings]).to eq(["Old page 2"])
   end
 
   it "should restore the layout of the page" do
@@ -334,21 +335,21 @@ describe "When setting page size" do
   it "should default to LETTER" do
     @pdf = Prawn::Document.new
     pages = PDF::Inspector::Page.analyze(@pdf.render).pages
-    pages.first[:size].should == PDF::Core::PageGeometry::SIZES["LETTER"]
+    expect(pages.first[:size]).to eq(PDF::Core::PageGeometry::SIZES["LETTER"])
   end
 
   (PDF::Core::PageGeometry::SIZES.keys - ["LETTER"]).each do |k|
     it "should provide #{k} geometry" do
       @pdf = Prawn::Document.new(:page_size => k)
       pages = PDF::Inspector::Page.analyze(@pdf.render).pages
-      pages.first[:size].should == PDF::Core::PageGeometry::SIZES[k]
+      expect(pages.first[:size]).to eq(PDF::Core::PageGeometry::SIZES[k])
     end
   end
 
   it "should allow custom page size" do
     @pdf = Prawn::Document.new(:page_size => [1920, 1080])
     pages = PDF::Inspector::Page.analyze(@pdf.render).pages
-    pages.first[:size].should == [1920, 1080]
+    expect(pages.first[:size]).to eq([1920, 1080])
   end
 
   it "should retain page size by default when starting a new page" do
@@ -356,7 +357,7 @@ describe "When setting page size" do
     @pdf.start_new_page
     pages = PDF::Inspector::Page.analyze(@pdf.render).pages
     pages.each do |page|
-      page[:size].should == PDF::Core::PageGeometry::SIZES["LEGAL"]
+      expect(page[:size]).to eq(PDF::Core::PageGeometry::SIZES["LEGAL"])
     end
   end
 end
@@ -365,7 +366,7 @@ describe "When setting page layout" do
   it "should reverse coordinates for landscape" do
     @pdf = Prawn::Document.new(:page_size => "A4", :page_layout => :landscape)
     pages = PDF::Inspector::Page.analyze(@pdf.render).pages
-    pages.first[:size].should == PDF::Core::PageGeometry::SIZES["A4"].reverse
+    expect(pages.first[:size]).to eq(PDF::Core::PageGeometry::SIZES["A4"].reverse)
   end
 
   it "should retain page layout by default when starting a new page" do
@@ -373,7 +374,7 @@ describe "When setting page layout" do
     @pdf.start_new_page(:trace => true)
     pages = PDF::Inspector::Page.analyze(@pdf.render).pages
     pages.each do |page|
-      page[:size].should == PDF::Core::PageGeometry::SIZES["LETTER"].reverse
+      expect(page[:size]).to eq(PDF::Core::PageGeometry::SIZES["LETTER"].reverse)
     end
   end
 
@@ -381,7 +382,7 @@ describe "When setting page layout" do
     @pdf = Prawn::Document.new
     size = [@pdf.bounds.width, @pdf.bounds.height]
     @pdf.start_new_page(:layout => :landscape)
-    [@pdf.bounds.width, @pdf.bounds.height].should == size.reverse
+    expect([@pdf.bounds.width, @pdf.bounds.height]).to eq(size.reverse)
   end
 end
 
@@ -392,11 +393,11 @@ describe "The mask() feature" do
     @pdf.mask(:y, :line_width) do
       @pdf.y = y + 1
       @pdf.line_width = line_width + 1
-      @pdf.y.should_not == y
-      @pdf.line_width.should_not == line_width
+      expect(@pdf.y).not_to eq(y)
+      expect(@pdf.line_width).not_to eq(line_width)
     end
-    @pdf.y.should == y
-    @pdf.line_width.should == line_width
+    expect(@pdf.y).to eq(y)
+    expect(@pdf.line_width).to eq(line_width)
   end
 end
 
@@ -407,7 +408,7 @@ describe "The group() feature" do
         text "Hello"
         text "World"
       }
-      (!!val).should == true
+      expect(!!val).to eq(true)
     end
   end
 
@@ -420,22 +421,22 @@ describe "The group() feature" do
       end
 
       # group should return a false value since a new page was started
-      (!!val).should == false
+      expect(!!val).to eq(false)
     end
     pages = PDF::Inspector::Page.analyze(pdf.render).pages
-    pages.size.should == 2
-    pages[0][:strings].should == []
-    pages[1][:strings].should == ["Hello", "World"]
+    expect(pages.size).to eq(2)
+    expect(pages[0][:strings]).to eq([])
+    expect(pages[1][:strings]).to eq(["Hello", "World"])
   end
 
   xit "should raise_error CannotGroup if the content is too tall" do
-    lambda {
+    expect {
       Prawn::Document.new do
         group do
           100.times { text "Too long" }
         end
       end.render
-    }.should raise_error(Prawn::Errors::CannotGroup)
+    }.to raise_error(Prawn::Errors::CannotGroup)
   end
 
   xit "should group within individual column boxes" do
@@ -452,8 +453,8 @@ describe "The group() feature" do
 
     # Second page should start with a 0 because it's a new group.
     pages = PDF::Inspector::Page.analyze(pdf.render).pages
-    pages.size.should == 2
-    pages[1][:strings].first.should == '0'
+    expect(pages.size).to eq(2)
+    expect(pages[1][:strings].first).to eq('0')
   end
 end
 
@@ -462,7 +463,7 @@ describe "The render() feature" do
     @pdf = Prawn::Document.new(:page_size => "A4", :page_layout => :landscape)
     @pdf.line [100,100], [200,200]
     str = @pdf.render
-    str.encoding.to_s.should == "ASCII-8BIT"
+    expect(str.encoding.to_s).to eq("ASCII-8BIT")
   end
 
   it "should trigger before_render callbacks just before rendering" do
@@ -491,7 +492,7 @@ describe "The render() feature" do
 
     contents  = pdf.render
     contents2 = pdf.render
-    contents2.should == contents
+    expect(contents2).to eq(contents)
   end
 end
 
@@ -499,14 +500,14 @@ describe "PDF file versions" do
   it "should default to 1.3" do
     @pdf = Prawn::Document.new
     str = @pdf.render
-    str[0,8].should == "%PDF-1.3"
+    expect(str[0,8]).to eq("%PDF-1.3")
   end
 
   it "should allow the default to be changed" do
     @pdf = Prawn::Document.new
     @pdf.renderer.min_version(1.4)
     str = @pdf.render
-    str[0,8].should == "%PDF-1.4"
+    expect(str[0,8]).to eq("%PDF-1.4")
   end
 end
 
@@ -520,7 +521,7 @@ describe "Documents that use go_to_page" do
     @pdf.text "Healy"
 
     page_counter = PDF::Inspector::Page.analyze(@pdf.render)
-    page_counter.pages.size.should == 2
+    expect(page_counter.pages.size).to eq(2)
   end
 
   it "should correctly add text to pages" do
@@ -533,10 +534,10 @@ describe "Documents that use go_to_page" do
 
     text = PDF::Inspector::Text.analyze(@pdf.render)
 
-    text.strings.size.should == 3
-    text.strings.include?("James").should == true
-    text.strings.include?("Anthony").should == true
-    text.strings.include?("Healy").should == true
+    expect(text.strings.size).to eq(3)
+    expect(text.strings.include?("James")).to eq(true)
+    expect(text.strings.include?("Anthony")).to eq(true)
+    expect(text.strings.include?("Healy")).to eq(true)
   end
 end
 
@@ -549,7 +550,7 @@ describe "content stream characteristics" do
 
     streams = hash.values.select { |obj| obj.kind_of?(PDF::Reader::Stream) }
 
-    streams.size.should == 1
+    expect(streams.size).to eq(1)
   end
 
   it "should have 1 single content stream for a single page PDF, even if go_to_page is used" do
@@ -562,7 +563,7 @@ describe "content stream characteristics" do
 
     streams = hash.values.select { |obj| obj.kind_of?(PDF::Reader::Stream) }
 
-    streams.size.should == 1
+    expect(streams.size).to eq(1)
   end
 end
 
@@ -711,31 +712,31 @@ describe "The page_match? method" do
   end
 
   it "returns nil given no filter" do
-    @pdf.page_match?(:nil, 1).should be_false
+    expect(@pdf.page_match?(:nil, 1)).to be_false
   end
 
   it "must provide an :all filter" do
-    (1..@pdf.page_count).all? { |i| @pdf.page_match?(:all, i) }.should be_true
+    expect((1..@pdf.page_count).all? { |i| @pdf.page_match?(:all, i) }).to be_true
   end
 
   it "must provide an :odd filter" do
     odd, even = (1..@pdf.page_count).partition(&:odd?)
-    odd.all? { |i| @pdf.page_match?(:odd, i) }.should be_true
-    even.any? { |i| @pdf.page_match?(:odd, i) }.should be_false
+    expect(odd.all? { |i| @pdf.page_match?(:odd, i) }).to be_true
+    expect(even.any? { |i| @pdf.page_match?(:odd, i) }).to be_false
   end
 
   it "must be able to filter by an array of page numbers" do
     fltr = [1,2,7]
-    (1..10).select { |i| @pdf.page_match?(fltr, i) }.should == [1,2,7]
+    expect((1..10).select { |i| @pdf.page_match?(fltr, i) }).to eq([1,2,7])
   end
 
   it "must be able to filter by a range of page numbers" do
     fltr = 2..4
-    (1..10).select { |i| @pdf.page_match?(fltr, i) }.should == [2,3,4]
+    expect((1..10).select { |i| @pdf.page_match?(fltr, i) }).to eq([2,3,4])
   end
 
   it "must be able to filter by an arbitrary proc" do
     fltr = lambda { |x| x == 1 or x % 3 == 0 }
-    (1..10).select { |i| @pdf.page_match?(fltr, i) }.should == [1,3,6,9]
+    expect((1..10).select { |i| @pdf.page_match?(fltr, i) }).to eq([1,3,6,9])
   end
 end

--- a/spec/font_metric_cache_spec.rb
+++ b/spec/font_metric_cache_spec.rb
@@ -9,27 +9,27 @@ describe "Font metrics caching" do
   subject { Prawn::FontMetricCache.new(document) }
 
   it "should start with an empty cache" do
-    subject.instance_variable_get(:@cache).should be_empty
+    expect(subject.instance_variable_get(:@cache)).to be_empty
   end
 
   it "should cache the width of the provided string" do
     subject.width_of('M', {})
 
-    subject.instance_variable_get(:@cache).should have(1).entry
+    expect(subject.instance_variable_get(:@cache).size).to eq(1)
   end
 
   it "should only cache a single copy of the same string" do
     subject.width_of('M', {})
     subject.width_of('M', {})
 
-    subject.instance_variable_get(:@cache).should have(1).entry
+    expect(subject.instance_variable_get(:@cache).size).to eq(1)
   end
 
   it "should cache different copies for different strings" do
     subject.width_of('M', {})
     subject.width_of('W', {})
 
-    subject.instance_variable_get(:@cache).should have(2).entries
+    expect(subject.instance_variable_get(:@cache).entries.size).to eq(2)
   end
 
   it "should cache different copies of the same string with different font sizes" do
@@ -38,7 +38,7 @@ describe "Font metrics caching" do
     document.font_size 24
     subject.width_of('M', {})
 
-    subject.instance_variable_get(:@cache).should have(2).entries
+    expect(subject.instance_variable_get(:@cache).entries.size).to eq(2)
   end
 
   it "should cache different copies of the same string with different fonts" do
@@ -47,6 +47,6 @@ describe "Font metrics caching" do
     document.font 'Courier'
     subject.width_of('M', {})
 
-    subject.instance_variable_get(:@cache).should have(2).entries
+    expect(subject.instance_variable_get(:@cache).entries.size).to eq(2)
   end
 end

--- a/spec/font_spec.rb
+++ b/spec/font_spec.rb
@@ -6,7 +6,7 @@ require 'pathname'
 describe "Font behavior" do
   it "should default to Helvetica if no font is specified" do
     @pdf = Prawn::Document.new
-    @pdf.font.name.should == "Helvetica"
+    expect(@pdf.font.name).to eq("Helvetica")
   end
 end
 
@@ -15,7 +15,7 @@ describe "Font objects" do
     font1 = Prawn::Document.new.font
     font2 = Prawn::Document.new.font
 
-    font1.should eql(font2)
+    expect(font1).to eql(font2)
   end
 
   it "should always be the same key" do
@@ -27,10 +27,10 @@ describe "Font objects" do
     hash[ font1 ] = "Original"
     hash[ font2 ] = "Overwritten"
 
-    hash.size.should == 1
+    expect(hash.size).to eq(1)
 
-    hash[ font1 ].should == "Overwritten"
-    hash[ font2 ].should == "Overwritten"
+    expect(hash[ font1 ]).to eq("Overwritten")
+    expect(hash[ font2 ]).to eq("Overwritten")
   end
 end
 
@@ -39,7 +39,7 @@ describe "#width_of" do
     create_pdf
     original_width = @pdf.width_of("hello world")
     @pdf.character_spacing(7) do
-      @pdf.width_of("hello world").should == original_width + 11 * 7
+      expect(@pdf.width_of("hello world")).to eq(original_width + 11 * 7)
     end
   end
 
@@ -48,8 +48,9 @@ describe "#width_of" do
     # Use a TTF font that has a non-zero width for \n
     @pdf.font("#{Prawn::DATADIR}/fonts/gkai00mp.ttf")
 
-    @pdf.width_of("\nhello world\n").should ==
+    expect(@pdf.width_of("\nhello world\n")).to eq(
       @pdf.width_of("hello world")
+    )
   end
 
   it "should take formatting into account" do
@@ -61,8 +62,8 @@ describe "#width_of" do
       @bold_hello = @pdf.width_of("hello")
     }
 
-    inline_bold_hello.should be > normal_hello
-    inline_bold_hello.should == @bold_hello
+    expect(inline_bold_hello).to be > normal_hello
+    expect(inline_bold_hello).to eq(@bold_hello)
   end
 
   it "should accept :style as an argument" do
@@ -73,7 +74,7 @@ describe "#width_of" do
       @bold_hello = @pdf.width_of("hello")
     }
 
-    styled_bold_hello.should == @bold_hello
+    expect(styled_bold_hello).to eq(@bold_hello)
   end
 
   it "should calculate styled widths correctly using TTFs" do
@@ -96,15 +97,15 @@ describe "#width_of" do
       @plain_hello = @pdf.width_of("hello")
     }
 
-    @plain_hello.should_not == @bold_hello
+    expect(@plain_hello).not_to eq(@bold_hello)
 
-    @styled_bold_hello.should == @bold_hello
+    expect(@styled_bold_hello).to eq(@bold_hello)
   end
 
   it "should not treat minus as if it were a hyphen", :issue => 578 do
     create_pdf
 
-    @pdf.width_of("-0.75").should be < @pdf.width_of("25.00")
+    expect(@pdf.width_of("-0.75")).to be < @pdf.width_of("25.00")
   end
 end
 
@@ -112,7 +113,7 @@ describe "#font_size" do
   it "should allow setting font size in DSL style" do
     create_pdf
     @pdf.font_size 20
-    @pdf.font_size.should == 20
+    expect(@pdf.font_size).to eq(20)
   end
 end
 
@@ -122,8 +123,8 @@ describe "font style support" do
   it "should complain if there is no @current_page" do
     pdf_without_page = Prawn::Document.new(:skip_page_creation => true)
 
-    lambda{ pdf_without_page.font "Helvetica" }.
-      should raise_error(Prawn::Errors::NotOnPage)
+    expect{ pdf_without_page.font "Helvetica" }.
+      to raise_error(Prawn::Errors::NotOnPage)
   end
 
   it "should allow specifying font style by style name and font family" do
@@ -143,11 +144,12 @@ describe "font style support" do
     @pdf.text "In Normal Helvetica"
 
     text = PDF::Inspector::Text.analyze(@pdf.render)
-    text.font_settings.map { |e| e[:name] }.should ==
+    expect(text.font_settings.map { |e| e[:name] }).to eq(
       [
         :"Courier-Bold", :"Courier-BoldOblique", :"Courier-Oblique",
         :Courier, :Helvetica
       ]
+    )
   end
 
   it "should allow font familes to be defined in a single dfont" do
@@ -165,7 +167,7 @@ describe "font style support" do
     text = PDF::Inspector::Text.analyze(@pdf.render)
     name = text.font_settings.map { |e| e[:name] }.first.to_s
     name = name.sub(/\w+\+/, "subset+")
-    name.should == "subset+PanicSans-Italic"
+    expect(name).to eq("subset+PanicSans-Italic")
   end
 
   it "should accept Pathname objects for font files" do
@@ -180,7 +182,7 @@ describe "font style support" do
     text = PDF::Inspector::Text.analyze(@pdf.render)
     name = text.font_settings.map { |e| e[:name] }.first.to_s
     name = name.sub(/\w+\+/, "subset+")
-    name.should == "subset+DejaVuSans"
+    expect(name).to eq("subset+DejaVuSans")
   end
 
   it "should accept IO objects for font files" do
@@ -195,7 +197,7 @@ describe "font style support" do
     text = PDF::Inspector::Text.analyze(@pdf.render)
     name = text.font_settings.map { |e| e[:name] }.first.to_s
     name = name.sub(/\w+\+/, "subset+")
-    name.should == "subset+DejaVuSans"
+    expect(name).to eq("subset+DejaVuSans")
   end
 end
 
@@ -204,30 +206,30 @@ describe "Transactional font handling" do
 
   it "should allow setting of size directly when font is created" do
     @pdf.font "Courier", :size => 16
-    @pdf.font_size.should == 16
+    expect(@pdf.font_size).to eq(16)
   end
 
   it "should allow temporary setting of a new font using a transaction" do
     @pdf.font "Helvetica", :size => 12
 
     @pdf.font "Courier", :size => 16 do
-      @pdf.font.name.should == "Courier"
-      @pdf.font_size.should == 16
+      expect(@pdf.font.name).to eq("Courier")
+      expect(@pdf.font_size).to eq(16)
     end
 
-    @pdf.font.name.should == "Helvetica"
-    @pdf.font_size.should == 12
+    expect(@pdf.font.name).to eq("Helvetica")
+    expect(@pdf.font_size).to eq(12)
   end
 
   it "should mask font size when using a transacation" do
     @pdf.font "Courier", :size => 16 do
-      @pdf.font_size.should == 16
+      expect(@pdf.font_size).to eq(16)
     end
 
     @pdf.font "Times-Roman"
     @pdf.font "Courier"
 
-    @pdf.font_size.should == 12
+    expect(@pdf.font_size).to eq(12)
   end
 end
 
@@ -263,11 +265,11 @@ describe "Document#page_fonts" do
   end
 
   def page_should_include_font(font)
-    page_includes_font?(font).should be_true
+    expect(page_includes_font?(font)).to be_true
   end
 
   def page_should_not_include_font(font)
-    page_includes_font?(font).should be_false
+    expect(page_includes_font?(font)).to be_false
   end
 end
 
@@ -279,52 +281,52 @@ describe "AFM fonts" do
 
   it "should calculate string width taking into account accented characters" do
     input = win1252_string("\xE9") # é in win-1252
-    @times.compute_width_of(input, :size => 12).should == @times.compute_width_of("e", :size => 12)
+    expect(@times.compute_width_of(input, :size => 12)).to eq(@times.compute_width_of("e", :size => 12))
   end
 
   it "should calculate string width taking into account kerning pairs" do
-    @times.compute_width_of(win1252_string("To"), :size => 12).should == 13.332
-    @times.compute_width_of(win1252_string("To"), :size => 12, :kerning => true).should == 12.372
+    expect(@times.compute_width_of(win1252_string("To"), :size => 12)).to eq(13.332)
+    expect(@times.compute_width_of(win1252_string("To"), :size => 12, :kerning => true)).to eq(12.372)
 
     input = win1252_string("T\xF6") # Tö in win-1252
-    @times.compute_width_of(input, :size => 12, :kerning => true).should == 12.372
+    expect(@times.compute_width_of(input, :size => 12, :kerning => true)).to eq(12.372)
   end
 
   it "should encode text without kerning by default" do
-    @times.encode_text(win1252_string("To")).should == [[0, "To"]]
+    expect(@times.encode_text(win1252_string("To"))).to eq([[0, "To"]])
     input = win1252_string("T\xE9l\xE9") # Télé in win-1252
-    @times.encode_text(input).should == [[0, input]]
-    @times.encode_text(win1252_string("Technology")).should == [[0, "Technology"]]
-    @times.encode_text(win1252_string("Technology...")).should == [[0, "Technology..."]]
+    expect(@times.encode_text(input)).to eq([[0, input]])
+    expect(@times.encode_text(win1252_string("Technology"))).to eq([[0, "Technology"]])
+    expect(@times.encode_text(win1252_string("Technology..."))).to eq([[0, "Technology..."]])
   end
 
   it "should encode text with kerning if requested" do
-    @times.encode_text(win1252_string("To"), :kerning => true).should == [[0, ["T", 80, "o"]]]
+    expect(@times.encode_text(win1252_string("To"), :kerning => true)).to eq([[0, ["T", 80, "o"]]])
     input  = win1252_string("T\xE9l\xE9") # Télé in win-1252
     output = win1252_string("\xE9l\xE9")  # élé  in win-1252
-    @times.encode_text(input, :kerning => true).should == [[0, ["T", 70, output]]]
-    @times.encode_text(win1252_string("Technology"), :kerning => true).should == [[0, ["T", 70, "echnology"]]]
-    @times.encode_text(win1252_string("Technology..."), :kerning => true).should == [[0, ["T", 70, "echnology", 65, "..."]]]
+    expect(@times.encode_text(input, :kerning => true)).to eq([[0, ["T", 70, output]]])
+    expect(@times.encode_text(win1252_string("Technology"), :kerning => true)).to eq([[0, ["T", 70, "echnology"]]])
+    expect(@times.encode_text(win1252_string("Technology..."), :kerning => true)).to eq([[0, ["T", 70, "echnology", 65, "..."]]])
   end
 
   describe "when normalizing encoding" do
     it "should not modify the original string when normalize_encoding() is used" do
       original = "Foo"
       normalized = @times.normalize_encoding(original)
-      original.equal?(normalized).should be_false
+      expect(original.equal?(normalized)).to be_false
     end
 
     it "should modify the original string when normalize_encoding!() is used" do
       original = "Foo"
       normalized = @times.normalize_encoding!(original)
-      original.equal?(normalized).should be_true
+      expect(original.equal?(normalized)).to be_true
     end
   end
 
   it "should omit /Encoding for symbolic fonts" do
     zapf = @pdf.find_font "ZapfDingbats"
     font_dict = zapf.send(:register, nil)
-    font_dict.data[:Encoding].should be_nil
+    expect(font_dict.data[:Encoding]).to be_nil
   end
 end
 
@@ -333,25 +335,25 @@ describe "#glyph_present" do
 
   it "should return true when present in an AFM font" do
     font = @pdf.find_font("Helvetica")
-    font.glyph_present?("H").should be_true
+    expect(font.glyph_present?("H")).to be_true
   end
 
   it "should return false when absent in an AFM font" do
     font = @pdf.find_font("Helvetica")
-    font.glyph_present?("再").should be_false
+    expect(font.glyph_present?("再")).to be_false
   end
 
   it "should return true when present in a TTF font" do
     font = @pdf.find_font("#{Prawn::DATADIR}/fonts/DejaVuSans.ttf")
-    font.glyph_present?("H").should be_true
+    expect(font.glyph_present?("H")).to be_true
   end
 
   it "should return false when absent in a TTF font" do
     font = @pdf.find_font("#{Prawn::DATADIR}/fonts/DejaVuSans.ttf")
-    font.glyph_present?("再").should be_false
+    expect(font.glyph_present?("再")).to be_false
 
     font = @pdf.find_font("#{Prawn::DATADIR}/fonts/gkai00mp.ttf")
-    font.glyph_present?("€").should be_false
+    expect(font.glyph_present?("€")).to be_false
   end
 end
 
@@ -362,33 +364,33 @@ describe "TTF fonts" do
   end
 
   it "should calculate string width taking into account accented characters" do
-    @font.compute_width_of("é", :size => 12).should == @font.compute_width_of("e", :size => 12)
+    expect(@font.compute_width_of("é", :size => 12)).to eq(@font.compute_width_of("e", :size => 12))
   end
 
   it "should calculate string width taking into account kerning pairs" do
-    @font.compute_width_of("To", :size => 12).should be_within(0.01).of(14.65)
-    @font.compute_width_of("To", :size => 12, :kerning => true).should be_within(0.01).of(12.61)
+    expect(@font.compute_width_of("To", :size => 12)).to be_within(0.01).of(14.65)
+    expect(@font.compute_width_of("To", :size => 12, :kerning => true)).to be_within(0.01).of(12.61)
   end
 
   it "should encode text without kerning by default" do
-    @font.encode_text("To").should == [[0, "To"]]
+    expect(@font.encode_text("To")).to eq([[0, "To"]])
 
     tele = "T\216l\216"
     result = @font.encode_text("Télé")
-    result.length.should == 1
-    result[0][0].should == 0
-    result[0][1].bytes.to_a.should == tele.bytes.to_a
+    expect(result.length).to eq(1)
+    expect(result[0][0]).to eq(0)
+    expect(result[0][1].bytes.to_a).to eq(tele.bytes.to_a)
 
-    @font.encode_text("Technology").should == [[0, "Technology"]]
-    @font.encode_text("Technology...").should == [[0, "Technology..."]]
-    @font.encode_text("Teχnology...").should == [[0, "Te"], [1, "!"], [0, "nology..."]]
+    expect(@font.encode_text("Technology")).to eq([[0, "Technology"]])
+    expect(@font.encode_text("Technology...")).to eq([[0, "Technology..."]])
+    expect(@font.encode_text("Teχnology...")).to eq([[0, "Te"], [1, "!"], [0, "nology..."]])
   end
 
   it "should encode text with kerning if requested" do
-    @font.encode_text("To", :kerning => true).should == [[0, ["T", 169.921875, "o"]]]
-    @font.encode_text("Technology", :kerning => true).should == [[0, ["T", 169.921875, "echnology"]]]
-    @font.encode_text("Technology...", :kerning => true).should == [[0, ["T", 169.921875, "echnology", 142.578125, "..."]]]
-    @font.encode_text("Teχnology...", :kerning => true).should == [[0, ["T", 169.921875, "e"]], [1, "!"], [0, ["nology", 142.578125, "..."]]]
+    expect(@font.encode_text("To", :kerning => true)).to eq([[0, ["T", 169.921875, "o"]]])
+    expect(@font.encode_text("Technology", :kerning => true)).to eq([[0, ["T", 169.921875, "echnology"]]])
+    expect(@font.encode_text("Technology...", :kerning => true)).to eq([[0, ["T", 169.921875, "echnology", 142.578125, "..."]]])
+    expect(@font.encode_text("Teχnology...", :kerning => true)).to eq([[0, ["T", 169.921875, "e"]], [1, "!"], [0, ["nology", 142.578125, "..."]]])
   end
 
   it "should use the ascender, descender, and cap height from the TTF verbatim" do
@@ -399,22 +401,22 @@ describe "TTF fonts" do
 
     # Pull out the embedded font descriptor
     descriptor = ref.data[:FontDescriptor].data
-    descriptor[:Ascent].should == 759
-    descriptor[:Descent].should == -240
-    descriptor[:CapHeight].should == 759
+    expect(descriptor[:Ascent]).to eq(759)
+    expect(descriptor[:Descent]).to eq(-240)
+    expect(descriptor[:CapHeight]).to eq(759)
   end
 
   describe "when normalizing encoding" do
     it "should not modify the original string when normalize_encoding() is used" do
       original = "Foo"
       normalized = @font.normalize_encoding(original)
-      original.equal?(normalized).should be_false
+      expect(original.equal?(normalized)).to be_false
     end
 
     it "should modify the original string when normalize_encoding!() is used" do
       original = "Foo"
       normalized = @font.normalize_encoding!(original)
-      original.equal?(normalized).should be_true
+      expect(original.equal?(normalized)).to be_true
     end
   end
 end
@@ -427,34 +429,34 @@ describe "DFont fonts" do
 
   it "should list all named fonts" do
     list = Prawn::Font::DFont.named_fonts(@file)
-    list.sort.should == %w(PanicSans PanicSans-Italic PanicSans-Bold PanicSans-BoldItalic).sort
+    expect(list.sort).to eq(%w(PanicSans PanicSans-Italic PanicSans-Bold PanicSans-BoldItalic).sort)
   end
 
   it "should count the number of fonts in the file" do
-    Prawn::Font::DFont.font_count(@file).should == 4
+    expect(Prawn::Font::DFont.font_count(@file)).to eq(4)
   end
 
   it "should default selected font to the first one if not specified" do
     font = @pdf.find_font(@file)
-    font.basename.should == "PanicSans"
+    expect(font.basename).to eq("PanicSans")
   end
 
   it "should allow font to be selected by index" do
     font = @pdf.find_font(@file, :font => 2)
-    font.basename.should == "PanicSans-Italic"
+    expect(font.basename).to eq("PanicSans-Italic")
   end
 
   it "should allow font to be selected by name" do
     font = @pdf.find_font(@file, :font => "PanicSans-BoldItalic")
-    font.basename.should == "PanicSans-BoldItalic"
+    expect(font.basename).to eq("PanicSans-BoldItalic")
   end
 
   it "should cache font object based on selected font" do
     f1 = @pdf.find_font(@file, :font => "PanicSans")
     f2 = @pdf.find_font(@file, :font => "PanicSans-Bold")
-    f2.object_id.should_not == f1.object_id
-    @pdf.find_font(@file, :font => "PanicSans").object_id.should == f1.object_id
-    @pdf.find_font(@file, :font => "PanicSans-Bold").object_id.should == f2.object_id
+    expect(f2.object_id).not_to eq(f1.object_id)
+    expect(@pdf.find_font(@file, :font => "PanicSans").object_id).to eq(f1.object_id)
+    expect(@pdf.find_font(@file, :font => "PanicSans-Bold").object_id).to eq(f2.object_id)
   end
 end
 
@@ -462,12 +464,12 @@ describe "#character_count(text)" do
   it "should work on TTF fonts" do
     create_pdf
     @pdf.font("#{Prawn::DATADIR}/fonts/gkai00mp.ttf")
-    @pdf.font.character_count("こんにちは世界").should == 7
-    @pdf.font.character_count("Hello, world!").should == 13
+    expect(@pdf.font.character_count("こんにちは世界")).to eq(7)
+    expect(@pdf.font.character_count("Hello, world!")).to eq(13)
   end
 
   it "should work on AFM fonts" do
     create_pdf
-    @pdf.font.character_count("Hello, world!").should == 13
+    expect(@pdf.font.character_count("Hello, world!")).to eq(13)
   end
 end

--- a/spec/formatted_text_arranger_spec.rb
+++ b/spec/formatted_text_arranger_spec.rb
@@ -11,22 +11,22 @@ describe "Core::Text::Formatted::Arranger#format_array" do
              { :text => "are", :styles => [:bold, :italic] },
              { :text => " you?" }]
     arranger.format_array = array
-    arranger.unconsumed[0].should == { :text => "hello " }
-    arranger.unconsumed[1].should == { :text => "world how ",
-                                       :styles => [:bold] }
-    arranger.unconsumed[2].should == { :text => "are",
-                                       :styles => [:bold, :italic] }
-    arranger.unconsumed[3].should == { :text => " you?" }
+    expect(arranger.unconsumed[0]).to eq(:text => "hello ")
+    expect(arranger.unconsumed[1]).to eq(:text => "world how ",
+                                         :styles => [:bold])
+    expect(arranger.unconsumed[2]).to eq(:text => "are",
+                                         :styles => [:bold, :italic])
+    expect(arranger.unconsumed[3]).to eq(:text => " you?")
   end
   it "should split newlines into their own elements" do
     create_pdf
     arranger = Prawn::Text::Formatted::Arranger.new(@pdf)
     array = [{ :text => "\nhello\nworld" }]
     arranger.format_array = array
-    arranger.unconsumed[0].should == { :text => "\n" }
-    arranger.unconsumed[1].should == { :text => "hello" }
-    arranger.unconsumed[2].should == { :text => "\n" }
-    arranger.unconsumed[3].should == { :text => "world" }
+    expect(arranger.unconsumed[0]).to eq(:text => "\n")
+    expect(arranger.unconsumed[1]).to eq(:text => "hello")
+    expect(arranger.unconsumed[2]).to eq(:text => "\n")
+    expect(arranger.unconsumed[3]).to eq(:text => "world")
   end
 end
 describe "Core::Text::Formatted::Arranger#preview_next_string" do
@@ -36,14 +36,14 @@ describe "Core::Text::Formatted::Arranger#preview_next_string" do
     array = [{ :text => "hello" }]
     arranger.format_array = array
     arranger.preview_next_string
-    arranger.consumed.should == []
+    expect(arranger.consumed).to eq([])
   end
   it "should not consumed array" do
     create_pdf
     arranger = Prawn::Text::Formatted::Arranger.new(@pdf)
     array = [{ :text => "hello" }]
     arranger.format_array = array
-    arranger.preview_next_string.should == "hello"
+    expect(arranger.preview_next_string).to eq("hello")
   end
 end
 describe "Core::Text::Formatted::Arranger#next_string" do
@@ -59,19 +59,19 @@ describe "Core::Text::Formatted::Arranger#next_string" do
   it "should raise_error an error if called after a line was finalized and" \
      " before a new line was initialized" do
     @arranger.finalize_line
-    lambda do
+    expect do
       @arranger.next_string
-    end.should raise_error(RuntimeError)
+    end.to raise_error(RuntimeError)
   end
   it "should populate consumed array" do
     while string = @arranger.next_string
     end
-    @arranger.consumed[0].should == { :text => "hello " }
-    @arranger.consumed[1].should == { :text => "world how ",
-                                      :styles => [:bold] }
-    @arranger.consumed[2].should == { :text => "are",
-                                      :styles => [:bold, :italic] }
-    @arranger.consumed[3].should == { :text => " you?" }
+    expect(@arranger.consumed[0]).to eq(:text => "hello ")
+    expect(@arranger.consumed[1]).to eq(:text => "world how ",
+                                        :styles => [:bold])
+    expect(@arranger.consumed[2]).to eq(:text => "are",
+                                        :styles => [:bold, :italic])
+    expect(@arranger.consumed[3]).to eq(:text => " you?")
   end
   it "should populate current_format_state array" do
     create_pdf
@@ -85,13 +85,13 @@ describe "Core::Text::Formatted::Arranger#next_string" do
     while string = arranger.next_string
       case counter
       when 0
-        arranger.current_format_state.should == {}
+        expect(arranger.current_format_state).to eq({})
       when 1
-        arranger.current_format_state.should == { :styles => [:bold] }
+        expect(arranger.current_format_state).to eq(:styles => [:bold])
       when 2
-        arranger.current_format_state.should == { :styles => [:bold, :italic] }
+        expect(arranger.current_format_state).to eq(:styles => [:bold, :italic])
       when 3
-        arranger.current_format_state.should == {}
+        expect(arranger.current_format_state).to eq({})
       end
       counter += 1
     end
@@ -109,9 +109,9 @@ describe "Core::Text::Formatted::Arranger#retrieve_fragment" do
     arranger.format_array = array
     while string = arranger.next_string
     end
-    lambda do
+    expect do
       arranger.retrieve_fragment
-    end.should raise_error(RuntimeError)
+    end.to raise_error(RuntimeError)
   end
   it "should return the consumed fragments in order of consumption" \
      " and update" do
@@ -125,10 +125,10 @@ describe "Core::Text::Formatted::Arranger#retrieve_fragment" do
     while string = arranger.next_string
     end
     arranger.finalize_line
-    arranger.retrieve_fragment.text.should == "hello "
-    arranger.retrieve_fragment.text.should == "world how "
-    arranger.retrieve_fragment.text.should == "are"
-    arranger.retrieve_fragment.text.should == " you?"
+    expect(arranger.retrieve_fragment.text).to eq("hello ")
+    expect(arranger.retrieve_fragment.text).to eq("world how ")
+    expect(arranger.retrieve_fragment.text).to eq("are")
+    expect(arranger.retrieve_fragment.text).to eq(" you?")
   end
   it "should never return a fragment whose text is an empty string" do
     create_pdf
@@ -147,7 +147,7 @@ describe "Core::Text::Formatted::Arranger#retrieve_fragment" do
     end
     arranger.finalize_line
     while fragment = arranger.retrieve_fragment
-      fragment.text.should_not be_empty
+      expect(fragment.text).not_to be_empty
     end
   end
   it "should not alter the current font style" do
@@ -162,7 +162,7 @@ describe "Core::Text::Formatted::Arranger#retrieve_fragment" do
     end
     arranger.finalize_line
     arranger.retrieve_fragment
-    arranger.current_format_state[:styles].should be_nil
+    expect(arranger.current_format_state[:styles]).to be_nil
   end
 end
 
@@ -179,10 +179,10 @@ describe "Core::Text::Formatted::Arranger#update_last_string" do
     while string = arranger.next_string
     end
     arranger.update_last_string(" you", " now?", nil)
-    arranger.consumed[3].should == { :text => " you",
-                                     :styles => [:bold, :italic] }
-    arranger.unconsumed.should == [{ :text => " now?",
-                                     :styles => [:bold, :italic] }]
+    expect(arranger.consumed[3]).to eq(:text => " you",
+                                       :styles => [:bold, :italic])
+    expect(arranger.unconsumed).to eq([{ :text => " now?",
+                                         :styles => [:bold, :italic] }])
   end
   it "should set the format state to the previously processed fragment" do
     create_pdf
@@ -193,9 +193,9 @@ describe "Core::Text::Formatted::Arranger#update_last_string" do
              { :text => " you now?" }]
     arranger.format_array = array
     3.times { arranger.next_string }
-    arranger.current_format_state.should == { :styles => [:bold, :italic] }
+    expect(arranger.current_format_state).to eq(:styles => [:bold, :italic])
     arranger.update_last_string("", "are", "-")
-    arranger.current_format_state.should == { :styles => [:bold] }
+    expect(arranger.current_format_state).to eq(:styles => [:bold])
   end
 
   context "when the entire string was used" do
@@ -212,7 +212,7 @@ describe "Core::Text::Formatted::Arranger#update_last_string" do
       while string = arranger.next_string
       end
       arranger.update_last_string(" you now?", "", nil)
-      arranger.unconsumed.should == []
+      expect(arranger.unconsumed).to eq([])
     end
   end
 end
@@ -229,13 +229,13 @@ describe "Core::Text::Formatted::Arranger#space_count" do
     end
   end
   it "should raise_error an error if called before finalize_line was called" do
-    lambda do
+    expect do
       @arranger.space_count
-    end.should raise_error(RuntimeError)
+    end.to raise_error(RuntimeError)
   end
   it "should return the total number of spaces in all fragments" do
     @arranger.finalize_line
-    @arranger.space_count.should == 4
+    expect(@arranger.space_count).to eq(4)
   end
 end
 describe "Core::Text::Formatted::Arranger#finalize_line" do
@@ -250,16 +250,16 @@ describe "Core::Text::Formatted::Arranger#finalize_line" do
     while string = arranger.next_string
     end
     arranger.finalize_line
-    arranger.fragments.length.should == 3
+    expect(arranger.fragments.length).to eq(3)
 
     fragment = arranger.retrieve_fragment
-    fragment.text.should == "hello "
+    expect(fragment.text).to eq("hello ")
 
     fragment = arranger.retrieve_fragment
-    fragment.text.should == "world how"
+    expect(fragment.text).to eq("world how")
 
     fragment = arranger.retrieve_fragment
-    fragment.text.should == ""
+    expect(fragment.text).to eq("")
   end
 end
 
@@ -274,13 +274,13 @@ describe "Core::Text::Formatted::Arranger#line_width" do
     end
   end
   it "should raise_error an error if called before finalize_line was called" do
-    lambda do
+    expect do
       @arranger.line_width
-    end.should raise_error(RuntimeError)
+    end.to raise_error(RuntimeError)
   end
   it "should return the width of the complete line" do
     @arranger.finalize_line
-    @arranger.line_width.should be > 0
+    expect(@arranger.line_width).to be > 0
   end
 end
 
@@ -305,7 +305,7 @@ describe "Core::Text::Formatted::Arranger#line_width with character_spacing > 0"
     while string = arranger.next_string
     end
     arranger.finalize_line
-    arranger.line_width.should be > base_line_width
+    expect(arranger.line_width).to be > base_line_width
   end
 end
 
@@ -320,13 +320,13 @@ describe "Core::Text::Formatted::Arranger#line" do
     end
   end
   it "should raise_error an error if called before finalize_line was called" do
-    lambda do
+    expect do
       @arranger.line
-    end.should raise_error(RuntimeError)
+    end.to raise_error(RuntimeError)
   end
   it "should return the complete line" do
     @arranger.finalize_line
-    @arranger.line.should == "hello world"
+    expect(@arranger.line).to eq("hello world")
   end
 end
 
@@ -339,7 +339,7 @@ describe "Core::Text::Formatted::Arranger#unconsumed" do
              { :text => "are", :styles => [:bold, :italic] },
              { :text => " you now?" }]
     arranger.format_array = array
-    arranger.unconsumed.should == array
+    expect(arranger.unconsumed).to eq(array)
   end
   it "should return an empty array if everything was consumed" do
     create_pdf
@@ -351,7 +351,7 @@ describe "Core::Text::Formatted::Arranger#unconsumed" do
     arranger.format_array = array
     while string = arranger.next_string
     end
-    arranger.unconsumed.should == []
+    expect(arranger.unconsumed).to eq([])
   end
 end
 
@@ -367,7 +367,7 @@ describe "Core::Text::Formatted::Arranger#finished" do
     while string = arranger.next_string
     end
     arranger.update_last_string(" you", "now?", nil)
-    arranger.should_not be_finished
+    expect(arranger).not_to be_finished
   end
   it "should be_false if everything was printed" do
     create_pdf
@@ -379,7 +379,7 @@ describe "Core::Text::Formatted::Arranger#finished" do
     arranger.format_array = array
     while string = arranger.next_string
     end
-    arranger.should be_finished
+    expect(arranger).to be_finished
   end
 end
 
@@ -396,7 +396,7 @@ describe "Core::Text::Formatted::Arranger.max_line_height" do
     while string = arranger.next_string
     end
     arranger.finalize_line
-    arranger.max_line_height.should be_within(0.0001).of(33.32)
+    expect(arranger.max_line_height).to be_within(0.0001).of(33.32)
   end
 end
 
@@ -415,9 +415,9 @@ describe "Core::Text::Formatted::Arranger#repack_unretrieved" do
     arranger.retrieve_fragment
     arranger.retrieve_fragment
     arranger.repack_unretrieved
-    arranger.unconsumed.should == [
+    expect(arranger.unconsumed).to eq([
       { :text => "are", :styles => [:bold, :italic] },
       { :text => " you now?" }
-    ]
+    ])
   end
 end

--- a/spec/formatted_text_box_spec.rb
+++ b/spec/formatted_text_box_spec.rb
@@ -15,7 +15,7 @@ describe "Text::Formatted::Box wrapping" do
     ]
     text_box = Prawn::Text::Formatted::Box.new(texts, :document => @pdf, :width => @pdf.width_of("Hello World"))
     text_box.render
-    text_box.text.should == "Hello\nWorld2"
+    expect(text_box.text).to eq("Hello\nWorld2")
   end
 
   it "should not raise an Encoding::CompatibilityError when keeping a TTF and an AFM font together" do
@@ -43,7 +43,7 @@ describe "Text::Formatted::Box wrapping" do
     ]
     text_box = Prawn::Text::Formatted::Box.new(texts, :document => @pdf, :width => @pdf.width_of("Hello World"))
     text_box.render
-    text_box.text.should == "Hello World\n2"
+    expect(text_box.text).to eq("Hello World\n2")
 
     texts = [
       { :text => "Hello " },
@@ -52,7 +52,7 @@ describe "Text::Formatted::Box wrapping" do
     ]
     text_box = Prawn::Text::Formatted::Box.new(texts, :document => @pdf, :width => @pdf.width_of("Hello World"))
     text_box.render
-    text_box.text.should == "Hello World\n2"
+    expect(text_box.text).to eq("Hello World\n2")
   end
 
   it "should wrap between two fragments when the final fragment begins with white space" do
@@ -63,7 +63,7 @@ describe "Text::Formatted::Box wrapping" do
     ]
     text_box = Prawn::Text::Formatted::Box.new(texts, :document => @pdf, :width => @pdf.width_of("Hello World"))
     text_box.render
-    text_box.text.should == "Hello World\n2"
+    expect(text_box.text).to eq("Hello World\n2")
 
     texts = [
       { :text => "Hello " },
@@ -72,16 +72,16 @@ describe "Text::Formatted::Box wrapping" do
     ]
     text_box = Prawn::Text::Formatted::Box.new(texts, :document => @pdf, :width => @pdf.width_of("Hello World"))
     text_box.render
-    text_box.text.should == "Hello World\n2"
+    expect(text_box.text).to eq("Hello World\n2")
   end
 
   it "should properly handle empty slices using default encoding" do
     texts = [{ :text => "Noua Delineatio Geographica generalis | Apostolicarum peregrinationum | S FRANCISCI XAUERII | Indiarum & Iaponiæ Apostoli", :font => 'Courier', :size => 10 }]
     text_box = Prawn::Text::Formatted::Box.new(texts, :document => @pdf, :width => @pdf.width_of("Noua Delineatio Geographica gen"))
-    lambda {
+    expect {
       text_box.render
-    }.should_not raise_error
-    text_box.text.should == "Noua Delineatio Geographica\ngeneralis | Apostolicarum\nperegrinationum | S FRANCISCI\nXAUERII | Indiarum & Iaponi\346\nApostoli"
+    }.not_to raise_error
+    expect(text_box.text).to eq("Noua Delineatio Geographica\ngeneralis | Apostolicarum\nperegrinationum | S FRANCISCI\nXAUERII | Indiarum & Iaponi\346\nApostoli")
   end
 end
 
@@ -100,16 +100,16 @@ describe "Text::Formatted::Box with :fallback_fonts option that includes" \
     text = PDF::Inspector::Text.analyze(@pdf.render)
 
     fonts_used = text.font_settings.map { |e| e[:name] }
-    fonts_used.length.should == 4
-    fonts_used[0].should == :Helvetica
-    fonts_used[1].to_s.should =~ /GBZenKai-Medium/
-    fonts_used[2].to_s.should =~ /GBZenKai-Medium/
-    fonts_used[3].should == :Helvetica
+    expect(fonts_used.length).to eq(4)
+    expect(fonts_used[0]).to eq(:Helvetica)
+    expect(fonts_used[1].to_s).to match(/GBZenKai-Medium/)
+    expect(fonts_used[2].to_s).to match(/GBZenKai-Medium/)
+    expect(fonts_used[3]).to eq(:Helvetica)
 
-    text.strings[0].should == "hello"
-    text.strings[1].should == "你好"
-    text.strings[2].should == "再见"
-    text.strings[3].should == "goodbye"
+    expect(text.strings[0]).to eq("hello")
+    expect(text.strings[1]).to eq("你好")
+    expect(text.strings[2]).to eq("再见")
+    expect(text.strings[3]).to eq("goodbye")
   end
 end
 
@@ -129,16 +129,16 @@ describe "Text::Formatted::Box with :fallback_fonts option that includes" \
     text = PDF::Inspector::Text.analyze(@pdf.render)
 
     fonts_used = text.font_settings.map { |e| e[:name] }
-    fonts_used.length.should == 4
-    fonts_used[0].to_s.should =~ /GBZenKai-Medium/
-    fonts_used[1].to_s.should =~ /GBZenKai-Medium/
-    fonts_used[2].to_s.should =~ /GBZenKai-Medium/
-    fonts_used[3].should == :Helvetica
+    expect(fonts_used.length).to eq(4)
+    expect(fonts_used[0].to_s).to match(/GBZenKai-Medium/)
+    expect(fonts_used[1].to_s).to match(/GBZenKai-Medium/)
+    expect(fonts_used[2].to_s).to match(/GBZenKai-Medium/)
+    expect(fonts_used[3]).to eq(:Helvetica)
 
-    text.strings[0].should == "hello"
-    text.strings[1].should == "你好"
-    text.strings[2].should == "再见"
-    text.strings[3].should == "€"
+    expect(text.strings[0]).to eq("hello")
+    expect(text.strings[1]).to eq("你好")
+    expect(text.strings[2]).to eq("再见")
+    expect(text.strings[3]).to eq("€")
   end
 end
 
@@ -163,16 +163,16 @@ describe "Text::Formatted::Box with :fallback_fonts option and fragment " \
     text = PDF::Inspector::Text.analyze(@pdf.render)
 
     fonts_used = text.font_settings.map { |e| e[:name] }
-    fonts_used.length.should == 4
-    fonts_used[0].should == :Helvetica
-    fonts_used[1].to_s.should =~ /GBZenKai-Medium/
-    fonts_used[2].to_s.should =~ /GBZenKai-Medium/
-    fonts_used[3].should == :"Times-Roman"
+    expect(fonts_used.length).to eq(4)
+    expect(fonts_used[0]).to eq(:Helvetica)
+    expect(fonts_used[1].to_s).to match(/GBZenKai-Medium/)
+    expect(fonts_used[2].to_s).to match(/GBZenKai-Medium/)
+    expect(fonts_used[3]).to eq(:"Times-Roman")
 
-    text.strings[0].should == "hello"
-    text.strings[1].should == "你好"
-    text.strings[2].should == "再见"
-    text.strings[3].should == "goodbye"
+    expect(text.strings[0]).to eq("hello")
+    expect(text.strings[1]).to eq("你好")
+    expect(text.strings[2]).to eq("再见")
+    expect(text.strings[3]).to eq("goodbye")
   end
 end
 
@@ -194,7 +194,7 @@ describe "Text::Formatted::Box" do
     @pdf.fallback_fonts = ["Kai"]
   end
   it "#fallback_fonts should return the document-wide fallback fonts" do
-    @pdf.fallback_fonts.should == ["Kai"]
+    expect(@pdf.fallback_fonts).to eq(["Kai"])
   end
   it "should be able to set text fallback_fonts document-wide" do
     @pdf.formatted_text_box(@formatted_text)
@@ -202,9 +202,9 @@ describe "Text::Formatted::Box" do
     text = PDF::Inspector::Text.analyze(@pdf.render)
 
     fonts_used = text.font_settings.map { |e| e[:name] }
-    fonts_used.length.should == 2
-    fonts_used[0].should == :Helvetica
-    fonts_used[1].to_s.should =~ /GBZenKai-Medium/
+    expect(fonts_used.length).to eq(2)
+    expect(fonts_used[0]).to eq(:Helvetica)
+    expect(fonts_used[1].to_s).to match(/GBZenKai-Medium/)
   end
   it "should be able to override document-wide fallback_fonts" do
     @pdf.fallback_fonts = ["DejaVu Sans"]
@@ -213,9 +213,9 @@ describe "Text::Formatted::Box" do
     text = PDF::Inspector::Text.analyze(@pdf.render)
 
     fonts_used = text.font_settings.map { |e| e[:name] }
-    fonts_used.length.should == 2
-    fonts_used[0].should == :Helvetica
-    fonts_used[1].should =~ /Kai/
+    expect(fonts_used.length).to eq(2)
+    expect(fonts_used[0]).to eq(:Helvetica)
+    expect(fonts_used[1]).to match(/Kai/)
   end
   it "should omit the fallback fonts overhead when passing an empty array " \
     "as the :fallback_fonts" do
@@ -248,9 +248,9 @@ describe "Text::Formatted::Box with :fallback_fonts option " \
     create_pdf
     formatted_text = [{ :text => "hello world. 世界你好。" }]
 
-    lambda {
+    expect {
       @pdf.formatted_text_box(formatted_text, :fallback_fonts => ["Courier"])
-    }.should raise_error(Prawn::Errors::IncompatibleStringEncoding)
+    }.to raise_error(Prawn::Errors::IncompatibleStringEncoding)
   end
 end
 
@@ -261,7 +261,7 @@ describe "Text::Formatted::Box#extensions" do
     @pdf.formatted_text_box([{ :text => "hello world" }], {})
     Prawn::Text::Formatted::Box.extensions.delete(TestFormattedWrapOverride)
     text = PDF::Inspector::Text.analyze(@pdf.render)
-    text.strings[0].should == "all your base are belong to us"
+    expect(text.strings[0]).to eq("all your base are belong to us")
   end
   it "overriding Text::Formatted::Box line wrapping should not affect " \
      "Text::Box wrapping" do
@@ -270,7 +270,7 @@ describe "Text::Formatted::Box#extensions" do
     @pdf.text_box("hello world", {})
     Prawn::Text::Formatted::Box.extensions.delete(TestFormattedWrapOverride)
     text = PDF::Inspector::Text.analyze(@pdf.render)
-    text.strings[0].should == "hello world"
+    expect(text.strings[0]).to eq("hello world")
   end
   it "overriding Text::Box line wrapping should override Text::Box wrapping" do
     create_pdf
@@ -278,7 +278,7 @@ describe "Text::Formatted::Box#extensions" do
     @pdf.text_box("hello world", {})
     Prawn::Text::Box.extensions.delete(TestFormattedWrapOverride)
     text = PDF::Inspector::Text.analyze(@pdf.render)
-    text.strings[0].should == "all your base are belong to us"
+    expect(text.strings[0]).to eq("all your base are belong to us")
   end
 end
 
@@ -289,7 +289,7 @@ describe "Text::Formatted::Box#render" do
     options = { :document => @pdf }
     text_box = Prawn::Text::Formatted::Box.new(array, options)
     text_box.render
-    text_box.text.should == "hello\nworld"
+    expect(text_box.text).to eq("hello\nworld")
   end
   it "should omit spaces from the beginning of the line" do
     create_pdf
@@ -297,7 +297,7 @@ describe "Text::Formatted::Box#render" do
     options = { :document => @pdf }
     text_box = Prawn::Text::Formatted::Box.new(array, options)
     text_box.render
-    text_box.text.should == "hello\nworld"
+    expect(text_box.text).to eq("hello\nworld")
   end
   it "should be okay printing a line of whitespace" do
     create_pdf
@@ -305,7 +305,7 @@ describe "Text::Formatted::Box#render" do
     options = { :document => @pdf }
     text_box = Prawn::Text::Formatted::Box.new(array, options)
     text_box.render
-    text_box.text.should == "hello\n\nworld"
+    expect(text_box.text).to eq("hello\n\nworld")
 
     array = [{ :text => "hello" + " " * 500 },
              { :text => " " * 500 },
@@ -314,7 +314,7 @@ describe "Text::Formatted::Box#render" do
     options = { :document => @pdf }
     text_box = Prawn::Text::Formatted::Box.new(array, options)
     text_box.render
-    text_box.text.should == "hello\n\nworld"
+    expect(text_box.text).to eq("hello\n\nworld")
   end
   it "should enable fragment level direction setting" do
     create_pdf
@@ -328,10 +328,10 @@ describe "Text::Formatted::Box#render" do
     text_box = Prawn::Text::Formatted::Box.new(array, options)
     text_box.render
     text = PDF::Inspector::Text.analyze(@pdf.render)
-    text.strings[0].should == "era woh ,"
-    text.strings[1].should == "world"
-    text.strings[2].should == " olleh" * number_of_hellos
-    text.strings[3].should == "?uoy"
+    expect(text.strings[0]).to eq("era woh ,")
+    expect(text.strings[1]).to eq("world")
+    expect(text.strings[2]).to eq(" olleh" * number_of_hellos)
+    expect(text.strings[3]).to eq("?uoy")
   end
 end
 
@@ -400,10 +400,10 @@ describe "Text::Formatted::Box#render" do
     text_box.render
     contents = PDF::Inspector::Text.analyze(@pdf.render)
     fonts = contents.font_settings.map { |e| e[:name] }
-    fonts.should == [:Helvetica, :"Times-Bold", :Helvetica]
-    contents.strings[0].should == "this contains "
-    contents.strings[1].should == "Times-Bold"
-    contents.strings[2].should == " text"
+    expect(fonts).to eq([:Helvetica, :"Times-Bold", :Helvetica])
+    expect(contents.strings[0]).to eq("this contains ")
+    expect(contents.strings[1]).to eq("Times-Bold")
+    expect(contents.strings[2]).to eq(" text")
   end
   it "should be able to set bold" do
     create_pdf
@@ -414,10 +414,10 @@ describe "Text::Formatted::Box#render" do
     text_box.render
     contents = PDF::Inspector::Text.analyze(@pdf.render)
     fonts = contents.font_settings.map { |e| e[:name] }
-    fonts.should == [:Helvetica, :"Helvetica-Bold", :Helvetica]
-    contents.strings[0].should == "this contains "
-    contents.strings[1].should == "bold"
-    contents.strings[2].should == " text"
+    expect(fonts).to eq([:Helvetica, :"Helvetica-Bold", :Helvetica])
+    expect(contents.strings[0]).to eq("this contains ")
+    expect(contents.strings[1]).to eq("bold")
+    expect(contents.strings[2]).to eq(" text")
   end
   it "should be able to set italics" do
     create_pdf
@@ -428,7 +428,7 @@ describe "Text::Formatted::Box#render" do
     text_box.render
     contents = PDF::Inspector::Text.analyze(@pdf.render)
     fonts = contents.font_settings.map { |e| e[:name] }
-    fonts.should == [:Helvetica, :"Helvetica-Oblique", :Helvetica]
+    expect(fonts).to eq([:Helvetica, :"Helvetica-Oblique", :Helvetica])
   end
   it "should be able to set subscript" do
     create_pdf
@@ -438,8 +438,8 @@ describe "Text::Formatted::Box#render" do
     text_box = Prawn::Text::Formatted::Box.new(array, :document => @pdf)
     text_box.render
     contents = PDF::Inspector::Text.analyze(@pdf.render)
-    contents.font_settings[0][:size].should == 12
-    contents.font_settings[1][:size].should be_within(0.0001).of(18 * 0.583)
+    expect(contents.font_settings[0][:size]).to eq(12)
+    expect(contents.font_settings[1][:size]).to be_within(0.0001).of(18 * 0.583)
   end
   it "should be able to set superscript" do
     create_pdf
@@ -449,8 +449,8 @@ describe "Text::Formatted::Box#render" do
     text_box = Prawn::Text::Formatted::Box.new(array, :document => @pdf)
     text_box.render
     contents = PDF::Inspector::Text.analyze(@pdf.render)
-    contents.font_settings[0][:size].should == 12
-    contents.font_settings[1][:size].should be_within(0.0001).of(18 * 0.583)
+    expect(contents.font_settings[0][:size]).to eq(12)
+    expect(contents.font_settings[1][:size]).to be_within(0.0001).of(18 * 0.583)
   end
   it "should be able to set compound bold and italic text" do
     create_pdf
@@ -461,7 +461,7 @@ describe "Text::Formatted::Box#render" do
     text_box.render
     contents = PDF::Inspector::Text.analyze(@pdf.render)
     fonts = contents.font_settings.map { |e| e[:name] }
-    fonts.should == [:Helvetica, :"Helvetica-BoldOblique", :Helvetica]
+    expect(fonts).to eq([:Helvetica, :"Helvetica-BoldOblique", :Helvetica])
   end
   it "should be able to underline" do
     create_pdf
@@ -471,7 +471,7 @@ describe "Text::Formatted::Box#render" do
     text_box = Prawn::Text::Formatted::Box.new(array, :document => @pdf)
     text_box.render
     line_drawing = PDF::Inspector::Graphics::Line.analyze(@pdf.render)
-    line_drawing.points.length.should == 2
+    expect(line_drawing.points.length).to eq(2)
   end
   it "should be able to strikethrough" do
     create_pdf
@@ -481,7 +481,7 @@ describe "Text::Formatted::Box#render" do
     text_box = Prawn::Text::Formatted::Box.new(array, :document => @pdf)
     text_box.render
     line_drawing = PDF::Inspector::Graphics::Line.analyze(@pdf.render)
-    line_drawing.points.length.should == 2
+    expect(line_drawing.points.length).to eq(2)
   end
   it "should be able to add URL links" do
     create_pdf
@@ -529,8 +529,8 @@ describe "Text::Formatted::Box#render" do
     text_box = Prawn::Text::Formatted::Box.new(array, :document => @pdf)
     text_box.render
     contents = PDF::Inspector::Text.analyze(@pdf.render)
-    contents.font_settings[0][:size].should == 12
-    contents.font_settings[1][:size].should == 24
+    expect(contents.font_settings[0][:size]).to eq(12)
+    expect(contents.font_settings[1][:size]).to eq(24)
   end
   it "should set the baseline based on the tallest fragment on a given line" do
     create_pdf
@@ -540,7 +540,7 @@ describe "Text::Formatted::Box#render" do
     text_box = Prawn::Text::Formatted::Box.new(array, :document => @pdf)
     text_box.render
     @pdf.font_size(24) do
-      text_box.height.should be_within(0.001).of(@pdf.font.ascender + @pdf.font.descender)
+      expect(text_box.height).to be_within(0.001).of(@pdf.font.ascender + @pdf.font.descender)
     end
   end
   it "should be able to set color via an rgb hex string" do
@@ -550,8 +550,8 @@ describe "Text::Formatted::Box#render" do
     text_box = Prawn::Text::Formatted::Box.new(array, :document => @pdf)
     text_box.render
     colors = PDF::Inspector::Graphics::Color.analyze(@pdf.render)
-    colors.fill_color_count.should == 2
-    colors.stroke_color_count.should == 2
+    expect(colors.fill_color_count).to eq(2)
+    expect(colors.stroke_color_count).to eq(2)
   end
   it "should be able to set color using a cmyk array" do
     create_pdf
@@ -560,8 +560,8 @@ describe "Text::Formatted::Box#render" do
     text_box = Prawn::Text::Formatted::Box.new(array, :document => @pdf)
     text_box.render
     colors = PDF::Inspector::Graphics::Color.analyze(@pdf.render)
-    colors.fill_color_count.should == 2
-    colors.stroke_color_count.should == 2
+    expect(colors.fill_color_count).to eq(2)
+    expect(colors.stroke_color_count).to eq(2)
   end
 end
 
@@ -581,9 +581,9 @@ describe "Text::Formatted::Box#render(:dry_run => true)" do
     text_box.render(:dry_run => true)
 
     state_after = PDF::Inspector::Graphics::Color.analyze(@pdf.render)
-    state_after.fill_color_count.should == fill_color_count
-    state_after.stroke_color_count.should == stroke_color_count
-    state_after.stroke_color_space_count.should == stroke_color_space_count
+    expect(state_after.fill_color_count).to eq(fill_color_count)
+    expect(state_after.stroke_color_count).to eq(stroke_color_count)
+    expect(state_after.stroke_color_space_count).to eq(stroke_color_space_count)
   end
 end
 
@@ -596,7 +596,7 @@ describe "Text::Formatted::Box#render with fragment level :character_spacing opt
     text_box = Prawn::Text::Formatted::Box.new(array, options)
     text_box.render
     contents = PDF::Inspector::Text.analyze(@pdf.render)
-    contents.character_spacing[0].should == 7
+    expect(contents.character_spacing[0]).to eq(7)
   end
   it "should draw the character spacing to the document" do
     create_pdf
@@ -608,7 +608,7 @@ describe "Text::Formatted::Box#render with fragment level :character_spacing opt
                 :overflow => :expand }
     text_box = Prawn::Text::Formatted::Box.new(array, options)
     text_box.render
-    text_box.text.should == "hello\nworld"
+    expect(text_box.text).to eq("hello\nworld")
   end
 end
 
@@ -622,7 +622,7 @@ describe "Text::Formatted::Box#render with :align => :justify" do
     text_box = Prawn::Text::Formatted::Box.new(array, options)
     text_box.render
     contents = PDF::Inspector::Text.analyze(@pdf.render)
-    contents.word_spacing.should be_empty
+    expect(contents.word_spacing).to be_empty
   end
 end
 
@@ -645,7 +645,7 @@ describe "Text::Formatted::Box#render with :valign => :center" do
     line_padding = (box_height - text_box.height + text_box.descender) * 0.5
     baseline = y - line_padding
 
-    text_box.at[1].should be_within(0.01).of(baseline)
+    expect(text_box.at[1]).to be_within(0.01).of(baseline)
   end
 end
 
@@ -667,7 +667,7 @@ describe "Text::Formatted::Box#render with :valign => :bottom" do
     text_box.render
     top_padding = y - (box_height - text_box.height)
 
-    text_box.at[1].should be_within(0.01).of(top_padding)
+    expect(text_box.at[1]).to be_within(0.01).of(top_padding)
   end
 end
 

--- a/spec/formatted_text_fragment_spec.rb
+++ b/spec/formatted_text_fragment_spec.rb
@@ -9,7 +9,7 @@ describe "Text::Formatted::Fragment#space_count" do
     fragment = Prawn::Text::Formatted::Fragment.new("hello world ",
                                                     format_state,
                                                     @pdf)
-    fragment.space_count.should == 2
+    expect(fragment.space_count).to eq(2)
   end
   it "should exclude trailing spaces from the count when " \
     ":exclude_trailing_white_space => true" do
@@ -18,7 +18,7 @@ describe "Text::Formatted::Fragment#space_count" do
     fragment = Prawn::Text::Formatted::Fragment.new("hello world ",
                                                     format_state,
                                                     @pdf)
-    fragment.space_count.should == 1
+    expect(fragment.space_count).to eq(1)
   end
 end
 
@@ -29,9 +29,9 @@ describe "Text::Formatted::Fragment#include_trailing_white_space!" do
     fragment = Prawn::Text::Formatted::Fragment.new("hello world ",
                                                     format_state,
                                                     @pdf)
-    fragment.space_count.should == 1
+    expect(fragment.space_count).to eq(1)
     fragment.include_trailing_white_space!
-    fragment.space_count.should == 2
+    expect(fragment.space_count).to eq(2)
   end
 end
 
@@ -42,7 +42,7 @@ describe "Text::Formatted::Fragment#text" do
     fragment = Prawn::Text::Formatted::Fragment.new("hello world ",
                                                     format_state,
                                                     @pdf)
-    fragment.text.should == "hello world "
+    expect(fragment.text).to eq("hello world ")
   end
   it "should return the fragment text without trailing spaces when " \
     ":exclude_trailing_white_space => true" do
@@ -51,7 +51,7 @@ describe "Text::Formatted::Fragment#text" do
     fragment = Prawn::Text::Formatted::Fragment.new("hello world ",
                                                     format_state,
                                                     @pdf)
-    fragment.text.should == "hello world"
+    expect(fragment.text).to eq("hello world")
   end
 end
 
@@ -77,11 +77,11 @@ describe "Text::Formatted::Fragment#word_spacing=" do
   end
 
   it "should account for word_spacing in #width" do
-    @fragment.width.should == 110
+    expect(@fragment.width).to eq(110)
   end
   it "should account for word_spacing in #bounding_box" do
     target_box = [50, 193, 160, 217]
-    @fragment.bounding_box.should == target_box
+    expect(@fragment.bounding_box).to eq(target_box)
   end
   it "should account for word_spacing in #absolute_bounding_box" do
     target_box = [50, 193, 160, 217]
@@ -89,17 +89,17 @@ describe "Text::Formatted::Fragment#word_spacing=" do
     target_box[1] += @pdf.bounds.absolute_bottom
     target_box[2] += @pdf.bounds.absolute_left
     target_box[3] += @pdf.bounds.absolute_bottom
-    @fragment.absolute_bounding_box.should == target_box
+    expect(@fragment.absolute_bounding_box).to eq(target_box)
   end
   it "should account for word_spacing in #underline_points" do
     y = 198.75
     target_points = [[50, y], [160, y]]
-    @fragment.underline_points.should == target_points
+    expect(@fragment.underline_points).to eq(target_points)
   end
   it "should account for word_spacing in #strikethrough_points" do
     y = 200 + @fragment.ascender * 0.3
     target_points = [[50, y], [160, y]]
-    @fragment.strikethrough_points.should == target_points
+    expect(@fragment.strikethrough_points).to eq(target_points)
   end
 end
 
@@ -125,13 +125,13 @@ describe "Text::Formatted::Fragment" do
 
   describe "#width" do
     it "should return the width" do
-      @fragment.width.should == 100
+      expect(@fragment.width).to eq(100)
     end
   end
 
   describe "#styles" do
     it "should return the styles array" do
-      @fragment.styles.should == [:bold, :italic]
+      expect(@fragment.styles).to eq([:bold, :italic])
     end
     it "should never return nil" do
       format_state = { :styles => nil,
@@ -143,38 +143,38 @@ describe "Text::Formatted::Fragment" do
       fragment = Prawn::Text::Formatted::Fragment.new("hello world",
                                                       format_state,
                                                       @pdf)
-      fragment.styles.should == []
+      expect(fragment.styles).to eq([])
     end
   end
 
   describe "#line_height" do
     it "should return the line_height" do
-      @fragment.line_height.should == 27
+      expect(@fragment.line_height).to eq(27)
     end
   end
 
   describe "#ascender" do
     it "should return the ascender" do
-      @fragment.ascender.should == 17
+      expect(@fragment.ascender).to eq(17)
     end
   end
 
   describe "#descender" do
     it "should return the descender" do
-      @fragment.descender.should == 7
+      expect(@fragment.descender).to eq(7)
     end
   end
 
   describe "#y_offset" do
     it "should be zero" do
-      @fragment.y_offset.should == 0
+      expect(@fragment.y_offset).to eq(0)
     end
   end
 
   describe "#bounding_box" do
     it "should return the bounding box surrounding the fragment" do
       target_box = [50, 193, 150, 217]
-      @fragment.bounding_box.should == target_box
+      expect(@fragment.bounding_box).to eq(target_box)
     end
   end
 
@@ -187,7 +187,7 @@ describe "Text::Formatted::Fragment" do
       target_box[2] += @pdf.bounds.absolute_left
       target_box[3] += @pdf.bounds.absolute_bottom
 
-      @fragment.absolute_bounding_box.should == target_box
+      expect(@fragment.absolute_bounding_box).to eq(target_box)
     end
   end
 
@@ -195,7 +195,7 @@ describe "Text::Formatted::Fragment" do
     it "should define a line under the fragment" do
       y = 198.75
       target_points = [[50, y], [150, y]]
-      @fragment.underline_points.should == target_points
+      expect(@fragment.underline_points).to eq(target_points)
     end
   end
 
@@ -203,7 +203,7 @@ describe "Text::Formatted::Fragment" do
     it "should define a line through the fragment" do
       y = 200 + @fragment.ascender * 0.3
       target_points = [[50, y], [150, y]]
-      @fragment.strikethrough_points.should == target_points
+      expect(@fragment.strikethrough_points).to eq(target_points)
     end
   end
 end
@@ -226,12 +226,12 @@ describe "Text::Formatted::Fragment that is a subscript" do
   end
   describe "#subscript?" do
     it "should be_true" do
-      @fragment.should be_subscript
+      expect(@fragment).to be_subscript
     end
   end
   describe "#y_offset" do
     it "should return a negative value" do
-      @fragment.y_offset.should be < 0
+      expect(@fragment.y_offset).to be < 0
     end
   end
 end
@@ -254,12 +254,12 @@ describe "Text::Formatted::Fragment that is a superscript" do
   end
   describe "#superscript?" do
     it "should be_true" do
-      @fragment.should be_superscript
+      expect(@fragment).to be_superscript
     end
   end
   describe "#y_offset" do
     it "should return a positive value" do
-      @fragment.y_offset.should be > 0
+      expect(@fragment.y_offset).to be > 0
     end
   end
 end
@@ -271,7 +271,7 @@ describe "Text::Formatted::Fragment with :direction => :rtl" do
     fragment = Prawn::Text::Formatted::Fragment.new("hello world",
                                                     format_state,
                                                     @pdf)
-    fragment.text.should == "dlrow olleh"
+    expect(fragment.text).to eq("dlrow olleh")
   end
 end
 
@@ -284,7 +284,7 @@ describe "Text::Formatted::Fragment default_direction=" do
                                                     format_state,
                                                     @pdf)
     fragment.default_direction = :rtl
-    fragment.direction.should == :rtl
+    expect(fragment.direction).to eq(:rtl)
   end
   it "should not set the direction if there is a fragment level direction " \
      "specification" do
@@ -294,6 +294,6 @@ describe "Text::Formatted::Fragment default_direction=" do
                                                     format_state,
                                                     @pdf)
     fragment.default_direction = :ltr
-    fragment.direction.should == :rtl
+    expect(fragment.direction).to eq(:rtl)
   end
 end

--- a/spec/graphics_spec.rb
+++ b/spec/graphics_spec.rb
@@ -10,7 +10,7 @@ describe "When drawing a line" do
 
     line_drawing = PDF::Inspector::Graphics::Line.analyze(@pdf.render)
 
-    line_drawing.points.should == [[100,600],[100,500]]
+    expect(line_drawing.points).to eq([[100,600],[100,500]])
   end
 
   it "should draw two lines at (100,600) to (100,500) " \
@@ -20,42 +20,43 @@ describe "When drawing a line" do
 
     line_drawing = PDF::Inspector::Graphics::Line.analyze(@pdf.render)
 
-    line_drawing.points.should ==
+    expect(line_drawing.points).to eq(
       [[100.0, 600.0], [100.0, 500.0], [75.0, 100.0], [50.0, 125.0]]
+    )
   end
 
   it "should properly set line width via line_width=" do
     @pdf.line_width = 10
     line = PDF::Inspector::Graphics::Line.analyze(@pdf.render)
-    line.widths.first.should == 10
+    expect(line.widths.first).to eq(10)
   end
 
   it "should properly set line width via line_width(width)" do
     @pdf.line_width(10)
     line = PDF::Inspector::Graphics::Line.analyze(@pdf.render)
-    line.widths.first.should == 10
+    expect(line.widths.first).to eq(10)
   end
 
   it "should carry the current line width settings over to new pages" do
     @pdf.line_width(10)
     @pdf.start_new_page
     line = PDF::Inspector::Graphics::Line.analyze(@pdf.render)
-    line.widths.length.should == 2
-    line.widths[1].should == 10
+    expect(line.widths.length).to eq(2)
+    expect(line.widths[1]).to eq(10)
   end
 
   describe "(Horizontally)" do
     it "should draw from [x1,pdf.y],[x2,pdf.y]" do
       @pdf.horizontal_line(100,150)
       @line = PDF::Inspector::Graphics::Line.analyze(@pdf.render)
-      @line.points.should == [[100.0 + @pdf.bounds.absolute_left, @pdf.y],
-                              [150.0 + @pdf.bounds.absolute_left, @pdf.y]]
+      expect(@line.points).to eq([[100.0 + @pdf.bounds.absolute_left, @pdf.y],
+                                  [150.0 + @pdf.bounds.absolute_left, @pdf.y]])
     end
 
     it "should draw a line from (200, 250) to (300, 250)" do
       @pdf.horizontal_line(200,300,:at => 250)
       line_drawing = PDF::Inspector::Graphics::Line.analyze(@pdf.render)
-      line_drawing.points.should == [[200,250],[300,250]]
+      expect(line_drawing.points).to eq([[200,250],[300,250]])
     end
   end
 
@@ -63,11 +64,11 @@ describe "When drawing a line" do
     it "should draw a line from (350, 300) to (350, 400)" do
       @pdf.vertical_line(300,400,:at => 350)
       line_drawing = PDF::Inspector::Graphics::Line.analyze(@pdf.render)
-      line_drawing.points.should == [[350,300],[350,400]]
+      expect(line_drawing.points).to eq([[350,300],[350,400]])
     end
     it "should require a y coordinate" do
-      lambda { @pdf.vertical_line(400,500) }.
-        should raise_error(ArgumentError)
+      expect { @pdf.vertical_line(400,500) }.
+        to raise_error(ArgumentError)
     end
   end
 end
@@ -79,7 +80,7 @@ describe "When drawing a polygon" do
     @pdf.polygon([100,500],[100,400],[200,400])
 
     line_drawing = PDF::Inspector::Graphics::Line.analyze(@pdf.render)
-    line_drawing.points.should == [[100,500],[100,400],[200,400],[100,500]]
+    expect(line_drawing.points).to eq([[100,500],[100,400],[200,400],[100,500]])
   end
 end
 
@@ -91,9 +92,9 @@ describe "When drawing a rectangle" do
 
     rectangles = PDF::Inspector::Graphics::Rectangle.analyze(@pdf.render).rectangles
     # PDF uses bottom left corner
-    rectangles[0][:point].should == [200,100]
-    rectangles[0][:width].should == 50
-    rectangles[0][:height].should == 100
+    expect(rectangles[0][:point]).to eq([200,100])
+    expect(rectangles[0][:width]).to eq(50)
+    expect(rectangles[0][:height]).to eq(100)
   end
 end
 
@@ -104,13 +105,13 @@ describe "When drawing a curve" do
     @pdf.move_to [50,50]
     @pdf.curve_to [100,100],:bounds => [[20,90], [90,70]]
     curve = PDF::Inspector::Graphics::Curve.analyze(@pdf.render)
-    curve.coords.should == [50.0, 50.0, 20.0, 90.0, 90.0, 70.0, 100.0, 100.0]
+    expect(curve.coords).to eq([50.0, 50.0, 20.0, 90.0, 90.0, 70.0, 100.0, 100.0])
   end
 
   it "should draw a bezier curve from 100,100 to 50,50" do
     @pdf.curve [100,100], [50,50], :bounds => [[20,90], [90,75]]
     curve = PDF::Inspector::Graphics::Curve.analyze(@pdf.render)
-    curve.coords.should == [100.0, 100.0, 20.0, 90.0, 90.0, 75.0, 50.0, 50.0]
+    expect(curve.coords).to eq([100.0, 100.0, 20.0, 90.0, 90.0, 75.0, 50.0, 50.0])
   end
 end
 
@@ -132,16 +133,16 @@ describe "When drawing a rounded rectangle" do
   end
 
   it "should draw a rectangle by connecting lines with rounded bezier curves" do
-    @all_coords.should == [[60.0, 550.0],[90.0, 550.0], [95.5228, 550.0],
-                           [100.0, 545.5228], [100.0, 540.0], [100.0, 460.0],
-                           [100.0, 454.4772], [95.5228, 450.0], [90.0, 450.0],
-                           [60.0, 450.0], [54.4772, 450.0], [50.0, 454.4772],
-                           [50.0, 460.0], [50.0, 540.0], [50.0, 545.5228],
-                           [54.4772, 550.0], [60.0, 550.0]]
+    expect(@all_coords).to eq([[60.0, 550.0],[90.0, 550.0], [95.5228, 550.0],
+                               [100.0, 545.5228], [100.0, 540.0], [100.0, 460.0],
+                               [100.0, 454.4772], [95.5228, 450.0], [90.0, 450.0],
+                               [60.0, 450.0], [54.4772, 450.0], [50.0, 454.4772],
+                               [50.0, 460.0], [50.0, 540.0], [50.0, 545.5228],
+                               [54.4772, 550.0], [60.0, 550.0]])
   end
 
   it "should start and end with the same point" do
-    @original_point.should == @all_coords.last
+    expect(@original_point).to eq(@all_coords.last)
   end
 end
 
@@ -153,7 +154,7 @@ describe "When drawing an ellipse" do
   end
 
   it "should use a Bézier approximation" do
-    @curve.coords.should ==
+    expect(@curve.coords).to eq(
       [125.0, 100.0,
 
        125.0, 127.6142,
@@ -173,10 +174,11 @@ describe "When drawing an ellipse" do
        125.0, 100.0,
 
        100.0, 100.0]
+    )
   end
 
   it "should move the pointer to the center of the ellipse after drawing" do
-    @curve.coords[-2..-1].should == [100,100]
+    expect(@curve.coords[-2..-1]).to eq([100,100])
   end
 end
 
@@ -190,7 +192,7 @@ describe "When drawing a circle" do
 
   it "should stroke the same path as the equivalent ellipse" do
     middle = @curve.coords.length / 2
-    @curve.coords[0...middle].should == @curve.coords[middle..-1]
+    expect(@curve.coords[0...middle]).to eq(@curve.coords[middle..-1])
   end
 end
 
@@ -225,14 +227,14 @@ describe "When setting colors" do
     @pdf.stroke_color "ffcccc"
     colors = PDF::Inspector::Graphics::Color.analyze(@pdf.render)
     # 100% red, 80% green, 80% blue
-    colors.stroke_color.should == [1.0, 0.8, 0.8]
+    expect(colors.stroke_color).to eq([1.0, 0.8, 0.8])
   end
 
   it "should set fill colors" do
     @pdf.fill_color "ccff00"
     colors = PDF::Inspector::Graphics::Color.analyze(@pdf.render)
     # 80% red, 100% green, 0% blue
-    colors.fill_color.should == [0.8,1.0,0]
+    expect(colors.fill_color).to eq([0.8,1.0,0])
   end
 
   it "should reset the colors on each new page if they have been defined" do
@@ -243,11 +245,11 @@ describe "When setting colors" do
 
     @pdf.start_new_page
     colors = PDF::Inspector::Graphics::Color.analyze(@pdf.render)
-    colors.fill_color_count.should == 3
-    colors.stroke_color_count.should == 2
+    expect(colors.fill_color_count).to eq(3)
+    expect(colors.stroke_color_count).to eq(2)
 
-    colors.fill_color.should == [0.8,1.0,0.0]
-    colors.stroke_color.should == [1.0,0.0,0.8]
+    expect(colors.fill_color).to eq([0.8,1.0,0.0])
+    expect(colors.stroke_color).to eq([1.0,0.0,0.8])
   end
 
   it "should set the color space when setting colors on new pages to please fussy readers" do
@@ -257,7 +259,7 @@ describe "When setting colors" do
     @pdf.stroke_color "000000"
     @pdf.stroke { @pdf.rectangle([10, 10], 10, 10) }
     colors = PDF::Inspector::Graphics::Color.analyze(@pdf.render)
-    colors.stroke_color_space_count[:DeviceRGB].should == 2
+    expect(colors.stroke_color_space_count[:DeviceRGB]).to eq(2)
   end
 end
 
@@ -273,15 +275,15 @@ describe "Patterns" do
       grad = PDF::Inspector::Graphics::Pattern.analyze(@pdf.render)
       pattern = grad.patterns.values.first
 
-      pattern.should_not be_nil
-      pattern[:Shading][:ShadingType].should == 2
-      pattern[:Shading][:Coords].should == [0, 0, @pdf.bounds.width, 0]
-      pattern[:Shading][:Function][:C0].zip([1, 0, 0]).all?{ |x1, x2|
+      expect(pattern).not_to be_nil
+      expect(pattern[:Shading][:ShadingType]).to eq(2)
+      expect(pattern[:Shading][:Coords]).to eq([0, 0, @pdf.bounds.width, 0])
+      expect(pattern[:Shading][:Function][:C0].zip([1, 0, 0]).all?{ |x1, x2|
         (x1 - x2).abs < 0.01
-      }.should be_true
-      pattern[:Shading][:Function][:C1].zip([0, 0, 1]).all?{ |x1, x2|
+      }).to be_true
+      expect(pattern[:Shading][:Function][:C1].zip([0, 0, 1]).all?{ |x1, x2|
         (x1 - x2).abs < 0.01
-      }.should be_true
+      }).to be_true
     end
 
     it "fill_gradient should set fill color to the pattern" do
@@ -290,7 +292,7 @@ describe "Patterns" do
                          'FF0000', '0000FF'
 
       str = @pdf.render
-      str.should =~ %r{/Pattern\s+cs\s*/SP-?\d+\s+scn}
+      expect(str).to match(%r{/Pattern\s+cs\s*/SP-?\d+\s+scn})
     end
 
     it "stroke_gradient should set stroke color to the pattern" do
@@ -299,7 +301,7 @@ describe "Patterns" do
                            'FF0000', '0000FF'
 
       str = @pdf.render
-      str.should =~ %r{/Pattern\s+CS\s*/SP-?\d+\s+SCN}
+      expect(str).to match(%r{/Pattern\s+CS\s*/SP-?\d+\s+SCN})
     end
   end
 
@@ -312,15 +314,15 @@ describe "Patterns" do
       grad = PDF::Inspector::Graphics::Pattern.analyze(@pdf.render)
       pattern = grad.patterns.values.first
 
-      pattern.should_not be_nil
-      pattern[:Shading][:ShadingType].should == 3
-      pattern[:Shading][:Coords].should == [0, 0, 10, @pdf.bounds.width, 0, 20]
-      pattern[:Shading][:Function][:C0].zip([1, 0, 0]).all?{ |x1, x2|
+      expect(pattern).not_to be_nil
+      expect(pattern[:Shading][:ShadingType]).to eq(3)
+      expect(pattern[:Shading][:Coords]).to eq([0, 0, 10, @pdf.bounds.width, 0, 20])
+      expect(pattern[:Shading][:Function][:C0].zip([1, 0, 0]).all?{ |x1, x2|
         (x1 - x2).abs < 0.01
-      }.should be_true
-      pattern[:Shading][:Function][:C1].zip([0, 0, 1]).all?{ |x1, x2|
+      }).to be_true
+      expect(pattern[:Shading][:Function][:C1].zip([0, 0, 1]).all?{ |x1, x2|
         (x1 - x2).abs < 0.01
-      }.should be_true
+      }).to be_true
     end
 
     it "fill_gradient should set fill color to the pattern" do
@@ -329,7 +331,7 @@ describe "Patterns" do
                          'FF0000', '0000FF'
 
       str = @pdf.render
-      str.should =~ %r{/Pattern\s+cs\s*/SP-?\d+\s+scn}
+      expect(str).to match(%r{/Pattern\s+cs\s*/SP-?\d+\s+scn})
     end
 
     it "stroke_gradient should set stroke color to the pattern" do
@@ -338,7 +340,7 @@ describe "Patterns" do
                            'FF0000', '0000FF'
 
       str = @pdf.render
-      str.should =~ %r{/Pattern\s+CS\s*/SP-?\d+\s+SCN}
+      expect(str).to match(%r{/Pattern\s+CS\s*/SP-?\d+\s+SCN})
     end
   end
 end
@@ -361,8 +363,8 @@ describe "When using painting shortcuts" do
   end
 
   it "should not break method_missing" do
-    lambda { @pdf.i_have_a_pretty_girlfriend_named_jia }.
-      should raise_error(NoMethodError)
+    expect { @pdf.i_have_a_pretty_girlfriend_named_jia }.
+      to raise_error(NoMethodError)
   end
 end
 
@@ -398,25 +400,25 @@ describe "When using graphics states" do
     @pdf.stroke_color 0, 0, 0, 0
     @pdf.restore_graphics_state
     @pdf.stroke_color 0, 0, 100, 0
-    @pdf.graphic_state.color_space.should == { :stroke => :DeviceCMYK }
+    expect(@pdf.graphic_state.color_space).to eq(:stroke => :DeviceCMYK)
     colors = PDF::Inspector::Graphics::Color.analyze(@pdf.render)
-    colors.color_space.should == :DeviceCMYK
-    colors.stroke_color_space_count[:DeviceCMYK].should == 2
+    expect(colors.color_space).to eq(:DeviceCMYK)
+    expect(colors.stroke_color_space_count[:DeviceCMYK]).to eq(2)
   end
 
   it "should use the correct dash setting after restoring and starting new page" do
     @pdf.dash 5
     @pdf.save_graphics_state
     @pdf.dash 10
-    @pdf.graphic_state.dash[:dash].should == 10
+    expect(@pdf.graphic_state.dash[:dash]).to eq(10)
     @pdf.restore_graphics_state
     @pdf.start_new_page
-    @pdf.graphic_state.dash[:dash].should == 5
+    expect(@pdf.graphic_state.dash[:dash]).to eq(5)
   end
 
   it "should round dash values to four decimal places" do
     @pdf.dash 5.12345
-    @pdf.graphic_state.dash_setting.should == "[5.1235 5.1235] 0.0 d"
+    expect(@pdf.graphic_state.dash_setting).to eq("[5.1235 5.1235] 0.0 d")
   end
 
   it "should raise an error when dash is called w. a zero length or space" do
@@ -436,51 +438,51 @@ describe "When using graphics states" do
     @pdf.fill_color 0, 0, 100, 0
     @pdf.save_graphics_state
 
-    @pdf.graphic_state.stroke_color.should == "000000"
-    @pdf.graphic_state.join_style.should == :miter
-    @pdf.graphic_state.fill_color.should == [0, 0, 100, 0]
-    @pdf.graphic_state.cap_style.should == :round
-    @pdf.graphic_state.color_space.should == { :fill => :DeviceCMYK, :stroke => :DeviceRGB }
-    @pdf.graphic_state.dash.should == { :space => 5, :phase => 0, :dash => 5 }
-    @pdf.graphic_state.line_width.should == 1
+    expect(@pdf.graphic_state.stroke_color).to eq("000000")
+    expect(@pdf.graphic_state.join_style).to eq(:miter)
+    expect(@pdf.graphic_state.fill_color).to eq([0, 0, 100, 0])
+    expect(@pdf.graphic_state.cap_style).to eq(:round)
+    expect(@pdf.graphic_state.color_space).to eq(:fill => :DeviceCMYK, :stroke => :DeviceRGB)
+    expect(@pdf.graphic_state.dash).to eq(:space => 5, :phase => 0, :dash => 5)
+    expect(@pdf.graphic_state.line_width).to eq(1)
   end
 
   it "should not add extra graphic space closings when rendering multiple times" do
     @pdf.render
     state = PDF::Inspector::Graphics::State.analyze(@pdf.render)
-    state.save_graphics_state_count.should == 1
-    state.restore_graphics_state_count.should == 1
+    expect(state.save_graphics_state_count).to eq(1)
+    expect(state.restore_graphics_state_count).to eq(1)
   end
 
   it "should add extra graphic state enclosings when content is added on multiple renderings" do
     @pdf.render
     @pdf.text "Adding a bit more content"
     state = PDF::Inspector::Graphics::State.analyze(@pdf.render)
-    state.save_graphics_state_count.should == 2
-    state.restore_graphics_state_count.should == 2
+    expect(state.save_graphics_state_count).to eq(2)
+    expect(state.restore_graphics_state_count).to eq(2)
   end
 
   it "adds extra graphic state enclosings when new settings are applied on multiple renderings" do
     @pdf.render
     @pdf.stroke_color 0, 0, 0, 0
     state = PDF::Inspector::Graphics::State.analyze(@pdf.render)
-    state.save_graphics_state_count.should == 2
-    state.restore_graphics_state_count.should == 2
+    expect(state.save_graphics_state_count).to eq(2)
+    expect(state.restore_graphics_state_count).to eq(2)
   end
 
   it "should raise_error error if closing an empty graphic stack" do
-    lambda {
+    expect {
       @pdf.render
       @pdf.restore_graphics_state
-    }.should raise_error(PDF::Core::Errors::EmptyGraphicStateStack)
+    }.to raise_error(PDF::Core::Errors::EmptyGraphicStateStack)
   end
 
   it "should copy mutable attributes when passing a previous_state to the initializer" do
     new_state = PDF::Core::GraphicState.new(@pdf.graphic_state)
 
     [:color_space, :dash, :fill_color, :stroke_color].each do |attr|
-      new_state.send(attr).should == @pdf.graphic_state.send(attr)
-      new_state.send(attr).should_not equal(@pdf.graphic_state.send(attr))
+      expect(new_state.send(attr)).to eq(@pdf.graphic_state.send(attr))
+      expect(new_state.send(attr)).not_to equal(@pdf.graphic_state.send(attr))
     end
   end
 
@@ -488,8 +490,8 @@ describe "When using graphics states" do
     new_state = @pdf.graphic_state.dup
 
     [:color_space, :dash, :fill_color, :stroke_color].each do |attr|
-      new_state.send(attr).should == @pdf.graphic_state.send(attr)
-      new_state.send(attr).should_not equal(@pdf.graphic_state.send(attr))
+      expect(new_state.send(attr)).to eq(@pdf.graphic_state.send(attr))
+      expect(new_state.send(attr)).not_to equal(@pdf.graphic_state.send(attr))
     end
   end
 end
@@ -515,7 +517,7 @@ describe "When using transformation matrix" do
   it "should be received by the inspector" do
     @pdf.transformation_matrix 1, 0, 0, -1, 5.5, 20
     matrices = PDF::Inspector::Graphics::Matrix.analyze(@pdf.render)
-    matrices.matrices.should == [[1, 0, 0, -1, 5.5, 20]]
+    expect(matrices.matrices).to eq([[1, 0, 0, -1, 5.5, 20]])
   end
 
   it "should save the graphics state inside the given block" do
@@ -558,13 +560,13 @@ describe "When using transformations shortcuts" do
       @pdf.rotate(@angle, :origin => [@x, @y]) { @pdf.text('hello world') }
 
       matrices = PDF::Inspector::Graphics::Matrix.analyze(@pdf.render)
-      matrices.matrices[0].should == [1, 0, 0, 1,
-                                      reduce_precision(@x - x_prime),
-                                      reduce_precision(@y - y_prime)]
-      matrices.matrices[1].should == [reduce_precision(@cos),
-                                      reduce_precision(@sin),
-                                      reduce_precision(-@sin),
-                                      reduce_precision(@cos), 0, 0]
+      expect(matrices.matrices[0]).to eq([1, 0, 0, 1,
+                                          reduce_precision(@x - x_prime),
+                                          reduce_precision(@y - y_prime)])
+      expect(matrices.matrices[1]).to eq([reduce_precision(@cos),
+                                          reduce_precision(@sin),
+                                          reduce_precision(-@sin),
+                                          reduce_precision(@cos), 0, 0])
     end
 
     it "should rotate around the origin in a document with a margin" do
@@ -578,19 +580,19 @@ describe "When using transformations shortcuts" do
       y_prime = x * @sin + y * @cos
 
       matrices = PDF::Inspector::Graphics::Matrix.analyze(@pdf.render)
-      matrices.matrices[0].should == [1, 0, 0, 1,
-                                      reduce_precision(x - x_prime),
-                                      reduce_precision(y - y_prime)]
-      matrices.matrices[1].should == [reduce_precision(@cos),
-                                      reduce_precision(@sin),
-                                      reduce_precision(-@sin),
-                                      reduce_precision(@cos), 0, 0]
+      expect(matrices.matrices[0]).to eq([1, 0, 0, 1,
+                                          reduce_precision(x - x_prime),
+                                          reduce_precision(y - y_prime)])
+      expect(matrices.matrices[1]).to eq([reduce_precision(@cos),
+                                          reduce_precision(@sin),
+                                          reduce_precision(-@sin),
+                                          reduce_precision(@cos), 0, 0])
     end
 
     it "should raise_error BlockRequired if no block is given" do
-      lambda {
+      expect {
         @pdf.rotate(@angle, :origin => [@x, @y])
-      }.should raise_error(Prawn::Errors::BlockRequired)
+      }.to raise_error(Prawn::Errors::BlockRequired)
     end
 
     def reduce_precision(float)
@@ -621,10 +623,10 @@ describe "When using transformations shortcuts" do
       @pdf.scale(@factor, :origin => [@x, @y]) { @pdf.text('hello world') }
 
       matrices = PDF::Inspector::Graphics::Matrix.analyze(@pdf.render)
-      matrices.matrices[0].should == [1, 0, 0, 1,
-                                      reduce_precision(@x - x_prime),
-                                      reduce_precision(@y - y_prime)]
-      matrices.matrices[1].should == [@factor, 0, 0, @factor, 0, 0]
+      expect(matrices.matrices[0]).to eq([1, 0, 0, 1,
+                                          reduce_precision(@x - x_prime),
+                                          reduce_precision(@y - y_prime)])
+      expect(matrices.matrices[1]).to eq([@factor, 0, 0, @factor, 0, 0])
     end
 
     it "should scale from the origin in a document with a margin" do
@@ -637,16 +639,16 @@ describe "When using transformations shortcuts" do
       @pdf.scale(@factor, :origin => [@x, @y]) { @pdf.text('hello world') }
 
       matrices = PDF::Inspector::Graphics::Matrix.analyze(@pdf.render)
-      matrices.matrices[0].should == [1, 0, 0, 1,
-                                      reduce_precision(x - x_prime),
-                                      reduce_precision(y - y_prime)]
-      matrices.matrices[1].should == [@factor, 0, 0, @factor, 0, 0]
+      expect(matrices.matrices[0]).to eq([1, 0, 0, 1,
+                                          reduce_precision(x - x_prime),
+                                          reduce_precision(y - y_prime)])
+      expect(matrices.matrices[1]).to eq([@factor, 0, 0, @factor, 0, 0])
     end
 
     it "should raise_error BlockRequired if no block is given" do
-      lambda {
+      expect {
         @pdf.scale(@factor, :origin => [@x, @y])
-      }.should raise_error(Prawn::Errors::BlockRequired)
+      }.to raise_error(Prawn::Errors::BlockRequired)
     end
 
     def reduce_precision(float)

--- a/spec/grid_spec.rb
+++ b/spec/grid_spec.rb
@@ -8,20 +8,20 @@ describe "A document's grid" do
 
   it "should allow definition of a grid" do
     @pdf.define_grid(:columns => 5, :rows => 8, :gutter => 0.1)
-    @pdf.grid.columns.should == 5
-    @pdf.grid.rows.should == 8
-    @pdf.grid.gutter.should == 0.1
+    expect(@pdf.grid.columns).to eq(5)
+    expect(@pdf.grid.rows).to eq(8)
+    expect(@pdf.grid.gutter).to eq(0.1)
   end
 
   it "should allow re-definition of a grid" do
     @pdf.define_grid(:columns => 5, :rows => 8, :gutter => 0.1)
-    @pdf.grid.columns.should == 5
-    @pdf.grid.rows.should == 8
-    @pdf.grid.gutter.should == 0.1
+    expect(@pdf.grid.columns).to eq(5)
+    expect(@pdf.grid.rows).to eq(8)
+    expect(@pdf.grid.gutter).to eq(0.1)
     @pdf.define_grid(:columns => 3, :rows => 6, :gutter => 0.1)
-    @pdf.grid.columns.should == 3
-    @pdf.grid.rows.should == 6
-    @pdf.grid.gutter.should == 0.1
+    expect(@pdf.grid.columns).to eq(3)
+    expect(@pdf.grid.rows).to eq(6)
+    expect(@pdf.grid.gutter).to eq(0.1)
   end
 
   describe "when a grid is defined" do
@@ -37,13 +37,13 @@ describe "A document's grid" do
     end
 
     it "should compute the column width" do
-      (@pdf.grid.column_width * @num_columns.to_f +
-        @gutter * (@num_columns - 1).to_f).should == @pdf.bounds.width
+      expect(@pdf.grid.column_width * @num_columns.to_f +
+        @gutter * (@num_columns - 1).to_f).to eq(@pdf.bounds.width)
     end
 
     it "should compute the row height" do
-      (@pdf.grid.row_height * @num_rows.to_f +
-        @gutter * (@num_rows - 1).to_f).should == @pdf.bounds.height
+      expect(@pdf.grid.row_height * @num_rows.to_f +
+        @gutter * (@num_rows - 1).to_f).to eq(@pdf.bounds.height)
     end
 
     it "should give the edges of a grid box" do
@@ -55,30 +55,30 @@ describe "A document's grid" do
       exp_tl_x = (grid_width + @gutter.to_f) * 4.0
       exp_tl_y = @pdf.bounds.height.to_f - (grid_height + @gutter.to_f)
 
-      @pdf.grid(1,4).top_left.should == [exp_tl_x, exp_tl_y]
-      @pdf.grid(1,4).top_right.should == [exp_tl_x + grid_width, exp_tl_y]
-      @pdf.grid(1,4).bottom_left.should == [exp_tl_x, exp_tl_y - grid_height]
-      @pdf.grid(1,4).bottom_right.should == [exp_tl_x + grid_width, exp_tl_y - grid_height]
+      expect(@pdf.grid(1,4).top_left).to eq([exp_tl_x, exp_tl_y])
+      expect(@pdf.grid(1,4).top_right).to eq([exp_tl_x + grid_width, exp_tl_y])
+      expect(@pdf.grid(1,4).bottom_left).to eq([exp_tl_x, exp_tl_y - grid_height])
+      expect(@pdf.grid(1,4).bottom_right).to eq([exp_tl_x + grid_width, exp_tl_y - grid_height])
     end
 
     it "should give the edges of a multiple grid boxes" do
       # Hand verified.  Cheating a bit.  Don't tell.
-      @pdf.grid([1,3], [2,5]).top_left.should == [330.0, 628.75]
-      @pdf.grid([1,3], [2,5]).top_right.should == [650.0, 628.75]
-      @pdf.grid([1,3], [2,5]).bottom_left.should == [330.0, 456.25]
-      @pdf.grid([1,3], [2,5]).bottom_right.should == [650.0, 456.25]
+      expect(@pdf.grid([1,3], [2,5]).top_left).to eq([330.0, 628.75])
+      expect(@pdf.grid([1,3], [2,5]).top_right).to eq([650.0, 628.75])
+      expect(@pdf.grid([1,3], [2,5]).bottom_left).to eq([330.0, 456.25])
+      expect(@pdf.grid([1,3], [2,5]).bottom_right).to eq([650.0, 456.25])
     end
 
     it "should draw outlines without changing global default colors to grid color" do
       @pdf.grid.show_all('cccccc')
 
       colors = PDF::Inspector::Graphics::Color.analyze(@pdf.render)
-      colors.fill_color.should_not == [0.8,0.8,0.8]
-      colors.stroke_color.should_not == [0.8,0.8,0.8]
+      expect(colors.fill_color).not_to eq([0.8,0.8,0.8])
+      expect(colors.stroke_color).not_to eq([0.8,0.8,0.8])
 
       # Hardcoded default color as I haven't been able to come up with a stable converter
       # between fill_color without lots code.
-      colors.stroke_color.should == [0.0,0.0,0.0]
+      expect(colors.stroke_color).to eq([0.0,0.0,0.0])
     end
 
     it "should draw outlines without curent color settings" do
@@ -88,8 +88,8 @@ describe "A document's grid" do
       @pdf.grid.show_all
 
       colors = PDF::Inspector::Graphics::Color.analyze(@pdf.render)
-      colors.fill_color.should == [0.8,1.0,0.0]
-      colors.stroke_color.should == [1.0,0.8,0.0]
+      expect(colors.fill_color).to eq([0.8,1.0,0.0])
+      expect(colors.stroke_color).to eq([1.0,0.8,0.0])
     end
   end
 end

--- a/spec/image_handler_spec.rb
+++ b/spec/image_handler_spec.rb
@@ -15,7 +15,7 @@ describe "ImageHandler" do
     image_handler.register(handler_b)
 
     handler = image_handler.find("arbitrary blob")
-    handler.should == handler_a
+    expect(handler).to eq(handler_a)
   end
 
   it "can prepend handlers" do
@@ -25,7 +25,7 @@ describe "ImageHandler" do
     image_handler.register!(handler_b)
 
     handler = image_handler.find("arbitrary blob")
-    handler.should == handler_b
+    expect(handler).to eq(handler_b)
   end
 
   it "can unregister a handler" do
@@ -37,7 +37,7 @@ describe "ImageHandler" do
     image_handler.unregister(handler_a)
 
     handler = image_handler.find('arbitrary blob')
-    handler.should == handler_b
+    expect(handler).to eq(handler_b)
   end
 
   it "raises an error when no matching handler is found" do

--- a/spec/images_spec.rb
+++ b/spec/images_spec.rb
@@ -17,24 +17,24 @@ describe "the image() function" do
     output = @pdf.render
     images = PDF::Inspector::XObject.analyze(output)
     # there should be 2 images in the page resources
-    images.page_xobjects.first.size.should == 2
+    expect(images.page_xobjects.first.size).to eq(2)
     # but only 1 image xobject
-    output.scan(/\/Type \/XObject/).size.should == 1
+    expect(output.scan(/\/Type \/XObject/).size).to eq(1)
   end
 
   it "should return the image info object" do
     info =  @pdf.image(@filename)
 
-    info.should be_a_kind_of(Prawn::Images::JPG)
+    expect(info).to be_a_kind_of(Prawn::Images::JPG)
 
-    info.height.should == 453
+    expect(info.height).to eq(453)
   end
 
   it "should accept IO objects" do
     file = File.open(@filename, "rb")
     info = @pdf.image(file)
 
-    info.height.should == 453
+    expect(info.height).to eq(453)
   end
 
   it "rewinds IO objects to be able to embed them multiply" do
@@ -42,12 +42,12 @@ describe "the image() function" do
 
     @pdf.image(file)
     info = @pdf.image(file)
-    info.height.should == 453
+    expect(info.height).to eq(453)
   end
 
   it "should accept Pathname objects" do
     info = @pdf.image(Pathname.new(@filename))
-    info.height.should == 453
+    expect(info.height).to eq(453)
   end
 
   context "setting the length of the bytestream" do
@@ -69,25 +69,25 @@ describe "the image() function" do
 
   it "should raise_error an UnsupportedImageType if passed a BMP" do
     filename = "#{Prawn::DATADIR}/images/tru256.bmp"
-    lambda { @pdf.image filename, :at => [100,100] }.should raise_error(Prawn::Errors::UnsupportedImageType)
+    expect { @pdf.image filename, :at => [100,100] }.to raise_error(Prawn::Errors::UnsupportedImageType)
   end
 
   it "should raise_error an UnsupportedImageType if passed an interlaced PNG" do
     filename = "#{Prawn::DATADIR}/images/dice_interlaced.png"
-    lambda { @pdf.image filename, :at => [100,100] }.should raise_error(Prawn::Errors::UnsupportedImageType)
+    expect { @pdf.image filename, :at => [100,100] }.to raise_error(Prawn::Errors::UnsupportedImageType)
   end
 
   it "should bump PDF version to 1.5 or greater on embedding 16-bit PNGs" do
     @pdf.image "#{Prawn::DATADIR}/images/16bit.png"
-    @pdf.state.version.should >= 1.5
+    expect(@pdf.state.version).to be >= 1.5
   end
 
   it "should embed 16-bit alpha channels for 16-bit PNGs" do
     @pdf.image "#{Prawn::DATADIR}/images/16bit.png"
 
     output = @pdf.render
-    output.should =~ /\/BitsPerComponent 16/
-    output.should_not =~ /\/BitsPerComponent 8/
+    expect(output).to match(/\/BitsPerComponent 16/)
+    expect(output).not_to match(/\/BitsPerComponent 8/)
   end
 
   it "should flow an image to a new page if it will not fit on a page" do
@@ -96,9 +96,9 @@ describe "the image() function" do
     output = StringIO.new(@pdf.render, 'r+')
     hash = PDF::Reader::ObjectHash.new(output)
     pages = hash.values.find {|obj| obj.is_a?(Hash) && obj[:Type] == :Pages}[:Kids]
-    pages.size.should == 2
-    hash[pages[0]][:Resources][:XObject].keys.should == [:I1]
-    hash[pages[1]][:Resources][:XObject].keys.should == [:I2]
+    expect(pages.size).to eq(2)
+    expect(hash[pages[0]][:Resources][:XObject].keys).to eq([:I1])
+    expect(hash[pages[1]][:Resources][:XObject].keys).to eq([:I2])
   end
 
   it "should not flow an image to a new page if it will fit on one page" do
@@ -107,9 +107,10 @@ describe "the image() function" do
     output = StringIO.new(@pdf.render, 'r+')
     hash = PDF::Reader::ObjectHash.new(output)
     pages = hash.values.find {|obj| obj.is_a?(Hash) && obj[:Type] == :Pages}[:Kids]
-    pages.size.should == 1
-    Set.new(hash[pages[0]][:Resources][:XObject].keys).should ==
+    expect(pages.size).to eq(1)
+    expect(Set.new(hash[pages[0]][:Resources][:XObject].keys)).to eq(
       Set.new([:I1, :I2])
+    )
   end
 
   it "should not start a new page just for a stretchy bounding box" do
@@ -122,21 +123,21 @@ describe "the image() function" do
   describe ":fit option" do
     it "should fit inside the defined constraints" do
       info = @pdf.image @filename, :fit => [100,400]
-      info.scaled_width.should <= 100
-      info.scaled_height.should <= 400
+      expect(info.scaled_width).to be <= 100
+      expect(info.scaled_height).to be <= 400
 
       info = @pdf.image @filename, :fit => [400,100]
-      info.scaled_width.should <= 400
-      info.scaled_height.should <= 100
+      expect(info.scaled_width).to be <= 400
+      expect(info.scaled_height).to be <= 100
 
       info = @pdf.image @filename, :fit => [604,453]
-      info.scaled_width.should == 604
-      info.scaled_height.should == 453
+      expect(info.scaled_width).to eq(604)
+      expect(info.scaled_height).to eq(453)
     end
     it "should move text position" do
       @y = @pdf.y
       info = @pdf.image @filename, :fit => [100,400]
-      @pdf.y.should < @y
+      expect(@pdf.y).to be < @y
     end
   end
 
@@ -144,23 +145,23 @@ describe "the image() function" do
     it "should not move text position" do
       @y = @pdf.y
       info = @pdf.image @filename, :at => [100,400]
-      @pdf.y.should == @y
+      expect(@pdf.y).to eq(@y)
     end
   end
 
   describe ":width option without :height option" do
     it "scales the width and height" do
       info = @pdf.image @filename, :width => 225
-      info.scaled_height.should == 168.75
-      info.scaled_width.should == 225.0
+      expect(info.scaled_height).to eq(168.75)
+      expect(info.scaled_width).to eq(225.0)
     end
   end
 
   describe ":height option without :width option" do
     it "scales the width and height" do
       info = @pdf.image @filename, :height => 225
-      info.scaled_height.should == 225.0
-      info.scaled_width.should == 300.0
+      expect(info.scaled_height).to eq(225.0)
+      expect(info.scaled_width).to eq(300.0)
     end
   end
 end

--- a/spec/inline_formatted_text_parser_spec.rb
+++ b/spec/inline_formatted_text_parser_spec.rb
@@ -5,348 +5,348 @@ describe "Text::Formatted::Parser#format" do
   it "should handle sup" do
     string = "<sup>superscript</sup>"
     array = Prawn::Text::Formatted::Parser.format(string)
-    array[0].should == { :text => "superscript",
-                         :styles => [:superscript],
-                         :color => nil,
-                         :link => nil,
-                         :anchor => nil,
-                         :local => nil,
-                         :font => nil,
-                         :size => nil,
-                         :character_spacing => nil }
+    expect(array[0]).to eq(:text => "superscript",
+                           :styles => [:superscript],
+                           :color => nil,
+                           :link => nil,
+                           :anchor => nil,
+                           :local => nil,
+                           :font => nil,
+                           :size => nil,
+                           :character_spacing => nil)
   end
   it "should handle sub" do
     string = "<sub>subscript</sub>"
     array = Prawn::Text::Formatted::Parser.format(string)
-    array[0].should == { :text => "subscript",
-                         :styles => [:subscript],
-                         :color => nil,
-                         :link => nil,
-                         :anchor => nil,
-                         :local => nil,
-                         :font => nil,
-                         :size => nil,
-                         :character_spacing => nil }
+    expect(array[0]).to eq(:text => "subscript",
+                           :styles => [:subscript],
+                           :color => nil,
+                           :link => nil,
+                           :anchor => nil,
+                           :local => nil,
+                           :font => nil,
+                           :size => nil,
+                           :character_spacing => nil)
   end
   it "should handle rgb" do
     string = "<color rgb='#ff0000'>red text</color>"
     array = Prawn::Text::Formatted::Parser.format(string)
-    array[0].should == { :text => "red text",
-                         :styles => [],
-                         :color => "ff0000",
-                         :link => nil,
-                         :anchor => nil,
-                         :local => nil,
-                         :font => nil,
-                         :size => nil,
-                         :character_spacing => nil }
+    expect(array[0]).to eq(:text => "red text",
+                           :styles => [],
+                           :color => "ff0000",
+                           :link => nil,
+                           :anchor => nil,
+                           :local => nil,
+                           :font => nil,
+                           :size => nil,
+                           :character_spacing => nil)
   end
   it "# should be optional in rgb" do
     string = "<color rgb='ff0000'>red text</color>"
     array = Prawn::Text::Formatted::Parser.format(string)
-    array[0].should == { :text => "red text",
-                         :styles => [],
-                         :color => "ff0000",
-                         :link => nil,
-                         :anchor => nil,
-                         :local => nil,
-                         :font => nil,
-                         :size => nil,
-                         :character_spacing => nil }
+    expect(array[0]).to eq(:text => "red text",
+                           :styles => [],
+                           :color => "ff0000",
+                           :link => nil,
+                           :anchor => nil,
+                           :local => nil,
+                           :font => nil,
+                           :size => nil,
+                           :character_spacing => nil)
   end
   it "should handle cmyk" do
     string = "<color c='0' m='100' y='0' k='0'>magenta text</color>"
     array = Prawn::Text::Formatted::Parser.format(string)
-    array[0].should == { :text => "magenta text",
-                         :styles => [],
-                         :color => [0, 100, 0, 0],
-                         :link => nil,
-                         :anchor => nil,
-                         :local => nil,
-                         :font => nil,
-                         :size => nil,
-                         :character_spacing => nil }
+    expect(array[0]).to eq(:text => "magenta text",
+                           :styles => [],
+                           :color => [0, 100, 0, 0],
+                           :link => nil,
+                           :anchor => nil,
+                           :local => nil,
+                           :font => nil,
+                           :size => nil,
+                           :character_spacing => nil)
   end
   it "should handle fonts" do
     string = "<font name='Courier'>Courier text</font>"
     array = Prawn::Text::Formatted::Parser.format(string)
-    array[0].should == { :text => "Courier text",
-                         :styles => [],
-                         :color => nil,
-                         :link => nil,
-                         :anchor => nil,
-                         :local => nil,
-                         :font => "Courier",
-                         :size => nil,
-                         :character_spacing => nil }
+    expect(array[0]).to eq(:text => "Courier text",
+                           :styles => [],
+                           :color => nil,
+                           :link => nil,
+                           :anchor => nil,
+                           :local => nil,
+                           :font => "Courier",
+                           :size => nil,
+                           :character_spacing => nil)
   end
   it "should handle size" do
     string = "<font size='14'>14 point text</font>"
     array = Prawn::Text::Formatted::Parser.format(string)
-    array[0].should == { :text => "14 point text",
-                         :styles => [],
-                         :color => nil,
-                         :link => nil,
-                         :anchor => nil,
-                         :local => nil,
-                         :font => nil,
-                         :size => 14,
-                         :character_spacing => nil }
+    expect(array[0]).to eq(:text => "14 point text",
+                           :styles => [],
+                           :color => nil,
+                           :link => nil,
+                           :anchor => nil,
+                           :local => nil,
+                           :font => nil,
+                           :size => 14,
+                           :character_spacing => nil)
   end
   it "should handle character_spacing" do
     string = "<font character_spacing='2.5'>extra character spacing</font>"
     array = Prawn::Text::Formatted::Parser.format(string)
-    array[0].should == { :text => "extra character spacing",
-                         :styles => [],
-                         :color => nil,
-                         :link => nil,
-                         :anchor => nil,
-                         :local => nil,
-                         :font => nil,
-                         :size => nil,
-                         :character_spacing => 2.5 }
+    expect(array[0]).to eq(:text => "extra character spacing",
+                           :styles => [],
+                           :color => nil,
+                           :link => nil,
+                           :anchor => nil,
+                           :local => nil,
+                           :font => nil,
+                           :size => nil,
+                           :character_spacing => 2.5)
   end
   it "should handle links" do
     string = "<link href='http://example.com'>external link</link>"
     array = Prawn::Text::Formatted::Parser.format(string)
-    array[0].should == { :text => "external link",
-                         :styles => [],
-                         :color => nil,
-                         :link => "http://example.com",
-                         :anchor => nil,
-                         :local => nil,
-                         :font => nil,
-                         :size => nil,
-                         :character_spacing => nil }
+    expect(array[0]).to eq(:text => "external link",
+                           :styles => [],
+                           :color => nil,
+                           :link => "http://example.com",
+                           :anchor => nil,
+                           :local => nil,
+                           :font => nil,
+                           :size => nil,
+                           :character_spacing => nil)
   end
   it "should handle local links" do
     string = "<link local='/home/example/foo.bar'>local link</link>"
     array = Prawn::Text::Formatted::Parser.format(string)
-    array[0].should == { :text => "local link",
-                         :styles => [],
-                         :color => nil,
-                         :link => nil,
-                         :anchor => nil,
-                         :local => "/home/example/foo.bar",
-                         :font => nil,
-                         :size => nil,
-                         :character_spacing => nil }
+    expect(array[0]).to eq(:text => "local link",
+                           :styles => [],
+                           :color => nil,
+                           :link => nil,
+                           :anchor => nil,
+                           :local => "/home/example/foo.bar",
+                           :font => nil,
+                           :size => nil,
+                           :character_spacing => nil)
   end
   it "should handle anchors" do
     string = "<link anchor='ToC'>internal link</link>"
     array = Prawn::Text::Formatted::Parser.format(string)
-    array[0].should == { :text => "internal link",
-                         :styles => [],
-                         :color => nil,
-                         :link => nil,
-                         :anchor => "ToC",
-                         :local => nil,
-                         :font => nil,
-                         :size => nil,
-                         :character_spacing => nil }
+    expect(array[0]).to eq(:text => "internal link",
+                           :styles => [],
+                           :color => nil,
+                           :link => nil,
+                           :anchor => "ToC",
+                           :local => nil,
+                           :font => nil,
+                           :size => nil,
+                           :character_spacing => nil)
   end
   it "should handle higher order characters properly" do
     string = "<b>©\n©</b>"
     array = Prawn::Text::Formatted::Parser.format(string)
-    array[0].should == { :text => "©",
-                         :styles => [:bold],
-                         :color => nil,
-                         :link => nil,
-                         :anchor => nil,
-                         :local => nil,
-                         :font => nil,
-                         :size => nil,
-                         :character_spacing => nil }
-    array[1].should == { :text => "\n",
-                         :styles => [:bold],
-                         :color => nil,
-                         :link => nil,
-                         :anchor => nil,
-                         :local => nil,
-                         :font => nil,
-                         :size => nil,
-                         :character_spacing => nil }
-    array[2].should == { :text => "©",
-                         :styles => [:bold],
-                         :color => nil,
-                         :link => nil,
-                         :anchor => nil,
-                         :local => nil,
-                         :font => nil,
-                         :size => nil,
-                         :character_spacing => nil }
+    expect(array[0]).to eq(:text => "©",
+                           :styles => [:bold],
+                           :color => nil,
+                           :link => nil,
+                           :anchor => nil,
+                           :local => nil,
+                           :font => nil,
+                           :size => nil,
+                           :character_spacing => nil)
+    expect(array[1]).to eq(:text => "\n",
+                           :styles => [:bold],
+                           :color => nil,
+                           :link => nil,
+                           :anchor => nil,
+                           :local => nil,
+                           :font => nil,
+                           :size => nil,
+                           :character_spacing => nil)
+    expect(array[2]).to eq(:text => "©",
+                           :styles => [:bold],
+                           :color => nil,
+                           :link => nil,
+                           :anchor => nil,
+                           :local => nil,
+                           :font => nil,
+                           :size => nil,
+                           :character_spacing => nil)
   end
   it "should convert &lt; &gt;, and &amp; to <, >, and &, respectively" do
     string = "hello <b>&lt;, &gt;, and &amp;</b>"
     array = Prawn::Text::Formatted::Parser.format(string)
-    array[1].should == { :text => "<, >, and &",
-                         :styles => [:bold],
-                         :color => nil,
-                         :link => nil,
-                         :anchor => nil,
-                         :local => nil,
-                         :font => nil,
-                         :size => nil,
-                         :character_spacing => nil }
+    expect(array[1]).to eq(:text => "<, >, and &",
+                           :styles => [:bold],
+                           :color => nil,
+                           :link => nil,
+                           :anchor => nil,
+                           :local => nil,
+                           :font => nil,
+                           :size => nil,
+                           :character_spacing => nil)
   end
   it "should handle double qoutes around tag attributes" do
     string = 'some <font size="14">sized</font> text'
     array = Prawn::Text::Formatted::Parser.format(string)
-    array[1].should == { :text => "sized",
-                         :styles => [],
-                         :color => nil,
-                         :link => nil,
-                         :anchor => nil,
-                         :local => nil,
-                         :font => nil,
-                         :size => 14,
-                         :character_spacing => nil }
+    expect(array[1]).to eq(:text => "sized",
+                           :styles => [],
+                           :color => nil,
+                           :link => nil,
+                           :anchor => nil,
+                           :local => nil,
+                           :font => nil,
+                           :size => 14,
+                           :character_spacing => nil)
   end
   it "should handle single qoutes around tag attributes" do
     string = "some <font size='14'>sized</font> text"
     array = Prawn::Text::Formatted::Parser.format(string)
-    array[1].should == { :text => "sized",
-                         :styles => [],
-                         :color => nil,
-                         :link => nil,
-                         :anchor => nil,
-                         :local => nil,
-                         :font => nil,
-                         :size => 14,
-                         :character_spacing => nil }
+    expect(array[1]).to eq(:text => "sized",
+                           :styles => [],
+                           :color => nil,
+                           :link => nil,
+                           :anchor => nil,
+                           :local => nil,
+                           :font => nil,
+                           :size => 14,
+                           :character_spacing => nil)
   end
   it "should construct a formatted text array from a string" do
     string = "hello <b>world\nhow <i>are</i></b> you?"
     array = Prawn::Text::Formatted::Parser.format(string)
 
-    array[0].should == { :text => "hello ",
-                         :styles => [],
-                         :color => nil,
-                         :link => nil,
-                         :anchor => nil,
-                         :local => nil,
-                         :font => nil,
-                         :size => nil,
-                         :character_spacing => nil }
-    array[1].should == { :text => "world",
-                         :styles => [:bold],
-                         :color => nil,
-                         :link => nil,
-                         :anchor => nil,
-                         :local => nil,
-                         :font => nil,
-                         :size => nil,
-                         :character_spacing => nil }
-    array[2].should == { :text => "\n",
-                         :styles => [:bold],
-                         :color => nil,
-                         :link => nil,
-                         :anchor => nil,
-                         :local => nil,
-                         :font => nil,
-                         :size => nil,
-                         :character_spacing => nil }
-    array[3].should == { :text => "how ",
-                         :styles => [:bold],
-                         :color => nil,
-                         :link => nil,
-                         :anchor => nil,
-                         :local => nil,
-                         :font => nil,
-                         :size => nil,
-                         :character_spacing => nil }
-    array[4].should == { :text => "are",
-                         :styles => [:bold, :italic],
-                         :color => nil,
-                         :link => nil,
-                         :anchor => nil,
-                         :local => nil,
-                         :font => nil,
-                         :size => nil,
-                         :character_spacing => nil }
-    array[5].should == { :text => " you?",
-                         :styles => [],
-                         :color => nil,
-                         :link => nil,
-                         :anchor => nil,
-                         :local => nil,
-                         :font => nil,
-                         :size => nil,
-                         :character_spacing => nil }
+    expect(array[0]).to eq(:text => "hello ",
+                           :styles => [],
+                           :color => nil,
+                           :link => nil,
+                           :anchor => nil,
+                           :local => nil,
+                           :font => nil,
+                           :size => nil,
+                           :character_spacing => nil)
+    expect(array[1]).to eq(:text => "world",
+                           :styles => [:bold],
+                           :color => nil,
+                           :link => nil,
+                           :anchor => nil,
+                           :local => nil,
+                           :font => nil,
+                           :size => nil,
+                           :character_spacing => nil)
+    expect(array[2]).to eq(:text => "\n",
+                           :styles => [:bold],
+                           :color => nil,
+                           :link => nil,
+                           :anchor => nil,
+                           :local => nil,
+                           :font => nil,
+                           :size => nil,
+                           :character_spacing => nil)
+    expect(array[3]).to eq(:text => "how ",
+                           :styles => [:bold],
+                           :color => nil,
+                           :link => nil,
+                           :anchor => nil,
+                           :local => nil,
+                           :font => nil,
+                           :size => nil,
+                           :character_spacing => nil)
+    expect(array[4]).to eq(:text => "are",
+                           :styles => [:bold, :italic],
+                           :color => nil,
+                           :link => nil,
+                           :anchor => nil,
+                           :local => nil,
+                           :font => nil,
+                           :size => nil,
+                           :character_spacing => nil)
+    expect(array[5]).to eq(:text => " you?",
+                           :styles => [],
+                           :color => nil,
+                           :link => nil,
+                           :anchor => nil,
+                           :local => nil,
+                           :font => nil,
+                           :size => nil,
+                           :character_spacing => nil)
   end
   it "should accept <strong> as an alternative to <b>" do
     string = "<strong>bold</strong> not bold"
     array = Prawn::Text::Formatted::Parser.format(string)
 
-    array[0].should == { :text => "bold",
-                         :styles => [:bold],
-                         :color => nil,
-                         :link => nil,
-                         :anchor => nil,
-                         :local => nil,
-                         :font => nil,
-                         :size => nil,
-                         :character_spacing => nil }
-    array[1].should == { :text => " not bold",
-                         :styles => [],
-                         :color => nil,
-                         :link => nil,
-                         :anchor => nil,
-                         :local => nil,
-                         :font => nil,
-                         :size => nil,
-                         :character_spacing => nil }
+    expect(array[0]).to eq(:text => "bold",
+                           :styles => [:bold],
+                           :color => nil,
+                           :link => nil,
+                           :anchor => nil,
+                           :local => nil,
+                           :font => nil,
+                           :size => nil,
+                           :character_spacing => nil)
+    expect(array[1]).to eq(:text => " not bold",
+                           :styles => [],
+                           :color => nil,
+                           :link => nil,
+                           :anchor => nil,
+                           :local => nil,
+                           :font => nil,
+                           :size => nil,
+                           :character_spacing => nil)
   end
   it "should accept <em> as an alternative to <i>" do
     string = "<em>italic</em> not italic"
     array = Prawn::Text::Formatted::Parser.format(string)
 
-    array[0].should == { :text => "italic",
-                         :styles => [:italic],
-                         :color => nil,
-                         :link => nil,
-                         :anchor => nil,
-                         :local => nil,
-                         :font => nil,
-                         :size => nil,
-                         :character_spacing => nil }
-    array[1].should == { :text => " not italic",
-                         :styles => [],
-                         :color => nil,
-                         :link => nil,
-                         :anchor => nil,
-                         :local => nil,
-                         :font => nil,
-                         :size => nil,
-                         :character_spacing => nil }
+    expect(array[0]).to eq(:text => "italic",
+                           :styles => [:italic],
+                           :color => nil,
+                           :link => nil,
+                           :anchor => nil,
+                           :local => nil,
+                           :font => nil,
+                           :size => nil,
+                           :character_spacing => nil)
+    expect(array[1]).to eq(:text => " not italic",
+                           :styles => [],
+                           :color => nil,
+                           :link => nil,
+                           :anchor => nil,
+                           :local => nil,
+                           :font => nil,
+                           :size => nil,
+                           :character_spacing => nil)
   end
   it "should accept <a> as an alternative to <link>" do
     string = "<a href='http://example.com'>link</a> not a link"
     array = Prawn::Text::Formatted::Parser.format(string)
 
-    array[0].should == { :text => "link",
-                         :styles => [],
-                         :color => nil,
-                         :link => "http://example.com",
-                         :anchor => nil,
-                         :local => nil,
-                         :font => nil,
-                         :size => nil,
-                         :character_spacing => nil }
-    array[1].should == { :text => " not a link",
-                         :styles => [],
-                         :color => nil,
-                         :link => nil,
-                         :anchor => nil,
-                         :local => nil,
-                         :font => nil,
-                         :size => nil,
-                         :character_spacing => nil }
+    expect(array[0]).to eq(:text => "link",
+                           :styles => [],
+                           :color => nil,
+                           :link => "http://example.com",
+                           :anchor => nil,
+                           :local => nil,
+                           :font => nil,
+                           :size => nil,
+                           :character_spacing => nil)
+    expect(array[1]).to eq(:text => " not a link",
+                           :styles => [],
+                           :color => nil,
+                           :link => nil,
+                           :anchor => nil,
+                           :local => nil,
+                           :font => nil,
+                           :size => nil,
+                           :character_spacing => nil)
   end
 
   it "should turn <br>, <br/> into newline" do
     array = Prawn::Text::Formatted::Parser.format("hello<br>big<br/>world")
-    array.map { |frag| frag[:text] }.join.should == "hello\nbig\nworld"
+    expect(array.map { |frag| frag[:text] }.join).to eq("hello\nbig\nworld")
   end
 end
 
@@ -362,7 +362,7 @@ describe "Text::Formatted::Parser#to_string" do
                :font => nil,
                :size => nil,
                :character_spacing => nil }]
-    Prawn::Text::Formatted::Parser.to_string(array).should == string
+    expect(Prawn::Text::Formatted::Parser.to_string(array)).to eq(string)
   end
   it "should handle sub" do
     string = "<sub>subscript</sub>"
@@ -375,7 +375,7 @@ describe "Text::Formatted::Parser#to_string" do
                :font => nil,
                :size => nil,
                :character_spacing => nil }]
-    Prawn::Text::Formatted::Parser.to_string(array).should == string
+    expect(Prawn::Text::Formatted::Parser.to_string(array)).to eq(string)
   end
   it "should handle rgb" do
     string = "<color rgb='ff0000'>red text</color>"
@@ -388,7 +388,7 @@ describe "Text::Formatted::Parser#to_string" do
                :font => nil,
                :size => nil,
                :character_spacing => nil }]
-    Prawn::Text::Formatted::Parser.to_string(array).should == string
+    expect(Prawn::Text::Formatted::Parser.to_string(array)).to eq(string)
   end
   it "should handle cmyk" do
     string = "<color c='0' m='100' y='0' k='0'>magenta text</color>"
@@ -401,7 +401,7 @@ describe "Text::Formatted::Parser#to_string" do
                :font => nil,
                :size => nil,
                :character_spacing => nil }]
-    Prawn::Text::Formatted::Parser.to_string(array).should == string
+    expect(Prawn::Text::Formatted::Parser.to_string(array)).to eq(string)
   end
   it "should handle fonts" do
     string = "<font name='Courier'>Courier text</font>"
@@ -414,7 +414,7 @@ describe "Text::Formatted::Parser#to_string" do
                :font => "Courier",
                :size => nil,
                :character_spacing => nil }]
-    Prawn::Text::Formatted::Parser.to_string(array).should == string
+    expect(Prawn::Text::Formatted::Parser.to_string(array)).to eq(string)
   end
   it "should handle size" do
     string = "<font size='14'>14 point text</font>"
@@ -427,7 +427,7 @@ describe "Text::Formatted::Parser#to_string" do
                :font => nil,
                :size => 14,
                :character_spacing => nil }]
-    Prawn::Text::Formatted::Parser.to_string(array).should == string
+    expect(Prawn::Text::Formatted::Parser.to_string(array)).to eq(string)
   end
   it "should handle character spacing" do
     string = "<font character_spacing='2.5'>2.5 extra character spacing</font>"
@@ -440,7 +440,7 @@ describe "Text::Formatted::Parser#to_string" do
                :font => nil,
                :size => nil,
                :character_spacing => 2.5 }]
-    Prawn::Text::Formatted::Parser.to_string(array).should == string
+    expect(Prawn::Text::Formatted::Parser.to_string(array)).to eq(string)
   end
   it "should handle links" do
     array = [{ :text => "external link",
@@ -453,7 +453,7 @@ describe "Text::Formatted::Parser#to_string" do
                :size => nil,
                :character_spacing => nil }]
     string = "<link href='http://example.com'>external link</link>"
-    Prawn::Text::Formatted::Parser.to_string(array).should == string
+    expect(Prawn::Text::Formatted::Parser.to_string(array)).to eq(string)
   end
   it "should handle anchors" do
     array = [{ :text => "internal link",
@@ -465,7 +465,7 @@ describe "Text::Formatted::Parser#to_string" do
                :size => nil,
                :character_spacing => nil }]
     string = "<link anchor='ToC'>internal link</link>"
-    Prawn::Text::Formatted::Parser.to_string(array).should == string
+    expect(Prawn::Text::Formatted::Parser.to_string(array)).to eq(string)
   end
   it "should convert <, >, and & to &lt; &gt;, and &amp;, respectively" do
     array = [
@@ -489,7 +489,7 @@ describe "Text::Formatted::Parser#to_string" do
       }
     ]
     string = "hello <b>&lt;, &gt;, and &amp;</b>"
-    Prawn::Text::Formatted::Parser.to_string(array).should == string
+    expect(Prawn::Text::Formatted::Parser.to_string(array)).to eq(string)
   end
   it "should construct an HTML-esque string from a formatted text array" do
     array = [
@@ -537,7 +537,7 @@ describe "Text::Formatted::Parser#to_string" do
         :character_spacing => nil }
     ]
     string = "<font size='14'>hello </font><b>world</b><b>\n</b><b>how </b><b><i>are</i></b> you?"
-    Prawn::Text::Formatted::Parser.to_string(array).should == string
+    expect(Prawn::Text::Formatted::Parser.to_string(array)).to eq(string)
   end
 end
 
@@ -555,7 +555,7 @@ describe "Text::Formatted::Parser#array_paragraphs" do
               [{ :text => "how" },
                { :text => "are" },
                { :text => "you" }]]
-    Prawn::Text::Formatted::Parser.array_paragraphs(array).should == target
+    expect(Prawn::Text::Formatted::Parser.array_paragraphs(array)).to eq(target)
   end
 
   it "should work properly if ending in an empty paragraph" do
@@ -563,6 +563,6 @@ describe "Text::Formatted::Parser#array_paragraphs" do
     target = [[{ :text => "\n" }],
               [{ :text => "hello" }],
               [{ :text => "world" }]]
-    Prawn::Text::Formatted::Parser.array_paragraphs(array).should == target
+    expect(Prawn::Text::Formatted::Parser.array_paragraphs(array)).to eq(target)
   end
 end

--- a/spec/jpg_spec.rb
+++ b/spec/jpg_spec.rb
@@ -15,9 +15,9 @@ describe "When reading a JPEG file" do
   it "should read the basic attributes correctly" do
     jpg = Prawn::Images::JPG.new(@img_data)
 
-    jpg.width.should == 604
-    jpg.height.should == 453
-    jpg.bits.should == 8
-    jpg.channels.should == 3
+    expect(jpg.width).to eq(604)
+    expect(jpg.height).to eq(453)
+    expect(jpg.bits).to eq(8)
+    expect(jpg.channels).to eq(3)
   end
 end

--- a/spec/line_wrap_spec.rb
+++ b/spec/line_wrap_spec.rb
@@ -16,7 +16,7 @@ describe "Core::Text::Formatted::LineWrap#wrap_line" do
     string = @line_wrap.wrap_line(:arranger => @arranger,
                                   :width => 300,
                                   :document => @pdf)
-    string.should == "hello world, goodbye"
+    expect(string).to eq("hello world, goodbye")
   end
   it "should strip trailing spaces when a white-space-only fragment was" \
      " successfully pushed onto the end of a line but no other non-white" \
@@ -28,17 +28,17 @@ describe "Core::Text::Formatted::LineWrap#wrap_line" do
     string = @line_wrap.wrap_line(:arranger => @arranger,
                                   :width => 300,
                                   :document => @pdf)
-    string.should == "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    expect(string).to eq("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
   end
   it "should raise_error CannotFit if a too-small width is given" do
     array = [{ :text => " hello world, " },
              { :text => "goodbye  ", :style => [:bold] }]
     @arranger.format_array = array
-    lambda do
+    expect do
       @line_wrap.wrap_line(:arranger => @arranger,
                            :width => 1,
                            :document => @pdf)
-    end.should raise_error(Prawn::Errors::CannotFit)
+    end.to raise_error(Prawn::Errors::CannotFit)
   end
 
   it "should break on space" do
@@ -47,7 +47,7 @@ describe "Core::Text::Formatted::LineWrap#wrap_line" do
     string = @line_wrap.wrap_line(:arranger => @arranger,
                                   :width => @one_word_width,
                                   :document => @pdf)
-    string.should == "hello"
+    expect(string).to eq("hello")
   end
 
   it "should break on zero-width space" do
@@ -57,7 +57,7 @@ describe "Core::Text::Formatted::LineWrap#wrap_line" do
     string = @line_wrap.wrap_line(:arranger => @arranger,
                                   :width => @one_word_width,
                                   :document => @pdf)
-    string.should == "hello"
+    expect(string).to eq("hello")
   end
 
   it "should not display zero-width space" do
@@ -67,7 +67,7 @@ describe "Core::Text::Formatted::LineWrap#wrap_line" do
     string = @line_wrap.wrap_line(:arranger => @arranger,
                                   :width => 300,
                                   :document => @pdf)
-    string.should == "helloworld"
+    expect(string).to eq("helloworld")
   end
 
   it "should break on tab" do
@@ -76,7 +76,7 @@ describe "Core::Text::Formatted::LineWrap#wrap_line" do
     string = @line_wrap.wrap_line(:arranger => @arranger,
                                   :width => @one_word_width,
                                   :document => @pdf)
-    string.should == "hello"
+    expect(string).to eq("hello")
   end
 
   it "should break on hyphens" do
@@ -85,7 +85,7 @@ describe "Core::Text::Formatted::LineWrap#wrap_line" do
     string = @line_wrap.wrap_line(:arranger => @arranger,
                                   :width => @one_word_width,
                                   :document => @pdf)
-    string.should == "hello-"
+    expect(string).to eq("hello-")
   end
 
   it "should not break after a hyphen that follows white space and" \
@@ -95,14 +95,14 @@ describe "Core::Text::Formatted::LineWrap#wrap_line" do
     string = @line_wrap.wrap_line(:arranger => @arranger,
                                   :width => @one_word_width,
                                   :document => @pdf)
-    string.should == "hello -"
+    expect(string).to eq("hello -")
 
     array = [{ :text => "hello -world" }]
     @arranger.format_array = array
     string = @line_wrap.wrap_line(:arranger => @arranger,
                                   :width => @one_word_width,
                                   :document => @pdf)
-    string.should == "hello"
+    expect(string).to eq("hello")
   end
 
   it "should break on a soft hyphen" do
@@ -114,7 +114,7 @@ describe "Core::Text::Formatted::LineWrap#wrap_line" do
                                   :document => @pdf)
     expected = @pdf.font.normalize_encoding("hello#{Prawn::Text::SHY}")
     expected.force_encoding(Encoding::UTF_8)
-    string.should == expected
+    expect(string).to eq(expected)
 
     @pdf.font("#{Prawn::DATADIR}/fonts/DejaVuSans.ttf")
     @line_wrap = Prawn::Text::Formatted::LineWrap.new
@@ -125,7 +125,7 @@ describe "Core::Text::Formatted::LineWrap#wrap_line" do
     string = @line_wrap.wrap_line(:arranger => @arranger,
                                   :width => @one_word_width,
                                   :document => @pdf)
-    string.should == "hello#{Prawn::Text::SHY}"
+    expect(string).to eq("hello#{Prawn::Text::SHY}")
   end
 
   it "should ignore width of a soft-hyphen during adding fragments to line", :issue => 775 do
@@ -149,7 +149,7 @@ describe "Core::Text::Formatted::LineWrap#wrap_line" do
     res2 = @line_wrap.wrap_line(:arranger => @arranger,
                                 :width => 300,
                                 :document => @pdf)
-    res1.should == res2
+    expect(res1).to eq(res2)
   end
 
   it "should not display soft hyphens except at the end of a line " \
@@ -164,7 +164,7 @@ describe "Core::Text::Formatted::LineWrap#wrap_line" do
     string = @line_wrap.wrap_line(:arranger => @arranger,
                                   :width => 300,
                                   :document => @pdf)
-    string.should == "helloworld hiearth"
+    expect(string).to eq("helloworld hiearth")
   end
 
   it "should not break before a hard hyphen that follows a word" do
@@ -175,14 +175,14 @@ describe "Core::Text::Formatted::LineWrap#wrap_line" do
     string = @line_wrap.wrap_line(:arranger => @arranger,
                                   :width => enough_width_for_hello_world,
                                   :document => @pdf)
-    string.should == "hello world"
+    expect(string).to eq("hello world")
 
     array = [{ :text => "hello world-" }]
     @arranger.format_array = array
     string = @line_wrap.wrap_line(:arranger => @arranger,
                                   :width => enough_width_for_hello_world,
                                   :document => @pdf)
-    string.should == "hello"
+    expect(string).to eq("hello")
 
     @pdf.font("#{Prawn::DATADIR}/fonts/DejaVuSans.ttf")
     @line_wrap = Prawn::Text::Formatted::LineWrap.new
@@ -193,14 +193,14 @@ describe "Core::Text::Formatted::LineWrap#wrap_line" do
     string = @line_wrap.wrap_line(:arranger => @arranger,
                                   :width => enough_width_for_hello_world,
                                   :document => @pdf)
-    string.should == "hello world"
+    expect(string).to eq("hello world")
 
     array = [{ :text => "hello world-" }]
     @arranger.format_array = array
     string = @line_wrap.wrap_line(:arranger => @arranger,
                                   :width => enough_width_for_hello_world,
                                   :document => @pdf)
-    string.should == "hello"
+    expect(string).to eq("hello")
   end
 
   it "should not break after a hard hyphen that follows a soft hyphen and" \
@@ -211,7 +211,7 @@ describe "Core::Text::Formatted::LineWrap#wrap_line" do
     string = @line_wrap.wrap_line(:arranger => @arranger,
                                   :width => @one_word_width,
                                   :document => @pdf)
-    string.should == "hello-"
+    expect(string).to eq("hello-")
 
     string = @pdf.font.normalize_encoding("hello#{Prawn::Text::SHY}-world")
     array = [{ :text => string }]
@@ -221,7 +221,7 @@ describe "Core::Text::Formatted::LineWrap#wrap_line" do
                                   :document => @pdf)
     expected = @pdf.font.normalize_encoding("hello#{Prawn::Text::SHY}")
     expected.force_encoding(Encoding::UTF_8)
-    string.should == expected
+    expect(string).to eq(expected)
 
     @pdf.font("#{Prawn::DATADIR}/fonts/DejaVuSans.ttf")
     @line_wrap = Prawn::Text::Formatted::LineWrap.new
@@ -232,7 +232,7 @@ describe "Core::Text::Formatted::LineWrap#wrap_line" do
     string = @line_wrap.wrap_line(:arranger => @arranger,
                                   :width => @one_word_width,
                                   :document => @pdf)
-    string.should == "hello-"
+    expect(string).to eq("hello-")
 
     string = "hello#{Prawn::Text::SHY}-world"
     array = [{ :text => string }]
@@ -240,7 +240,7 @@ describe "Core::Text::Formatted::LineWrap#wrap_line" do
     string = @line_wrap.wrap_line(:arranger => @arranger,
                                   :width => @one_word_width,
                                   :document => @pdf)
-    string.should == "hello#{Prawn::Text::SHY}"
+    expect(string).to eq("hello#{Prawn::Text::SHY}")
   end
 
   it "should process UTF-8 chars", :unresolved, :issue => 693 do
@@ -251,7 +251,7 @@ describe "Core::Text::Formatted::LineWrap#wrap_line" do
     string = @line_wrap.wrap_line(:arranger => @arranger,
                                   :width => 300,
                                   :document => @pdf)
-    string.should == "Ｔｅｓｔ"
+    expect(string).to eq("Ｔｅｓｔ")
   end
 end
 
@@ -268,7 +268,7 @@ describe "Core::Text::Formatted::LineWrap#space_count" do
     @line_wrap.wrap_line(:arranger => @arranger,
                          :width => 300,
                          :document => @pdf)
-    @line_wrap.space_count.should == 2
+    expect(@line_wrap.space_count).to eq(2)
   end
   it "should exclude preceding and trailing spaces from the count" do
     array = [{ :text => " hello world, " },
@@ -277,7 +277,7 @@ describe "Core::Text::Formatted::LineWrap#space_count" do
     @line_wrap.wrap_line(:arranger => @arranger,
                          :width => 300,
                          :document => @pdf)
-    @line_wrap.space_count.should == 2
+    expect(@line_wrap.space_count).to eq(2)
   end
 end
 
@@ -302,16 +302,16 @@ describe "Core::Text::Formatted::LineWrap" do
       line = @line_wrap.wrap_line(:arranger => @arranger,
                                   :width => 200,
                                   :document => @pdf)
-      line.should_not be_empty
+      expect(line).not_to be_empty
     end
     line = @line_wrap.wrap_line(:arranger => @arranger,
                                 :width => 200,
                                 :document => @pdf)
-    line.should be_empty
+    expect(line).to be_empty
   end
   it "should tokenize a string using the scan_pattern" do
     tokens = @line_wrap.tokenize("one two three")
-    tokens.length.should == 6
+    expect(tokens.length).to eq(6)
   end
 end
 
@@ -329,7 +329,7 @@ describe "Core::Text::Formatted::LineWrap#paragraph_finished?" do
                                   :width => @one_word_width,
                                   :document => @pdf)
 
-    @line_wrap.paragraph_finished?.should == false
+    expect(@line_wrap.paragraph_finished?).to eq(false)
   end
   it "should be_true when the last printed line is the last fragment to print" do
     array = [{ :text => "hello world" }]
@@ -341,7 +341,7 @@ describe "Core::Text::Formatted::LineWrap#paragraph_finished?" do
                                   :width => @one_word_width,
                                   :document => @pdf)
 
-    @line_wrap.paragraph_finished?.should == true
+    expect(@line_wrap.paragraph_finished?).to eq(true)
   end
   it "should be_true when a newline exists on the current line" do
     array = [{ :text => "hello\n world" }]
@@ -350,7 +350,7 @@ describe "Core::Text::Formatted::LineWrap#paragraph_finished?" do
                                   :width => @one_word_width,
                                   :document => @pdf)
 
-    @line_wrap.paragraph_finished?.should == true
+    expect(@line_wrap.paragraph_finished?).to eq(true)
   end
   it "should be_true when a newline exists in the next fragment" do
     array = [{ :text => "hello " },
@@ -361,6 +361,6 @@ describe "Core::Text::Formatted::LineWrap#paragraph_finished?" do
                                   :width => @one_word_width,
                                   :document => @pdf)
 
-    @line_wrap.paragraph_finished?.should == true
+    expect(@line_wrap.paragraph_finished?).to eq(true)
   end
 end

--- a/spec/measurement_units_spec.rb
+++ b/spec/measurement_units_spec.rb
@@ -5,18 +5,18 @@ require "prawn/measurement_extensions"
 
 describe "Measurement units" do
   it "should convert units to PostScriptPoints" do
-    1.mm.should be_within(0.000000001).of(2.834645669)
-    1.mm.should == (72 / 25.4)
-    2.mm.should == (2 * 72 / 25.4)
-    3.mm.should == 3 * 72 / 25.4
-    -3.mm.should == -3 * 72 / 25.4
-    1.cm.should == 10 * 72 / 25.4
-    1.dm.should == 100 * 72 / 25.4
-    1.m.should == 1000 * 72 / 25.4
+    expect(1.mm).to be_within(0.000000001).of(2.834645669)
+    expect(1.mm).to eq(72 / 25.4)
+    expect(2.mm).to eq(2 * 72 / 25.4)
+    expect(3.mm).to eq(3 * 72 / 25.4)
+    expect(-3.mm).to eq(-3 * 72 / 25.4)
+    expect(1.cm).to eq(10 * 72 / 25.4)
+    expect(1.dm).to eq(100 * 72 / 25.4)
+    expect(1.m).to eq(1000 * 72 / 25.4)
 
-    1.in.should == 72
-    1.ft.should == 72 * 12
-    1.yd.should == 72 * 12 * 3
-    1.pt.should == 1
+    expect(1.in).to eq(72)
+    expect(1.ft).to eq(72 * 12)
+    expect(1.yd).to eq(72 * 12 * 3)
+    expect(1.pt).to eq(1)
   end
 end

--- a/spec/outline_spec.rb
+++ b/spec/outline_spec.rb
@@ -24,7 +24,7 @@ describe "Outline" do
         if obj.is_a?(Hash) && obj[:Title]
           title = obj[:Title].dup
           title.force_encoding(Encoding::UTF_16LE)
-          title.valid_encoding?.should == true
+          expect(title.valid_encoding?).to eq(true)
         end
       end
     end
@@ -36,48 +36,48 @@ describe "Outline" do
     end
 
     it "should create a root outline dictionary item" do
-      @outline_root.should_not be_nil
+      expect(@outline_root).not_to be_nil
     end
 
     it "should set the first and last top items of the root outline dictionary item" do
-      referenced_object(@outline_root[:First]).should == @section_1
-      referenced_object(@outline_root[:Last]).should == @section_1
+      expect(referenced_object(@outline_root[:First])).to eq(@section_1)
+      expect(referenced_object(@outline_root[:Last])).to eq(@section_1)
     end
 
     describe "#create_outline_item" do
       it "should create outline items for each section and page" do
-        [@section_1, @page_1, @page_2].each {|item| item.should_not be_nil}
+        [@section_1, @page_1, @page_2].each {|item| expect(item).not_to be_nil}
       end
     end
 
     describe "#set_relations, #set_variables_for_block, and #reset_parent" do
       it "should link sibling items" do
-        referenced_object(@page_1[:Next]).should == @page_2
-        referenced_object(@page_2[:Prev]).should == @page_1
+        expect(referenced_object(@page_1[:Next])).to eq(@page_2)
+        expect(referenced_object(@page_2[:Prev])).to eq(@page_1)
       end
 
       it "should link child items to parent item" do
-        [@page_1, @page_2].each {|page| referenced_object(page[:Parent]).should == @section_1 }
+        [@page_1, @page_2].each {|page| expect(referenced_object(page[:Parent])).to eq(@section_1) }
       end
 
       it "should set the first and last child items for parent item" do
-        referenced_object(@section_1[:First]).should == @page_1
-        referenced_object(@section_1[:Last]).should == @page_2
+        expect(referenced_object(@section_1[:First])).to eq(@page_1)
+        expect(referenced_object(@section_1[:Last])).to eq(@page_2)
       end
     end
 
     describe "#increase_count" do
       it "should add the count of all descendant items" do
-        @outline_root[:Count].should == 3
-        @section_1[:Count].abs.should == 2
-        @page_1[:Count].should == 0
-        @page_2[:Count].should == 0
+        expect(@outline_root[:Count]).to eq(3)
+        expect(@section_1[:Count].abs).to eq(2)
+        expect(@page_1[:Count]).to eq(0)
+        expect(@page_2[:Count]).to eq(0)
       end
     end
 
     describe "closed option" do
       it "should set the item's integer count to negative" do
-        @section_1[:Count].should == -2
+        expect(@section_1[:Count]).to eq(-2)
       end
     end
   end
@@ -95,11 +95,11 @@ describe "Outline" do
     end
 
     it "should create an outline item" do
-      @custom_dest.should_not be_nil
+      expect(@custom_dest).not_to be_nil
     end
 
     it "should reference the custom destination" do
-      referenced_object(@custom_dest[:Dest].first).should == referenced_object(@pages.last)
+      expect(referenced_object(@custom_dest[:Dest].first)).to eq(referenced_object(@pages.last))
     end
   end
 
@@ -116,24 +116,24 @@ describe "Outline" do
     end
 
     it "should add new outline items to document" do
-      [@section_2, @page_3].each { |item| item.should_not be_nil}
+      [@section_2, @page_3].each { |item| expect(item).not_to be_nil}
     end
 
     it "should reset the last items for root outline dictionary" do
-      referenced_object(@outline_root[:First]).should == @section_1
-      referenced_object(@outline_root[:Last]).should == @section_2
+      expect(referenced_object(@outline_root[:First])).to eq(@section_1)
+      expect(referenced_object(@outline_root[:Last])).to eq(@section_2)
     end
 
     it "should reset the next relation for the previous last top level item" do
-      referenced_object(@section_1[:Next]).should == @section_2
+      expect(referenced_object(@section_1[:Next])).to eq(@section_2)
     end
 
     it "should set the previous relation of the addded to section" do
-      referenced_object(@section_2[:Prev]).should == @section_1
+      expect(referenced_object(@section_2[:Prev])).to eq(@section_1)
     end
 
     it "should increase the count of root outline dictionary" do
-      @outline_root[:Count].should == 5
+      expect(@outline_root[:Count]).to eq(5)
     end
   end
 
@@ -153,32 +153,32 @@ describe "Outline" do
       end
 
       it "should add new outline items to document" do
-        [@subsection, @added_page_3].each { |item| item.should_not be_nil}
+        [@subsection, @added_page_3].each { |item| expect(item).not_to be_nil}
       end
 
       it "should reset the last item for parent item dictionary" do
-        referenced_object(@section_1[:First]).should == @page_1
-        referenced_object(@section_1[:Last]).should == @subsection
+        expect(referenced_object(@section_1[:First])).to eq(@page_1)
+        expect(referenced_object(@section_1[:Last])).to eq(@subsection)
       end
 
       it "should set the prev relation for the new subsection to its parent's old last item" do
-        referenced_object(@subsection[:Prev]).should == @page_2
+        expect(referenced_object(@subsection[:Prev])).to eq(@page_2)
       end
 
       it "the subsection should become the next relation for its parent's old last item" do
-        referenced_object(@page_2[:Next]).should == @subsection
+        expect(referenced_object(@page_2[:Next])).to eq(@subsection)
       end
 
       it "should set the first relation for the new subsection" do
-        referenced_object(@subsection[:First]).should == @added_page_3
+        expect(referenced_object(@subsection[:First])).to eq(@added_page_3)
       end
 
       it "should set the correct last relation of the added to section" do
-        referenced_object(@subsection[:Last]).should == @added_page_3
+        expect(referenced_object(@subsection[:Last])).to eq(@added_page_3)
       end
 
       it "should increase the count of root outline dictionary" do
-        @outline_root[:Count].should == 5
+        expect(@outline_root[:Count]).to eq(5)
       end
     end
 
@@ -197,37 +197,37 @@ describe "Outline" do
       end
 
       it "should add new outline items to document" do
-        [@subsection, @added_page_3].each { |item| item.should_not be_nil}
+        [@subsection, @added_page_3].each { |item| expect(item).not_to be_nil}
       end
 
       it "should reset the first item for parent item dictionary" do
-        referenced_object(@section_1[:First]).should == @subsection
-        referenced_object(@section_1[:Last]).should == @page_2
+        expect(referenced_object(@section_1[:First])).to eq(@subsection)
+        expect(referenced_object(@section_1[:Last])).to eq(@page_2)
       end
 
       it "should set the next relation for the new subsection to its parent's old first item" do
-        referenced_object(@subsection[:Next]).should == @page_1
+        expect(referenced_object(@subsection[:Next])).to eq(@page_1)
       end
 
       it "the subsection should become the prev relation for its parent's old first item" do
-        referenced_object(@page_1[:Prev]).should == @subsection
+        expect(referenced_object(@page_1[:Prev])).to eq(@subsection)
       end
 
       it "should set the first relation for the new subsection" do
-        referenced_object(@subsection[:First]).should == @added_page_3
+        expect(referenced_object(@subsection[:First])).to eq(@added_page_3)
       end
 
       it "should set the correct last relation of the added to section" do
-        referenced_object(@subsection[:Last]).should == @added_page_3
+        expect(referenced_object(@subsection[:Last])).to eq(@added_page_3)
       end
 
       it "should increase the count of root outline dictionary" do
-        @outline_root[:Count].should == 5
+        expect(@outline_root[:Count]).to eq(5)
       end
     end
 
     it "should require an existing title" do
-      lambda do
+      expect do
         @pdf.go_to_page 1
         @pdf.start_new_page
         @pdf.text "Inserted Page"
@@ -237,7 +237,7 @@ describe "Outline" do
           end
         end
         render_and_find_objects
-      end.should raise_error(Prawn::Errors::UnknownOutlineTitle)
+      end.to raise_error(Prawn::Errors::UnknownOutlineTitle)
     end
   end
 
@@ -256,32 +256,32 @@ describe "Outline" do
 
       it "should insert new outline items to document" do
         render_and_find_objects
-        @inserted_page.should_not be_nil
+        expect(@inserted_page).not_to be_nil
       end
 
       it "should adjust the count of all ancestors" do
         render_and_find_objects
-        @outline_root[:Count].should == 4
-        @section_1[:Count].abs.should == 3
+        expect(@outline_root[:Count]).to eq(4)
+        expect(@section_1[:Count].abs).to eq(3)
       end
 
       describe "#adjust_relations" do
         it "should reset the sibling relations of adjoining items to inserted item" do
           render_and_find_objects
-          referenced_object(@page_1[:Next]).should == @inserted_page
-          referenced_object(@page_2[:Prev]).should == @inserted_page
+          expect(referenced_object(@page_1[:Next])).to eq(@inserted_page)
+          expect(referenced_object(@page_2[:Prev])).to eq(@inserted_page)
         end
 
         it "should set the sibling relation of added item to adjoining items" do
           render_and_find_objects
-          referenced_object(@inserted_page[:Next]).should == @page_2
-          referenced_object(@inserted_page[:Prev]).should == @page_1
+          expect(referenced_object(@inserted_page[:Next])).to eq(@page_2)
+          expect(referenced_object(@inserted_page[:Prev])).to eq(@page_1)
         end
 
         it "should not affect the first and last relations of parent item" do
           render_and_find_objects
-          referenced_object(@section_1[:First]).should == @page_1
-          referenced_object(@section_1[:Last]).should == @page_2
+          expect(referenced_object(@section_1[:First])).to eq(@page_1)
+          expect(referenced_object(@section_1[:Last])).to eq(@page_2)
         end
       end
 
@@ -295,8 +295,8 @@ describe "Outline" do
             end
           end
           render_and_find_objects
-          referenced_object(@outline_root[:Last]).should == @section_2
-          referenced_object(@section_1[:Next]).should == @section_2
+          expect(referenced_object(@outline_root[:Last])).to eq(@section_2)
+          expect(referenced_object(@section_1[:Next])).to eq(@section_2)
         end
       end
     end
@@ -316,22 +316,22 @@ describe "Outline" do
 
       describe "#adjust_relations" do
         it "should reset the sibling relations of adjoining item to inserted item" do
-          referenced_object(@page_2[:Next]).should == @inserted_page
+          expect(referenced_object(@page_2[:Next])).to eq(@inserted_page)
         end
 
         it "should set the sibling relation of added item to adjoining items" do
-          referenced_object(@inserted_page[:Next]).should be_nil
-          referenced_object(@inserted_page[:Prev]).should == @page_2
+          expect(referenced_object(@inserted_page[:Next])).to be_nil
+          expect(referenced_object(@inserted_page[:Prev])).to eq(@page_2)
         end
 
         it "should adjust the last relation of parent item" do
-          referenced_object(@section_1[:Last]).should == @inserted_page
+          expect(referenced_object(@section_1[:Last])).to eq(@inserted_page)
         end
       end
     end
 
     it "should require an existing title" do
-      lambda do
+      expect do
         @pdf.go_to_page 1
         @pdf.start_new_page
         @pdf.text "Inserted Page"
@@ -341,20 +341,20 @@ describe "Outline" do
           end
         end
         render_and_find_objects
-      end.should raise_error(Prawn::Errors::UnknownOutlineTitle)
+      end.to raise_error(Prawn::Errors::UnknownOutlineTitle)
     end
   end
 
   describe "#page" do
     it "should require a title option to be set" do
-      lambda do
+      expect do
         @pdf = Prawn::Document.new do
           text "Page 1. This is the first Chapter. "
           outline.define do
             page :destination => 1, :title => nil
           end
         end
-      end.should raise_error(Prawn::Errors::RequiredOption)
+      end.to raise_error(Prawn::Errors::RequiredOption)
     end
   end
 end
@@ -371,7 +371,7 @@ describe "foreign character encoding" do
 
   it "should handle other encodings for the title" do
     object = find_by_title('La pomme croquée')
-    object.should_not be_nil
+    expect(object).not_to be_nil
   end
 end
 

--- a/spec/png_spec.rb
+++ b/spec/png_spec.rb
@@ -19,19 +19,19 @@ describe "When reading a greyscale PNG file (color type 0)" do
   it "should read the attributes from the header chunk correctly" do
     png = Prawn::Images::PNG.new(@img_data)
 
-    png.width.should == 21
-    png.height.should == 14
-    png.bits.should == 8
-    png.color_type.should == 0
-    png.compression_method.should == 0
-    png.filter_method.should == 0
-    png.interlace_method.should == 0
+    expect(png.width).to eq(21)
+    expect(png.height).to eq(14)
+    expect(png.bits).to eq(8)
+    expect(png.color_type).to eq(0)
+    expect(png.compression_method).to eq(0)
+    expect(png.filter_method).to eq(0)
+    expect(png.interlace_method).to eq(0)
   end
 
   it "should read the image data chunk correctly" do
     png = Prawn::Images::PNG.new(@img_data)
     data = Zlib::Inflate.inflate(File.binread(@data_filename))
-    png.img_data.should == data
+    expect(png.img_data).to eq(data)
   end
 end
 
@@ -47,7 +47,7 @@ describe "When reading a greyscale PNG file with transparency (color type 0)" do
   # http://www.w3.org/TR/PNG/#11tRNS
   it "should read the tRNS chunk correctly" do
     png = Prawn::Images::PNG.new(@img_data)
-    png.transparency[:grayscale].should == 255
+    expect(png.transparency[:grayscale]).to eq(255)
   end
 end
 
@@ -61,19 +61,19 @@ describe "When reading an RGB PNG file (color type 2)" do
   it "should read the attributes from the header chunk correctly" do
     png = Prawn::Images::PNG.new(@img_data)
 
-    png.width.should == 258
-    png.height.should == 105
-    png.bits.should == 8
-    png.color_type.should == 2
-    png.compression_method.should == 0
-    png.filter_method.should == 0
-    png.interlace_method.should == 0
+    expect(png.width).to eq(258)
+    expect(png.height).to eq(105)
+    expect(png.bits).to eq(8)
+    expect(png.color_type).to eq(2)
+    expect(png.compression_method).to eq(0)
+    expect(png.filter_method).to eq(0)
+    expect(png.interlace_method).to eq(0)
   end
 
   it "should read the image data chunk correctly" do
     png = Prawn::Images::PNG.new(@img_data)
     data = Zlib::Inflate.inflate(File.binread(@data_filename))
-    png.img_data.should == data
+    expect(png.img_data).to eq(data)
   end
 end
 
@@ -90,7 +90,7 @@ describe "When reading an RGB PNG file with transparency (color type 2)" do
   # http://www.w3.org/TR/PNG/#11tRNS
   it "should read the tRNS chunk correctly" do
     png = Prawn::Images::PNG.new(@img_data)
-    png.transparency[:rgb].should == [0, 255, 0]
+    expect(png.transparency[:rgb]).to eq([0, 255, 0])
   end
 end
 
@@ -112,19 +112,19 @@ describe "When reading an indexed color PNG file (color type 3)" do
   it "should read the attributes from the header chunk correctly" do
     png = Prawn::Images::PNG.new(@img_data)
 
-    png.width.should == 150
-    png.height.should == 200
-    png.bits.should == 8
-    png.color_type.should == 3
-    png.compression_method.should == 0
-    png.filter_method.should == 0
-    png.interlace_method.should == 0
+    expect(png.width).to eq(150)
+    expect(png.height).to eq(200)
+    expect(png.bits).to eq(8)
+    expect(png.color_type).to eq(3)
+    expect(png.compression_method).to eq(0)
+    expect(png.filter_method).to eq(0)
+    expect(png.interlace_method).to eq(0)
   end
 
   it "should read the image data chunk correctly" do
     png = Prawn::Images::PNG.new(@img_data)
     data = Zlib::Inflate.inflate(File.binread(@data_filename))
-    png.img_data.should == data
+    expect(png.img_data).to eq(data)
   end
 end
 
@@ -139,27 +139,27 @@ describe "When reading a greyscale+alpha PNG file (color type 4)" do
   it "should read the attributes from the header chunk correctly" do
     png = Prawn::Images::PNG.new(@img_data)
 
-    png.width.should == 16
-    png.height.should == 16
-    png.bits.should == 8
-    png.color_type.should == 4
-    png.compression_method.should == 0
-    png.filter_method.should == 0
-    png.interlace_method.should == 0
+    expect(png.width).to eq(16)
+    expect(png.height).to eq(16)
+    expect(png.bits).to eq(8)
+    expect(png.color_type).to eq(4)
+    expect(png.compression_method).to eq(0)
+    expect(png.filter_method).to eq(0)
+    expect(png.interlace_method).to eq(0)
   end
 
   it "should correctly return the raw image data (with no alpha channel) from the image data chunk" do
     png = Prawn::Images::PNG.new(@img_data)
     png.split_alpha_channel!
     data = File.binread(@color_data_filename)
-    png.img_data.should == data
+    expect(png.img_data).to eq(data)
   end
 
   it "should correctly extract the alpha channel data from the image data chunk" do
     png = Prawn::Images::PNG.new(@img_data)
     png.split_alpha_channel!
     data = File.binread(@alpha_data_filename)
-    png.alpha_channel.should == data
+    expect(png.alpha_channel).to eq(data)
   end
 end
 
@@ -174,27 +174,27 @@ describe "When reading an RGB+alpha PNG file (color type 6)" do
   it "should read the attributes from the header chunk correctly" do
     png = Prawn::Images::PNG.new(@img_data)
 
-    png.width.should == 320
-    png.height.should == 240
-    png.bits.should == 8
-    png.color_type.should == 6
-    png.compression_method.should == 0
-    png.filter_method.should == 0
-    png.interlace_method.should == 0
+    expect(png.width).to eq(320)
+    expect(png.height).to eq(240)
+    expect(png.bits).to eq(8)
+    expect(png.color_type).to eq(6)
+    expect(png.compression_method).to eq(0)
+    expect(png.filter_method).to eq(0)
+    expect(png.interlace_method).to eq(0)
   end
 
   it "should correctly return the raw image data (with no alpha channel) from the image data chunk" do
     png = Prawn::Images::PNG.new(@img_data)
     png.split_alpha_channel!
     data = File.binread(@color_data_filename)
-    png.img_data.should == data
+    expect(png.img_data).to eq(data)
   end
 
   it "should correctly extract the alpha channel data from the image data chunk" do
     png = Prawn::Images::PNG.new(@img_data)
     png.split_alpha_channel!
     data = File.binread(@alpha_data_filename)
-    png.alpha_channel.should == data
+    expect(png.alpha_channel).to eq(data)
   end
 end
 
@@ -210,26 +210,26 @@ describe "When reading a 16bit RGB+alpha PNG file (color type 6)" do
   it "should read the attributes from the header chunk correctly" do
     png = Prawn::Images::PNG.new(@img_data)
 
-    png.width.should == 32
-    png.height.should == 32
-    png.bits.should == 16
-    png.color_type.should == 6
-    png.compression_method.should == 0
-    png.filter_method.should == 0
-    png.interlace_method.should == 0
+    expect(png.width).to eq(32)
+    expect(png.height).to eq(32)
+    expect(png.bits).to eq(16)
+    expect(png.color_type).to eq(6)
+    expect(png.compression_method).to eq(0)
+    expect(png.filter_method).to eq(0)
+    expect(png.interlace_method).to eq(0)
   end
 
   it "should correctly return the raw image data (with no alpha channel) from the image data chunk" do
     png = Prawn::Images::PNG.new(@img_data)
     png.split_alpha_channel!
     data = File.binread(@color_data_filename)
-    png.img_data.should == data
+    expect(png.img_data).to eq(data)
   end
 
   it "should correctly extract the alpha channel data from the image data chunk" do
     png = Prawn::Images::PNG.new(@img_data)
     png.split_alpha_channel!
     data = File.binread(@alpha_data_filename)
-    png.alpha_channel.should == data
+    expect(png.alpha_channel).to eq(data)
   end
 end

--- a/spec/reference_spec.rb
+++ b/spec/reference_spec.rb
@@ -6,20 +6,20 @@ describe "A Reference object" do
   describe "generated via Prawn::Document" do
     it "should return a proper reference on ref!" do
       pdf = Prawn::Document.new
-      pdf.ref!({}).is_a?(PDF::Core::Reference).should == true
+      expect(pdf.ref!({}).is_a?(PDF::Core::Reference)).to eq(true)
     end
 
     it "should return an identifier on ref" do
       pdf = Prawn::Document.new
       r = pdf.ref({})
-      r.is_a?(Integer).should == true
+      expect(r.is_a?(Integer)).to eq(true)
     end
 
     it "should have :Length of stream if it has one when compression disabled" do
       pdf = Prawn::Document.new :compress => false
       ref = pdf.ref!({})
       ref << 'Hello'
-      ref.stream.data[:Length].should == 5
+      expect(ref.stream.data[:Length]).to eq(5)
     end
   end
 end

--- a/spec/repeater_spec.rb
+++ b/spec/repeater_spec.rb
@@ -11,14 +11,14 @@ describe "Repeaters" do
 
     r = repeater(doc, :all) { :do_nothing }
 
-    Prawn::Repeater.count.should == orig_count + 1
+    expect(Prawn::Repeater.count).to eq(orig_count + 1)
   end
 
   it "must provide an :all filter" do
     doc = sample_document
     r = repeater(doc, :all) { :do_nothing }
 
-    (1..doc.page_count).all? { |i| r.match?(i) }.should be_true
+    expect((1..doc.page_count).all? { |i| r.match?(i) }).to be_true
   end
 
   it "must provide an :odd filter" do
@@ -27,29 +27,29 @@ describe "Repeaters" do
 
     odd, even = (1..doc.page_count).partition(&:odd?)
 
-    odd.all? { |i| r.match?(i) }.should be_true
-    even.any? { |i| r.match?(i) }.should be_false
+    expect(odd.all? { |i| r.match?(i) }).to be_true
+    expect(even.any? { |i| r.match?(i) }).to be_false
   end
 
   it "must be able to filter by an array of page numbers" do
     doc = sample_document
     r = repeater(doc, [1,2,7]) { :do_nothing }
 
-    (1..10).select { |i| r.match?(i) }.should == [1,2,7]
+    expect((1..10).select { |i| r.match?(i) }).to eq([1,2,7])
   end
 
   it "must be able to filter by a range of page numbers" do
     doc = sample_document
     r = repeater(doc, 2..4) { :do_nothing }
 
-    (1..10).select { |i| r.match?(i) }.should == [2,3,4]
+    expect((1..10).select { |i| r.match?(i) }).to eq([2,3,4])
   end
 
   it "must be able to filter by an arbitrary proc" do
     doc = sample_document
     r = repeater(doc, lambda { |x| x == 1 or x % 3 == 0 })
 
-    (1..10).select { |i| r.match?(i) }.should == [1,3,6,9]
+    expect((1..10).select { |i| r.match?(i) }).to eq([1,3,6,9])
   end
 
   it "must try to run a stamp if the page number matches" do
@@ -96,7 +96,7 @@ describe "Repeaters" do
     end
 
     text = PDF::Inspector::Text.analyze(doc.render)
-    text.strings.should == (1..10).to_a.map{|p| "Page #{p}"}
+    expect(text.strings).to eq((1..10).to_a.map{|p| "Page #{p}"})
   end
 
   it "must treat any block as a closure (Document.new instance_eval form)" do
@@ -111,7 +111,7 @@ describe "Repeaters" do
     end
 
     text = PDF::Inspector::Text.analyze(doc.render)
-    text.strings.should == (1..10).to_a.map{|p| "Page #{p}"}
+    expect(text.strings).to eq((1..10).to_a.map{|p| "Page #{p}"})
   end
 
   def sample_document
@@ -131,7 +131,7 @@ describe "Repeaters" do
       @pdf.repeat :all do
         @pdf.text "Testing", :size => 24, :style => :bold
       end
-      @pdf.state.page.graphic_state.color_space.should == starting_color_space
+      expect(@pdf.state.page.graphic_state.color_space).to eq(starting_color_space)
     end
 
     context "dynamic repeaters" do
@@ -144,10 +144,10 @@ describe "Repeaters" do
         @pdf.fill_color "666666"
         @pdf.cap_style :round
         text = PDF::Inspector::Text.analyze(@pdf.render)
-        text.strings.include?("fill_color: 666666").should == false
-        text.strings.include?("fill_color: 000000").should == true
-        text.strings.include?("cap_style: round").should == false
-        text.strings.include?("cap_style: butt").should == true
+        expect(text.strings.include?("fill_color: 666666")).to eq(false)
+        expect(text.strings.include?("fill_color: 000000")).to eq(true)
+        expect(text.strings.include?("cap_style: round")).to eq(false)
+        expect(text.strings.include?("cap_style: butt")).to eq(true)
       end
     end
   end

--- a/spec/security_spec.rb
+++ b/spec/security_spec.rb
@@ -10,22 +10,22 @@ describe "Document encryption" do
     it "should truncate long passwords" do
       pw = "Long long string" * 30
       padded = pad_password(pw)
-      padded.length.should == 32
-      padded.should == pw[0, 32]
+      expect(padded.length).to eq(32)
+      expect(padded).to eq(pw[0, 32])
     end
 
     it "should pad short passwords" do
       pw = "abcd"
       padded = pad_password(pw)
-      padded.length.should == 32
-      padded.should == pw + Prawn::Document::Security::PasswordPadding[0, 28]
+      expect(padded.length).to eq(32)
+      expect(padded).to eq(pw + Prawn::Document::Security::PasswordPadding[0, 28])
     end
 
     it "should fully pad null passwords" do
       pw = ""
       padded = pad_password(pw)
-      padded.length.should == 32
-      padded.should == Prawn::Document::Security::PasswordPadding
+      expect(padded.length).to eq(32)
+      expect(padded).to eq(Prawn::Document::Security::PasswordPadding)
     end
   end
 
@@ -43,29 +43,29 @@ describe "Document encryption" do
     end
 
     it "should default to full permissions" do
-      doc_with_permissions({}).permissions_value.should == 0xFFFFFFFF
-      doc_with_permissions(:print_document     => true,
-                           :modify_contents    => true,
-                           :copy_contents      => true,
-                           :modify_annotations => true).permissions_value.
-        should == 0xFFFFFFFF
+      expect(doc_with_permissions({}).permissions_value).to eq(0xFFFFFFFF)
+      expect(doc_with_permissions(:print_document     => true,
+                                  :modify_contents    => true,
+                                  :copy_contents      => true,
+                                  :modify_annotations => true).permissions_value).
+        to eq(0xFFFFFFFF)
     end
 
     it "should clear the appropriate bits for each permission flag" do
-      doc_with_permissions(:print_document => false).permissions_value.
-        should == 0b1111_1111_1111_1111_1111_1111_1111_1011
-      doc_with_permissions(:modify_contents => false).permissions_value.
-        should == 0b1111_1111_1111_1111_1111_1111_1111_0111
-      doc_with_permissions(:copy_contents => false).permissions_value.
-        should == 0b1111_1111_1111_1111_1111_1111_1110_1111
-      doc_with_permissions(:modify_annotations => false).permissions_value.
-        should == 0b1111_1111_1111_1111_1111_1111_1101_1111
+      expect(doc_with_permissions(:print_document => false).permissions_value).
+        to eq(0b1111_1111_1111_1111_1111_1111_1111_1011)
+      expect(doc_with_permissions(:modify_contents => false).permissions_value).
+        to eq(0b1111_1111_1111_1111_1111_1111_1111_0111)
+      expect(doc_with_permissions(:copy_contents => false).permissions_value).
+        to eq(0b1111_1111_1111_1111_1111_1111_1110_1111)
+      expect(doc_with_permissions(:modify_annotations => false).permissions_value).
+        to eq(0b1111_1111_1111_1111_1111_1111_1101_1111)
     end
 
     it "should raise_error ArgumentError if invalid option is provided" do
-      lambda {
+      expect {
         doc_with_permissions(:modify_document => false)
-      }.should raise_error(ArgumentError)
+      }.to raise_error(ArgumentError)
     end
   end
 
@@ -85,56 +85,58 @@ describe "Document encryption" do
     end
 
     it "should calculate the correct owner hash" do
-      @pdf.owner_password_hash.unpack("H*").first.should match(/^61CA855012/i)
+      expect(@pdf.owner_password_hash.unpack("H*").first).to match(/^61CA855012/i)
     end
 
     it "should calculate the correct user hash" do
-      @pdf.user_password_hash.unpack("H*").first.should =~ /^6BC8C51031/i
+      expect(@pdf.user_password_hash.unpack("H*").first).to match(/^6BC8C51031/i)
     end
 
     it "should calculate the correct user_encryption_key" do
-      @pdf.user_encryption_key.unpack("H*").first.upcase.should == "B100AB6429"
+      expect(@pdf.user_encryption_key.unpack("H*").first.upcase).to eq("B100AB6429")
     end
   end
 
   describe "EncryptedPdfObject" do
     it "should delegate to PdfObject for simple types" do
-      PDF::Core::EncryptedPdfObject(true, nil, nil, nil).should == "true"
-      PDF::Core::EncryptedPdfObject(42, nil, nil, nil).should == "42"
+      expect(PDF::Core::EncryptedPdfObject(true, nil, nil, nil)).to eq("true")
+      expect(PDF::Core::EncryptedPdfObject(42, nil, nil, nil)).to eq("42")
     end
 
     it "should encrypt strings properly" do
-      PDF::Core::EncryptedPdfObject("foo", "12345", 123, 0).should == "<4ad6e3>"
+      expect(PDF::Core::EncryptedPdfObject("foo", "12345", 123, 0)).to eq("<4ad6e3>")
     end
 
     it "should encrypt literal strings properly" do
-      PDF::Core::EncryptedPdfObject(PDF::Core::LiteralString.new("foo"), "12345", 123, 0).should == bin_string("(J\xD6\xE3)")
-      PDF::Core::EncryptedPdfObject(PDF::Core::LiteralString.new("lhfbqg3do5u0satu3fjf"), nil, 123, 0).should == bin_string("(\xF1\x8B\\(\b\xBB\xE18S\x130~4*#\\(%\x87\xE7\x8E\\\n)")
+      expect(PDF::Core::EncryptedPdfObject(PDF::Core::LiteralString.new("foo"), "12345", 123, 0)).to eq(bin_string("(J\xD6\xE3)"))
+      expect(PDF::Core::EncryptedPdfObject(PDF::Core::LiteralString.new("lhfbqg3do5u0satu3fjf"), nil, 123, 0)).to eq(bin_string("(\xF1\x8B\\(\b\xBB\xE18S\x130~4*#\\(%\x87\xE7\x8E\\\n)"))
     end
 
     it "should encrypt time properly" do
-      PDF::Core::EncryptedPdfObject(Time.utc(2050, 04, 26, 10, 17, 10), "12345", 123, 0).should == bin_string("(h\x83\xBE\xDC\xEC\x99\x0F\xD7\\)%\x13\xD4$\xB8\xF0\x16\xB8\x80\xC5\xE91+\xCF)")
+      expect(PDF::Core::EncryptedPdfObject(Time.utc(2050, 04, 26, 10, 17, 10), "12345", 123, 0)).to eq(bin_string("(h\x83\xBE\xDC\xEC\x99\x0F\xD7\\)%\x13\xD4$\xB8\xF0\x16\xB8\x80\xC5\xE91+\xCF)"))
     end
 
     it "should properly handle compound types" do
-      PDF::Core::EncryptedPdfObject({ :Bar => "foo" }, "12345", 123, 0).should ==
+      expect(PDF::Core::EncryptedPdfObject({ :Bar => "foo" }, "12345", 123, 0)).to eq(
         "<< /Bar <4ad6e3>\n>>"
-      PDF::Core::EncryptedPdfObject(["foo", "bar"], "12345", 123, 0).should ==
+      )
+      expect(PDF::Core::EncryptedPdfObject(["foo", "bar"], "12345", 123, 0)).to eq(
         "[<4ad6e3> <4ed8fe>]"
+      )
     end
   end
 
   describe "Reference#encrypted_object" do
     it "should encrypt references properly" do
       ref = PDF::Core::Reference(1,["foo"])
-      ref.encrypted_object(nil).should == "1 0 obj\n[<4fca3f>]\nendobj\n"
+      expect(ref.encrypted_object(nil)).to eq("1 0 obj\n[<4fca3f>]\nendobj\n")
     end
 
     it "should encrypt references with streams properly" do
       ref = PDF::Core::Reference(1, {})
       ref << 'foo'
       result = bin_string("1 0 obj\n<< /Length 3\n>>\nstream\nO\xCA?\nendstream\nendobj\n")
-      ref.encrypted_object(nil).should == result
+      expect(ref.encrypted_object(nil)).to eq(result)
     end
   end
 
@@ -143,7 +145,7 @@ describe "Document encryption" do
       stream = PDF::Core::Stream.new
       stream << "foo"
       result = bin_string("stream\nO\xCA?\nendstream\n")
-      stream.encrypted_object(nil, 1, 0).should == result
+      expect(stream.encrypted_object(nil, 1, 0)).to eq(result)
     end
   end
 end

--- a/spec/soft_mask_spec.rb
+++ b/spec/soft_mask_spec.rb
@@ -27,7 +27,7 @@ describe "Document with soft masks" do
     create_pdf
     make_soft_mask
     str = @pdf.render
-    str[0,8].should == "%PDF-1.4"
+    expect(str[0,8]).to eq("%PDF-1.4")
   end
 
   it "should create a new extended graphics state for each unique soft mask" do
@@ -44,7 +44,7 @@ describe "Document with soft masks" do
     end
 
     extgstates = PDF::Inspector::ExtGState.analyze(@pdf.render).extgstates
-    extgstates.length.should == 2
+    expect(extgstates.length).to eq(2)
   end
 
   it "a new extended graphics state should contain soft mask with drawing instructions" do
@@ -56,7 +56,7 @@ describe "Document with soft masks" do
     end
 
     extgstate = PDF::Inspector::ExtGState.analyze(@pdf.render).extgstates.first
-    extgstate[:soft_mask][:G].data.should == "q\n/DeviceRGB cs\n0.000 0.000 0.000 scn\n/DeviceRGB CS\n0.000 0.000 0.000 SCN\n1 w\n0 J\n0 j\n[] 0 d\n/DeviceRGB cs\n0.502 0.502 0.502 scn\n100.0 -100.0 200.0 200.0 re\nf\nQ\n"
+    expect(extgstate[:soft_mask][:G].data).to eq("q\n/DeviceRGB cs\n0.000 0.000 0.000 scn\n/DeviceRGB CS\n0.000 0.000 0.000 SCN\n1 w\n0 J\n0 j\n[] 0 d\n/DeviceRGB cs\n0.502 0.502 0.502 scn\n100.0 -100.0 200.0 200.0 re\nf\nQ\n")
   end
 
   it "should not create duplicate extended graphics states" do
@@ -73,6 +73,6 @@ describe "Document with soft masks" do
     end
 
     extgstates = PDF::Inspector::ExtGState.analyze(@pdf.render).extgstates
-    extgstates.length.should == 1
+    expect(extgstates.length).to eq(1)
   end
 end

--- a/spec/span_spec.rb
+++ b/spec/span_spec.rb
@@ -14,11 +14,11 @@ describe "drawing span" do
 
   it "should only accept :position as option in debug mode" do
     Prawn.debug = true
-    lambda { @pdf.span(350, :x => 3) {} }.should raise_error(Prawn::Errors::UnknownOption)
+    expect { @pdf.span(350, :x => 3) {} }.to raise_error(Prawn::Errors::UnknownOption)
   end
 
   it "should have raise an error if :position is invalid" do
-    lambda { @pdf.span(350, :position => :x) {} }.should raise_error(ArgumentError)
+    expect { @pdf.span(350, :position => :x) {} }.to raise_error(ArgumentError)
   end
 
   it "should restore the margin box when bounding box exits" do
@@ -28,7 +28,7 @@ describe "drawing span" do
       @pdf.text "Here's some centered text in a 350 point column. " * 100
     end
 
-    @pdf.bounds.should == margin_box
+    expect(@pdf.bounds).to eq(margin_box)
   end
 
   it "should do create a margin box" do
@@ -37,7 +37,7 @@ describe "drawing span" do
       @pdf.text "Here's some centered text in a 350 point column. " * 100
     end
 
-    margin_box.top.should == 792.0
-    margin_box.bottom.should == 0
+    expect(margin_box.top).to eq(792.0)
+    expect(margin_box.bottom).to eq(0)
   end
 end

--- a/spec/stamp_spec.rb
+++ b/spec/stamp_spec.rb
@@ -31,7 +31,7 @@ describe "#stamp_at" do
     # invoke_xobject message and count the number of times it was
     # called, but it was only called once, so I reverted checking the
     # output with a regular expression
-    @pdf.render.should =~ /\/Stamp1 Do.*?/m
+    expect(@pdf.render).to match(/\/Stamp1 Do.*?/m)
   end
 end
 
@@ -40,17 +40,17 @@ describe "Document with a stamp" do
      "with same name as an existing stamp" do
     create_pdf
     @pdf.create_stamp("MyStamp")
-    lambda {
+    expect {
       @pdf.create_stamp("MyStamp")
-    }.should raise_error(Prawn::Errors::NameTaken)
+    }.to raise_error(Prawn::Errors::NameTaken)
   end
 
   it "should raise_error InvalidName error when attempt to create " \
      "stamp with a blank name" do
     create_pdf
-    lambda {
+    expect {
       @pdf.create_stamp("")
-    }.should raise_error(Prawn::Errors::InvalidName)
+    }.to raise_error(Prawn::Errors::InvalidName)
   end
 
   it "a new XObject should be defined for each stamp created" do
@@ -62,16 +62,16 @@ describe "Document with a stamp" do
 
     inspector = PDF::Inspector::XObject.analyze(@pdf.render)
     xobjects = inspector.page_xobjects.last
-    xobjects.length.should == 2
+    expect(xobjects.length).to eq(2)
   end
 
   it "calling stamp with a name that does not match an existing stamp " \
      "should raise_error UndefinedObjectName" do
     create_pdf
     @pdf.create_stamp("MyStamp")
-    lambda {
+    expect {
       @pdf.stamp("OtherStamp")
-    }.should raise_error(Prawn::Errors::UndefinedObjectName)
+    }.to raise_error(Prawn::Errors::UndefinedObjectName)
   end
 
   it "stamp should be drawn into the document each time stamp is called" do
@@ -84,7 +84,7 @@ describe "Document with a stamp" do
     # invoke_xobject message and count the number of times it was
     # called, but it was only called once, so I reverted checking the
     # output with a regular expression
-    @pdf.render.should =~ /(\/Stamp1 Do.*?){3}/m
+    expect(@pdf.render).to match(/(\/Stamp1 Do.*?){3}/m)
   end
 
   it "stamp should render clickable links" do
@@ -101,7 +101,7 @@ describe "Document with a stamp" do
       if obj =~ /\/Type \/Page$/
         # The page object must contain the annotation reference
         # to render a clickable link
-        obj.should =~ /^\/Annots \[\d \d .\]$/
+        expect(obj).to match(/^\/Annots \[\d \d .\]$/)
       end
     end
   end
@@ -121,9 +121,9 @@ describe "Document with a stamp" do
     objects = output.split("endobj")
     objects.each do |object|
       if object =~ /\/Type \/Page$/
-        object.should_not =~ /\/ExtGState/
+        expect(object).not_to match(/\/ExtGState/)
       elsif object =~ /\/Type \/XObject$/
-        object.should =~ /\/ExtGState/
+        expect(object).to match(/\/ExtGState/)
       end
     end
   end
@@ -135,12 +135,12 @@ describe "Document with a stamp" do
     end
     @pdf.stamp("MyStamp")
     stamps = PDF::Inspector::XObject.analyze(@pdf.render)
-    stamps.xobject_streams[:Stamp1].data.chomp.should =~ /q(.|\s)*Q\Z/
+    expect(stamps.xobject_streams[:Stamp1].data.chomp).to match(/q(.|\s)*Q\Z/)
   end
 
   it "should not add to the page graphic state stack " do
     create_pdf
-    @pdf.state.page.stack.stack.size.should == 1
+    expect(@pdf.state.page.stack.stack.size).to eq(1)
 
     @pdf.create_stamp("MyStamp") do
       @pdf.save_graphics_state
@@ -149,7 +149,7 @@ describe "Document with a stamp" do
       @pdf.text "This should have a 'q' before it and a 'Q' after it"
       @pdf.restore_graphics_state
     end
-    @pdf.state.page.stack.stack.size.should == 1
+    expect(@pdf.state.page.stack.stack.size).to eq(1)
   end
 
   it "should be able to change fill and stroke colors within the stamp stream" do
@@ -161,8 +161,8 @@ describe "Document with a stamp" do
     @pdf.stamp("MyStamp")
     stamps = PDF::Inspector::XObject.analyze(@pdf.render)
     stamp_stream = stamps.xobject_streams[:Stamp1].data
-    stamp_stream.should include("/DeviceCMYK cs\n1.000 1.000 0.200 0.000 scn")
-    stamp_stream.should include("/DeviceCMYK CS\n1.000 1.000 0.200 0.000 SCN")
+    expect(stamp_stream).to include("/DeviceCMYK cs\n1.000 1.000 0.200 0.000 scn")
+    expect(stamp_stream).to include("/DeviceCMYK CS\n1.000 1.000 0.200 0.000 SCN")
   end
 
   it "should save the color space even when same as current page color space" do
@@ -174,6 +174,6 @@ describe "Document with a stamp" do
     @pdf.stamp("MyStamp")
     stamps = PDF::Inspector::XObject.analyze(@pdf.render)
     stamp_stream = stamps.xobject_streams[:Stamp1].data
-    stamp_stream.should include("/DeviceCMYK CS\n1.000 1.000 0.200 0.000 SCN")
+    expect(stamp_stream).to include("/DeviceCMYK CS\n1.000 1.000 0.200 0.000 SCN")
   end
 end

--- a/spec/stroke_styles_spec.rb
+++ b/spec/stroke_styles_spec.rb
@@ -5,15 +5,15 @@ require File.join(File.expand_path(File.dirname(__FILE__)), "spec_helper")
 describe "When stroking with default settings" do
   before(:each) { create_pdf }
   it "cap_style should be :butt" do
-    @pdf.cap_style.should == :butt
+    expect(@pdf.cap_style).to eq(:butt)
   end
 
   it "join_style should be :miter" do
-    @pdf.join_style.should == :miter
+    expect(@pdf.join_style).to eq(:miter)
   end
 
   it "dashed? should be_false" do
-    @pdf.should_not be_dashed
+    expect(@pdf).not_to be_dashed
   end
 end
 
@@ -22,14 +22,14 @@ describe "Cap styles" do
 
   it "should be able to use assignment operator" do
     @pdf.cap_style = :round
-    @pdf.cap_style.should == :round
+    expect(@pdf.cap_style).to eq(:round)
   end
 
   describe "#cap_style(:butt)" do
     it "rendered PDF should include butt style cap" do
       @pdf.cap_style(:butt)
       cap_style = PDF::Inspector::Graphics::CapStyle.analyze(@pdf.render).cap_style
-      cap_style.should == 0
+      expect(cap_style).to eq(0)
     end
   end
 
@@ -37,7 +37,7 @@ describe "Cap styles" do
     it "rendered PDF should include round style cap" do
       @pdf.cap_style(:round)
       cap_style = PDF::Inspector::Graphics::CapStyle.analyze(@pdf.render).cap_style
-      cap_style.should == 1
+      expect(cap_style).to eq(1)
     end
   end
 
@@ -45,7 +45,7 @@ describe "Cap styles" do
     it "rendered PDF should include projecting_square style cap" do
       @pdf.cap_style(:projecting_square)
       cap_style = PDF::Inspector::Graphics::CapStyle.analyze(@pdf.render).cap_style
-      cap_style.should == 2
+      expect(cap_style).to eq(2)
     end
   end
 
@@ -53,8 +53,8 @@ describe "Cap styles" do
     @pdf.cap_style(:round)
     @pdf.start_new_page
     cap_styles = PDF::Inspector::Graphics::CapStyle.analyze(@pdf.render)
-    cap_styles.cap_style_count.should == 2
-    cap_styles.cap_style.should == 1
+    expect(cap_styles.cap_style_count).to eq(2)
+    expect(cap_styles.cap_style).to eq(1)
   end
 end
 
@@ -63,14 +63,14 @@ describe "Join styles" do
 
   it "should be able to use assignment operator" do
     @pdf.join_style = :round
-    @pdf.join_style.should == :round
+    expect(@pdf.join_style).to eq(:round)
   end
 
   describe "#join_style(:miter)" do
     it "rendered PDF should include miter style join" do
       @pdf.join_style(:miter)
       join_style = PDF::Inspector::Graphics::JoinStyle.analyze(@pdf.render).join_style
-      join_style.should == 0
+      expect(join_style).to eq(0)
     end
   end
 
@@ -78,7 +78,7 @@ describe "Join styles" do
     it "rendered PDF should include round style join" do
       @pdf.join_style(:round)
       join_style = PDF::Inspector::Graphics::JoinStyle.analyze(@pdf.render).join_style
-      join_style.should == 1
+      expect(join_style).to eq(1)
     end
   end
 
@@ -86,7 +86,7 @@ describe "Join styles" do
     it "rendered PDF should include bevel style join" do
       @pdf.join_style(:bevel)
       join_style = PDF::Inspector::Graphics::JoinStyle.analyze(@pdf.render).join_style
-      join_style.should == 2
+      expect(join_style).to eq(2)
     end
   end
 
@@ -94,8 +94,8 @@ describe "Join styles" do
     @pdf.join_style(:round)
     @pdf.start_new_page
     join_styles = PDF::Inspector::Graphics::JoinStyle.analyze(@pdf.render)
-    join_styles.join_style_count.should == 2
-    join_styles.join_style.should == 1
+    expect(join_styles.join_style_count).to eq(2)
+    expect(join_styles.join_style).to eq(1)
   end
 end
 
@@ -104,18 +104,18 @@ describe "Dashes" do
 
   it "should be able to use assignment operator" do
     @pdf.dash = 2
-    @pdf.should be_dashed
+    expect(@pdf).to be_dashed
   end
 
   describe "setting a dash" do
     it "dashed? should be_true" do
       @pdf.dash(2)
-      @pdf.should be_dashed
+      expect(@pdf).to be_dashed
     end
     it "rendered PDF should include a stroked dash" do
       @pdf.dash(2)
       dashes = PDF::Inspector::Graphics::Dash.analyze(@pdf.render)
-      dashes.stroke_dash.should == [[2, 2], 0]
+      expect(dashes.stroke_dash).to eq([[2, 2], 0])
     end
   end
 
@@ -123,7 +123,7 @@ describe "Dashes" do
     it "space between dashes should be the same length as the dash in the rendered PDF" do
       @pdf.dash(2)
       dashes = PDF::Inspector::Graphics::Dash.analyze(@pdf.render)
-      dashes.stroke_dash.should == [[2, 2], 0]
+      expect(dashes.stroke_dash).to eq([[2, 2], 0])
     end
   end
 
@@ -131,7 +131,7 @@ describe "Dashes" do
     it "space between dashes in the rendered PDF should be different length than the length of the dash" do
       @pdf.dash(2, :space => 3)
       dashes = PDF::Inspector::Graphics::Dash.analyze(@pdf.render)
-      dashes.stroke_dash.should == [[2, 3], 0]
+      expect(dashes.stroke_dash).to eq([[2, 3], 0])
     end
   end
 
@@ -139,7 +139,7 @@ describe "Dashes" do
     it "rendered PDF should include a non-zero phase" do
       @pdf.dash(2, :phase => 1)
       dashes = PDF::Inspector::Graphics::Dash.analyze(@pdf.render)
-      dashes.stroke_dash.should == [[2, 2], 1]
+      expect(dashes.stroke_dash).to eq([[2, 2], 1])
     end
   end
 
@@ -147,17 +147,17 @@ describe "Dashes" do
     it "dash and spaces should be set from the array" do
       @pdf.dash([1,2,3,4])
       dashes = PDF::Inspector::Graphics::Dash.analyze(@pdf.render)
-      dashes.stroke_dash.should == [[1, 2, 3, 4], 0]
+      expect(dashes.stroke_dash).to eq([[1, 2, 3, 4], 0])
     end
     it "space options has to be ignored" do
       @pdf.dash([1,2,3,4], :space => 3)
       dashes = PDF::Inspector::Graphics::Dash.analyze(@pdf.render)
-      dashes.stroke_dash.should == [[1, 2, 3, 4], 0]
+      expect(dashes.stroke_dash).to eq([[1, 2, 3, 4], 0])
     end
     it "phase options should be correctly used" do
       @pdf.dash([1,2,3,4], :phase => 3)
       dashes = PDF::Inspector::Graphics::Dash.analyze(@pdf.render)
-      dashes.stroke_dash.should == [[1, 2, 3, 4], 3]
+      expect(dashes.stroke_dash).to eq([[1, 2, 3, 4], 3])
     end
   end
 
@@ -166,7 +166,7 @@ describe "Dashes" do
       @pdf.dash(2)
       @pdf.undash
       dashes = PDF::Inspector::Graphics::Dash.analyze(@pdf.render)
-      dashes.stroke_dash.should == [[], 0]
+      expect(dashes.stroke_dash).to eq([[], 0])
     end
   end
 
@@ -174,19 +174,19 @@ describe "Dashes" do
     @pdf.dash(2)
     @pdf.start_new_page
     dashes = PDF::Inspector::Graphics::Dash.analyze(@pdf.render)
-    dashes.stroke_dash_count.should == 2
-    dashes.stroke_dash.should == [[2, 2], 0]
+    expect(dashes.stroke_dash_count).to eq(2)
+    expect(dashes.stroke_dash).to eq([[2, 2], 0])
   end
 
   describe "#dashed?" do
     it "an initial document should not be dashed" do
-      @pdf.dashed?.should == false
+      expect(@pdf.dashed?).to eq(false)
     end
 
     it "should return true if any of the currently active settings are dashed" do
       @pdf.dash(2)
       @pdf.save_graphics_state
-      @pdf.dashed?.should == true
+      expect(@pdf.dashed?).to eq(true)
     end
 
     it "should return false if the document was most recently undashed" do
@@ -194,7 +194,7 @@ describe "Dashes" do
       @pdf.save_graphics_state
       @pdf.undash
       @pdf.save_graphics_state
-      @pdf.dashed?.should == false
+      expect(@pdf.dashed?).to eq(false)
     end
 
     it "should return true when restoring to a state that was dashed" do
@@ -202,7 +202,7 @@ describe "Dashes" do
       @pdf.save_graphics_state
       @pdf.undash
       @pdf.restore_graphics_state
-      @pdf.dashed?.should == true
+      expect(@pdf.dashed?).to eq(true)
     end
   end
 end

--- a/spec/text_at_spec.rb
+++ b/spec/text_at_spec.rb
@@ -6,31 +6,31 @@ describe "#draw_text" do
   before(:each) { create_pdf }
 
   it "should raise_error ArgumentError if :at option omitted" do
-    lambda { @pdf.draw_text("hai", {}) }.should raise_error(ArgumentError)
+    expect { @pdf.draw_text("hai", {}) }.to raise_error(ArgumentError)
   end
 
   it "should raise_error ArgumentError if :align option included" do
-    lambda { @pdf.draw_text("hai", :at => [0, 0], :align => :center) }.should raise_error(ArgumentError)
+    expect { @pdf.draw_text("hai", :at => [0, 0], :align => :center) }.to raise_error(ArgumentError)
   end
 
   it "should allow drawing empty strings to the page" do
     @pdf.draw_text(" ", :at => [100,100])
     text = PDF::Inspector::Text.analyze(@pdf.render)
-    text.strings.first.should == " "
+    expect(text.strings.first).to eq(" ")
   end
 
   it "should default to 12 point helvetica" do
     @pdf.draw_text("Blah", :at => [100,100])
     text = PDF::Inspector::Text.analyze(@pdf.render)
-    text.font_settings[0][:name].should == :Helvetica
-    text.font_settings[0][:size].should == 12
-    text.strings.first.should == "Blah"
+    expect(text.font_settings[0][:name]).to eq(:Helvetica)
+    expect(text.font_settings[0][:size]).to eq(12)
+    expect(text.strings.first).to eq("Blah")
   end
 
   it "should allow setting font size" do
     @pdf.draw_text("Blah", :at => [100,100], :size => 16)
     text = PDF::Inspector::Text.analyze(@pdf.render)
-    text.font_settings[0][:size].should == 16
+    expect(text.font_settings[0][:size]).to eq(16)
   end
 
   it "should allow setting a default font size" do
@@ -38,7 +38,7 @@ describe "#draw_text" do
     @pdf.draw_text("Blah", :at => [0, 0])
 
     text = PDF::Inspector::Text.analyze(@pdf.render)
-    text.font_settings[0][:size].should == 16
+    expect(text.font_settings[0][:size]).to eq(16)
   end
 
   rotated_text_inspector = Class.new(PDF::Inspector) do
@@ -58,7 +58,7 @@ describe "#draw_text" do
 
     text = rotated_text_inspector.analyze(@pdf.render)
 
-    text.tm_operator_used.should(be_true)
+    expect(text.tm_operator_used).to(be_true)
   end
 
   it "should not use rotation matrix by default" do
@@ -66,7 +66,7 @@ describe "#draw_text" do
 
     text = rotated_text_inspector.analyze(@pdf.render)
 
-    text.tm_operator_used.should(be_false)
+    expect(text.tm_operator_used).to(be_false)
   end
 
   it "should allow overriding default font for a single instance" do
@@ -75,8 +75,8 @@ describe "#draw_text" do
     @pdf.draw_text("Blah", :size => 11, :at => [0, 0])
     @pdf.draw_text("Blaz", :at => [0, 0])
     text = PDF::Inspector::Text.analyze(@pdf.render)
-    text.font_settings[0][:size].should == 11
-    text.font_settings[1][:size].should == 16
+    expect(text.font_settings[0][:size]).to eq(11)
+    expect(text.font_settings[1][:size]).to eq(16)
   end
 
   it "should allow setting a font size transaction with a block" do
@@ -87,8 +87,8 @@ describe "#draw_text" do
     @pdf.draw_text('blah', :at => [0, 0])
 
     text = PDF::Inspector::Text.analyze(@pdf.render)
-    text.font_settings[0][:size].should == 16
-    text.font_settings[1][:size].should == 12
+    expect(text.font_settings[0][:size]).to eq(16)
+    expect(text.font_settings[1][:size]).to eq(12)
   end
 
   it "should allow manual setting the font size when in a font size block" do
@@ -98,9 +98,9 @@ describe "#draw_text" do
       @pdf.draw_text('Blaz', :at => [0, 0])
     end
     text = PDF::Inspector::Text.analyze(@pdf.render)
-    text.font_settings[0][:size].should == 16
-    text.font_settings[1][:size].should == 11
-    text.font_settings[2][:size].should == 16
+    expect(text.font_settings[0][:size]).to eq(16)
+    expect(text.font_settings[1][:size]).to eq(11)
+    expect(text.font_settings[2][:size]).to eq(16)
   end
 
   it "should allow registering of built-in font_settings on the fly" do
@@ -109,12 +109,12 @@ describe "#draw_text" do
     @pdf.font "Courier"
     @pdf.draw_text("Blaz", :at => [150,150])
     text = PDF::Inspector::Text.analyze(@pdf.render)
-    text.font_settings[0][:name].should == :"Times-Roman"
-    text.font_settings[1][:name].should == :Courier
+    expect(text.font_settings[0][:name]).to eq(:"Times-Roman")
+    expect(text.font_settings[1][:name]).to eq(:Courier)
   end
 
   it "should raise_error an exception when an unknown font is used" do
-    lambda { @pdf.font "Pao bu" }.should raise_error(Prawn::Errors::UnknownFont)
+    expect { @pdf.font "Pao bu" }.to raise_error(Prawn::Errors::UnknownFont)
   end
 
   it "should correctly render a utf-8 string when using a built-in font" do
@@ -123,12 +123,12 @@ describe "#draw_text" do
 
     # grab the text from the rendered PDF and ensure it matches
     text = PDF::Inspector::Text.analyze(@pdf.render)
-    text.strings.first.should == str
+    expect(text.strings.first).to eq(str)
   end
 
   it "should raise_error an exception when a utf-8 incompatible string is rendered" do
     str = "Blah \xDD"
-    lambda { @pdf.draw_text(str, :at => [0, 0]) }.should raise_error(
+    expect { @pdf.draw_text(str, :at => [0, 0]) }.to raise_error(
       Prawn::Errors::IncompatibleStringEncoding)
   end
 

--- a/spec/text_box_spec.rb
+++ b/spec/text_box_spec.rb
@@ -10,7 +10,7 @@ describe "Text::Box#nothing_printed?" do
                                     :height => 2,
                                     :document => @pdf)
     text_box.render
-    text_box.nothing_printed?.should be_true
+    expect(text_box.nothing_printed?).to be_true
   end
   it "should be_false when something printed" do
     create_pdf
@@ -19,7 +19,7 @@ describe "Text::Box#nothing_printed?" do
                                     :height => 14,
                                     :document => @pdf)
     text_box.render
-    text_box.nothing_printed?.should be_false
+    expect(text_box.nothing_printed?).to be_false
   end
 end
 
@@ -31,7 +31,7 @@ describe "Text::Box#everything_printed?" do
                                     :height => 14,
                                     :document => @pdf)
     text_box.render
-    text_box.everything_printed?.should be_false
+    expect(text_box.everything_printed?).to be_false
   end
   it "should be_true when everything printed" do
     create_pdf
@@ -39,7 +39,7 @@ describe "Text::Box#everything_printed?" do
     text_box = Prawn::Text::Box.new(string,
                                     :document => @pdf)
     text_box.render
-    text_box.everything_printed?.should be_true
+    expect(text_box.everything_printed?).to be_true
   end
 end
 
@@ -51,7 +51,7 @@ describe "Text::Box#line_gap" do
     text_box = Prawn::Text::Box.new(string,
                                     :document => @pdf)
     text_box.render
-    text_box.line_gap.should be_within(0.0001).of(@pdf.font.line_gap)
+    expect(text_box.line_gap).to be_within(0.0001).of(@pdf.font.line_gap)
   end
 end
 
@@ -65,8 +65,8 @@ describe "Text::Box" do
                                     :document => @pdf)
     text_box.render
     text = PDF::Inspector::Text.analyze(@pdf.render)
-    text.strings[0].should == "?uoy era woh ,dlrow olleH"
-    text.strings[1].should == ".uoy knaht ,enif m'I"
+    expect(text.strings[0]).to eq("?uoy era woh ,dlrow olleH")
+    expect(text.strings[1]).to eq(".uoy knaht ,enif m'I")
   end
 
   it "should be able to reverse multi-byte text" do
@@ -78,7 +78,7 @@ describe "Text::Box" do
       @pdf.text "写个小"
     end
     text = PDF::Inspector::Text.analyze(@pdf.render)
-    text.strings[0].should == "小个写"
+    expect(text.strings[0]).to eq("小个写")
   end
 
   it "option should be able to override document-wide text direction" do
@@ -90,8 +90,8 @@ describe "Text::Box" do
                                     :direction => :ltr)
     text_box.render
     text = PDF::Inspector::Text.analyze(@pdf.render)
-    text.strings[0].should == "Hello world, how are you?"
-    text.strings[1].should == "I'm fine, thank you."
+    expect(text.strings[0]).to eq("Hello world, how are you?")
+    expect(text.strings[1]).to eq("I'm fine, thank you.")
   end
 end
 
@@ -102,7 +102,7 @@ describe "Text::Box" do
     @pdf.default_leading = 7
     text_box = Prawn::Text::Box.new("hello world",
                                     :document => @pdf)
-    text_box.leading.should == 7
+    expect(text_box.leading).to eq(7)
   end
 
   it "option should be able to override document-wide leading" do
@@ -111,7 +111,7 @@ describe "Text::Box" do
     text_box = Prawn::Text::Box.new("hello world",
                                     :document => @pdf,
                                     :leading => 20)
-    text_box.leading.should == 20
+    expect(text_box.leading).to eq(20)
   end
   it "should default to document-wide leading if no" \
     "leading option is provided" do
@@ -126,7 +126,7 @@ describe "Text::Box#render with :align => :justify" do
     text_box = Prawn::Text::Box.new(string, options)
     text_box.render
     contents = PDF::Inspector::Text.analyze(@pdf.render)
-    contents.word_spacing[0].should be > 0
+    expect(contents.word_spacing[0]).to be > 0
   end
   it "should not justify the last line of a paragraph" do
     create_pdf
@@ -135,7 +135,7 @@ describe "Text::Box#render with :align => :justify" do
     text_box = Prawn::Text::Box.new(string, options)
     text_box.render
     contents = PDF::Inspector::Text.analyze(@pdf.render)
-    contents.word_spacing.should be_empty
+    expect(contents.word_spacing).to be_empty
   end
 end
 
@@ -147,13 +147,13 @@ describe "Text::Box" do
     options = { :document => @pdf, :height => @pdf.font.ascender + @pdf.font.descender }
     text_box = Prawn::Text::Box.new(text, options)
     text_box.render
-    text_box.text.should == "Oh hai text rect"
+    expect(text_box.text).to eq("Oh hai text rect")
 
     text = "Oh hai text rect\nOh hai text rect"
     options = { :document => @pdf, :height => @pdf.font.height + @pdf.font.ascender + @pdf.font.descender }
     text_box = Prawn::Text::Box.new(text, options)
     text_box.render
-    text_box.text.should == "Oh hai text rect\nOh hai text rect"
+    expect(text_box.text).to eq("Oh hai text rect\nOh hai text rect")
   end
 end
 
@@ -165,7 +165,7 @@ describe "Text::Box#height without leading" do
     options = { :document => @pdf }
     text_box = Prawn::Text::Box.new(text, options)
     text_box.render
-    text_box.height.should be_within(0.001).of(@pdf.font.height * 2 - @pdf.font.line_gap)
+    expect(text_box.height).to be_within(0.001).of(@pdf.font.height * 2 - @pdf.font.line_gap)
   end
 end
 
@@ -178,7 +178,7 @@ describe "Text::Box#height with leading" do
     options = { :document => @pdf, :leading => leading }
     text_box = Prawn::Text::Box.new(text, options)
     text_box.render
-    text_box.height.should be_within(0.001).of((@pdf.font.height + leading) * 2 - @pdf.font.line_gap - leading)
+    expect(text_box.height).to be_within(0.001).of((@pdf.font.height + leading) * 2 - @pdf.font.line_gap - leading)
   end
 end
 
@@ -217,7 +217,7 @@ describe "Text::Box#valid_options" do
   it "should return an array" do
     create_pdf
     text_box = Prawn::Text::Box.new("", :document => @pdf)
-    text_box.valid_options.should be_a_kind_of(Array)
+    expect(text_box.valid_options).to be_a_kind_of(Array)
   end
 end
 
@@ -231,7 +231,7 @@ describe "Text::Box#render" do
     }
     text_box = Prawn::Text::Box.new(@text, @options)
     text_box.render
-    text_box.text.should == ""
+    expect(text_box.text).to eq("")
   end
   it "should draw content to the page" do
     create_pdf
@@ -240,7 +240,7 @@ describe "Text::Box#render" do
     text_box = Prawn::Text::Box.new(@text, @options)
     text_box.render
     text = PDF::Inspector::Text.analyze(@pdf.render)
-    text.strings.should_not be_empty
+    expect(text.strings).not_to be_empty
   end
   it "should not draw a transformation matrix" do
     create_pdf
@@ -249,7 +249,7 @@ describe "Text::Box#render" do
     text_box = Prawn::Text::Box.new(@text, @options)
     text_box.render
     matrices = PDF::Inspector::Graphics::Matrix.analyze(@pdf.render)
-    matrices.matrices.length.should == 0
+    expect(matrices.matrices.length).to eq(0)
   end
 end
 
@@ -262,7 +262,7 @@ describe "Text::Box#render(:single_line => true)" do
     text_box = Prawn::Text::Box.new(@text, @options)
     text_box.render
     text = PDF::Inspector::Text.analyze(@pdf.render)
-    text.strings.length.should == 1
+    expect(text.strings.length).to eq(1)
   end
 end
 
@@ -274,7 +274,7 @@ describe "Text::Box#render(:dry_run => true)" do
     text_box = Prawn::Text::Box.new(@text, @options)
     text_box.render(:dry_run => true)
     text = PDF::Inspector::Text.analyze(@pdf.render)
-    text.strings.should be_empty
+    expect(text.strings).to be_empty
   end
 
   it "subsequent calls to render should_not raise_error an ArgumentError exception" do
@@ -301,7 +301,7 @@ describe "Text::Box#render(:valign => :bottom)" do
     original_at = text_box.at.dup
 
     text_box.render(:dry_run => true)
-    text_box.at.should == original_at
+    expect(text_box.at).to eq(original_at)
   end
 end
 
@@ -318,7 +318,7 @@ describe "Text::Box#render(:valign => :center)" do
     original_at = text_box.at.dup
 
     text_box.render(:dry_run => true)
-    text_box.at.should == original_at
+    expect(text_box.at).to eq(original_at)
   end
 end
 
@@ -350,16 +350,16 @@ describe "Text::Box#render with :rotate option of 30)" do
       y = @y - @height / 2
       x_prime = x * @cos - y * @sin
       y_prime = x * @sin + y * @cos
-      matrices.matrices[0].should == [1, 0, 0, 1,
-                                      reduce_precision(x - x_prime),
-                                      reduce_precision(y - y_prime)]
-      matrices.matrices[1].should == [reduce_precision(@cos),
-                                      reduce_precision(@sin),
-                                      reduce_precision(-@sin),
-                                      reduce_precision(@cos), 0, 0]
+      expect(matrices.matrices[0]).to eq([1, 0, 0, 1,
+                                          reduce_precision(x - x_prime),
+                                          reduce_precision(y - y_prime)])
+      expect(matrices.matrices[1]).to eq([reduce_precision(@cos),
+                                          reduce_precision(@sin),
+                                          reduce_precision(-@sin),
+                                          reduce_precision(@cos), 0, 0])
 
       text = PDF::Inspector::Text.analyze(@pdf.render)
-      text.strings.should_not be_empty
+      expect(text.strings).not_to be_empty
     end
   end
   context ":rotate_around option of :upper_left" do
@@ -373,16 +373,16 @@ describe "Text::Box#render with :rotate option of 30)" do
       y = @y
       x_prime = x * @cos - y * @sin
       y_prime = x * @sin + y * @cos
-      matrices.matrices[0].should == [1, 0, 0, 1,
-                                      reduce_precision(x - x_prime),
-                                      reduce_precision(y - y_prime)]
-      matrices.matrices[1].should == [reduce_precision(@cos),
-                                      reduce_precision(@sin),
-                                      reduce_precision(-@sin),
-                                      reduce_precision(@cos), 0, 0]
+      expect(matrices.matrices[0]).to eq([1, 0, 0, 1,
+                                          reduce_precision(x - x_prime),
+                                          reduce_precision(y - y_prime)])
+      expect(matrices.matrices[1]).to eq([reduce_precision(@cos),
+                                          reduce_precision(@sin),
+                                          reduce_precision(-@sin),
+                                          reduce_precision(@cos), 0, 0])
 
       text = PDF::Inspector::Text.analyze(@pdf.render)
-      text.strings.should_not be_empty
+      expect(text.strings).not_to be_empty
     end
   end
   context "default :rotate_around" do
@@ -395,16 +395,16 @@ describe "Text::Box#render with :rotate option of 30)" do
       y = @y
       x_prime = x * @cos - y * @sin
       y_prime = x * @sin + y * @cos
-      matrices.matrices[0].should == [1, 0, 0, 1,
-                                      reduce_precision(x - x_prime),
-                                      reduce_precision(y - y_prime)]
-      matrices.matrices[1].should == [reduce_precision(@cos),
-                                      reduce_precision(@sin),
-                                      reduce_precision(-@sin),
-                                      reduce_precision(@cos), 0, 0]
+      expect(matrices.matrices[0]).to eq([1, 0, 0, 1,
+                                          reduce_precision(x - x_prime),
+                                          reduce_precision(y - y_prime)])
+      expect(matrices.matrices[1]).to eq([reduce_precision(@cos),
+                                          reduce_precision(@sin),
+                                          reduce_precision(-@sin),
+                                          reduce_precision(@cos), 0, 0])
 
       text = PDF::Inspector::Text.analyze(@pdf.render)
-      text.strings.should_not be_empty
+      expect(text.strings).not_to be_empty
     end
   end
   context ":rotate_around option of :upper_right" do
@@ -418,16 +418,16 @@ describe "Text::Box#render with :rotate option of 30)" do
       y = @y
       x_prime = x * @cos - y * @sin
       y_prime = x * @sin + y * @cos
-      matrices.matrices[0].should == [1, 0, 0, 1,
-                                      reduce_precision(x - x_prime),
-                                      reduce_precision(y - y_prime)]
-      matrices.matrices[1].should == [reduce_precision(@cos),
-                                      reduce_precision(@sin),
-                                      reduce_precision(-@sin),
-                                      reduce_precision(@cos), 0, 0]
+      expect(matrices.matrices[0]).to eq([1, 0, 0, 1,
+                                          reduce_precision(x - x_prime),
+                                          reduce_precision(y - y_prime)])
+      expect(matrices.matrices[1]).to eq([reduce_precision(@cos),
+                                          reduce_precision(@sin),
+                                          reduce_precision(-@sin),
+                                          reduce_precision(@cos), 0, 0])
 
       text = PDF::Inspector::Text.analyze(@pdf.render)
-      text.strings.should_not be_empty
+      expect(text.strings).not_to be_empty
     end
   end
   context ":rotate_around option of :lower_right" do
@@ -441,16 +441,16 @@ describe "Text::Box#render with :rotate option of 30)" do
       y = @y - @height
       x_prime = x * @cos - y * @sin
       y_prime = x * @sin + y * @cos
-      matrices.matrices[0].should == [1, 0, 0, 1,
-                                      reduce_precision(x - x_prime),
-                                      reduce_precision(y - y_prime)]
-      matrices.matrices[1].should == [reduce_precision(@cos),
-                                      reduce_precision(@sin),
-                                      reduce_precision(-@sin),
-                                      reduce_precision(@cos), 0, 0]
+      expect(matrices.matrices[0]).to eq([1, 0, 0, 1,
+                                          reduce_precision(x - x_prime),
+                                          reduce_precision(y - y_prime)])
+      expect(matrices.matrices[1]).to eq([reduce_precision(@cos),
+                                          reduce_precision(@sin),
+                                          reduce_precision(-@sin),
+                                          reduce_precision(@cos), 0, 0])
 
       text = PDF::Inspector::Text.analyze(@pdf.render)
-      text.strings.should_not be_empty
+      expect(text.strings).not_to be_empty
     end
   end
   context ":rotate_around option of :lower_left" do
@@ -464,16 +464,16 @@ describe "Text::Box#render with :rotate option of 30)" do
       y = @y - @height
       x_prime = x * @cos - y * @sin
       y_prime = x * @sin + y * @cos
-      matrices.matrices[0].should == [1, 0, 0, 1,
-                                      reduce_precision(x - x_prime),
-                                      reduce_precision(y - y_prime)]
-      matrices.matrices[1].should == [reduce_precision(@cos),
-                                      reduce_precision(@sin),
-                                      reduce_precision(-@sin),
-                                      reduce_precision(@cos), 0, 0]
+      expect(matrices.matrices[0]).to eq([1, 0, 0, 1,
+                                          reduce_precision(x - x_prime),
+                                          reduce_precision(y - y_prime)])
+      expect(matrices.matrices[1]).to eq([reduce_precision(@cos),
+                                          reduce_precision(@sin),
+                                          reduce_precision(-@sin),
+                                          reduce_precision(@cos), 0, 0])
 
       text = PDF::Inspector::Text.analyze(@pdf.render)
-      text.strings.should_not be_empty
+      expect(text.strings).not_to be_empty
     end
   end
 end
@@ -486,7 +486,7 @@ describe "Text::Box default height" do
     @text = "Oh hai\n" * 60
     text_box = Prawn::Text::Box.new(@text, :document => @pdf)
     text_box.render
-    text_box.height.should be_within(@pdf.font.height).of(target_height)
+    expect(text_box.height).to be_within(@pdf.font.height).of(target_height)
   end
 
   it "should use the margin-box bottom if only in a stretchy bbox" do
@@ -495,7 +495,7 @@ describe "Text::Box default height" do
       @text = "Oh hai\n" * 60
       text_box = Prawn::Text::Box.new(@text, :document => @pdf)
       text_box.render
-      text_box.height.should be_within(@pdf.font.height).of(target_height)
+      expect(text_box.height).to be_within(@pdf.font.height).of(target_height)
     end
   end
 
@@ -508,7 +508,7 @@ describe "Text::Box default height" do
                                              :height => 100,
                                              :overflow => :expand)
       text_box.render
-      text_box.height.should be_within(@pdf.font.height).of(target_height)
+      expect(text_box.height).to be_within(@pdf.font.height).of(target_height)
     end
   end
 
@@ -519,7 +519,7 @@ describe "Text::Box default height" do
         @text = "Oh hai\n" * 60
         text_box = Prawn::Text::Box.new(@text, :document => @pdf)
         text_box.render
-        text_box.height.should be_within(@pdf.font.height).of(200)
+        expect(text_box.height).to be_within(@pdf.font.height).of(200)
       end
     end
   end
@@ -533,7 +533,7 @@ describe "Text::Box default at" do
     @options = { :document => @pdf }
     text_box = Prawn::Text::Box.new(@text, @options)
     text_box.render
-    text_box.at.should == target_at
+    expect(text_box.at).to eq(target_at)
   end
 end
 
@@ -553,19 +553,19 @@ describe "Text::Box with text than can fit in the box" do
     "be inserted" do
     text_box = Prawn::Text::Box.new("  " + @text, @options)
     text_box.render
-    text_box.text.gsub("\n", " ").should == @text.strip
+    expect(text_box.text.gsub("\n", " ")).to eq(@text.strip)
   end
 
   it "render should return an empty string because no text remains unprinted" do
     text_box = Prawn::Text::Box.new(@text, @options)
-    text_box.render.should == ""
+    expect(text_box.render).to eq("")
   end
 
   it "should be truncated when the leading is set high enough to prevent all the lines from being printed" do
     @options[:leading] = 40
     text_box = Prawn::Text::Box.new(@text, @options)
     text_box.render
-    text_box.text.gsub("\n", " ").should_not == @text.strip
+    expect(text_box.text.gsub("\n", " ")).not_to eq(@text.strip)
   end
 end
 
@@ -586,13 +586,13 @@ describe "Text::Box with text that fits exactly in the box" do
     expected_height = @options.delete(:height)
     text_box = Prawn::Text::Box.new(@text, @options)
     text_box.render
-    text_box.height.should be_within(0.0001).of(expected_height)
+    expect(text_box.height).to be_within(0.0001).of(expected_height)
   end
 
   it "should print everything" do
     text_box = Prawn::Text::Box.new(@text, @options)
     text_box.render
-    text_box.text.should == @text
+    expect(text_box.text).to eq(@text)
   end
 
   describe "with leading" do
@@ -604,14 +604,14 @@ describe "Text::Box with text that fits exactly in the box" do
       @options[:height] += @options[:leading] * @interlines
       text_box = Prawn::Text::Box.new(@text, @options)
       text_box.render
-      text_box.text.should == @text
+      expect(text_box.text).to eq(@text)
     end
 
     it "should overflow when insufficient height is added" do
       @options[:height] += @options[:leading] * @interlines - 1
       text_box = Prawn::Text::Box.new(@text, @options)
       text_box.render
-      text_box.text.should_not == @text
+      expect(text_box.text).not_to eq(@text)
     end
   end
 
@@ -624,14 +624,14 @@ describe "Text::Box with text that fits exactly in the box" do
       @options[:height] += @options[:leading] * @interlines
       text_box = Prawn::Text::Box.new(@text, @options)
       text_box.render
-      text_box.text.should == @text
+      expect(text_box.text).to eq(@text)
     end
 
     it "should overflow when too much height is removed" do
       @options[:height] += @options[:leading] * @interlines - 1
       text_box = Prawn::Text::Box.new(@text, @options)
       text_box.render
-      text_box.text.should_not == @text
+      expect(text_box.text).not_to eq(@text)
     end
   end
 end
@@ -660,14 +660,14 @@ describe "Text::Box printing UTF-8 string with higher bit characters" do
     it "unprinted text should be in UTF-8 encoding" do
       @pdf.font("Panic Sans")
       remaining_text = @text_box.render
-      remaining_text.should == @text
+      expect(remaining_text).to eq(@text)
     end
   end
 
   describe "when using an AFM font" do
     it "unprinted text should be in UTF-8 encoding" do
       remaining_text = @text_box.render
-      remaining_text.should == @text
+      expect(remaining_text).to eq(@text)
     end
   end
 end
@@ -691,18 +691,18 @@ describe "Text::Box with more text than can fit in the box" do
     end
     it "should be truncated" do
       @text_box.render
-      @text_box.text.gsub("\n", " ").should_not == @text.strip
+      expect(@text_box.text.gsub("\n", " ")).not_to eq(@text.strip)
     end
     it "render should not return an empty string because some text remains unprinted" do
-      @text_box.render.should_not be_empty
+      expect(@text_box.render).not_to be_empty
     end
     it "#height should be no taller than the specified height" do
       @text_box.render
-      @text_box.height.should be <= @bounding_height
+      expect(@text_box.height).to be <= @bounding_height
     end
     it "#height should be within one font height of the specified height" do
       @text_box.render
-      @bounding_height.should be_within(@pdf.font.height).of(@text_box.height)
+      expect(@bounding_height).to be_within(@pdf.font.height).of(@text_box.height)
     end
     context "with :rotate option" do
       it "unrendered text should be the same as when not rotated" do
@@ -717,7 +717,7 @@ describe "Text::Box with more text than can fit in the box" do
         @options[:rotate] = rotate
         @options[:at] = [x, y]
         rotated_text_box = Prawn::Text::Box.new(@text, @options)
-        rotated_text_box.render.should == remaining_text
+        expect(rotated_text_box.render).to eq(remaining_text)
       end
     end
   end
@@ -732,7 +732,7 @@ describe "Text::Box with more text than can fit in the box" do
       @options[:size] = 18
       @text_box = Prawn::Text::Box.new(@text, @options)
       remaining_text = @text_box.render
-      remaining_text.should == "text will procede to be rendered this time by calling another method. .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  . "
+      expect(remaining_text).to eq("text will procede to be rendered this time by calling another method. .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  . ")
     end
   end
 
@@ -743,14 +743,14 @@ describe "Text::Box with more text than can fit in the box" do
     end
     it "height should expand to encompass all the text (but not exceed the height of the page)" do
       @text_box.render
-      @text_box.height.should > @bounding_height
+      expect(@text_box.height).to be > @bounding_height
     end
     it "should display the entire string (as long as there was space remaining on the page to print all the text)" do
       @text_box.render
-      @text_box.text.gsub("\n", " ").should == @text.strip
+      expect(@text_box.text.gsub("\n", " ")).to eq(@text.strip)
     end
     it "render should return an empty string because no text remains unprinted(as long as there was space remaining on the page to print all the text)" do
-      @text_box.render.should == ""
+      expect(@text_box.render).to eq("")
     end
   end
 
@@ -762,10 +762,10 @@ describe "Text::Box with more text than can fit in the box" do
     end
     it "should display the entire text" do
       @text_box.render
-      @text_box.text.gsub("\n", " ").should == @text.strip
+      expect(@text_box.text.gsub("\n", " ")).to eq(@text.strip)
     end
     it "render should return an empty string because no text remains unprinted" do
-      @text_box.render.should == ""
+      expect(@text_box.render).to eq("")
     end
   end
 
@@ -777,7 +777,7 @@ describe "Text::Box with more text than can fit in the box" do
       @text_box.render
 
       text = PDF::Inspector::Text.analyze(@pdf.render)
-      text.font_settings[0][:size].should == 10.1
+      expect(text.font_settings[0][:size]).to eq(10.1)
     end
   end
 end
@@ -798,7 +798,7 @@ describe "Text::Box with enough space to fit the text but using the " \
     @text_box.render
 
     text = PDF::Inspector::Text.analyze(@pdf.render)
-    text.font_settings[0][:size].should == 12
+    expect(text.font_settings[0][:size]).to eq(12)
   end
 end
 
@@ -815,7 +815,7 @@ describe "Text::Box with a solid block of Chinese characters" do
     @options[:overflow] = :truncate
     text_box = Prawn::Text::Box.new(@text, @options)
     text_box.render
-    text_box.text.gsub("\n", "").should == @text
+    expect(text_box.text.gsub("\n", "")).to eq(@text)
   end
 end
 
@@ -827,7 +827,7 @@ describe "drawing bounding boxes" do
 
     @pdf.text_box "Oh hai text box. " * 11, :height => @pdf.font.height * 10
 
-    @pdf.bounds.should == margin_box
+    expect(@pdf.bounds).to eq(margin_box)
   end
 end
 
@@ -839,7 +839,7 @@ describe "Text::Box#render with :character_spacing option" do
     text_box = Prawn::Text::Box.new(string, options)
     text_box.render
     contents = PDF::Inspector::Text.analyze(@pdf.render)
-    contents.character_spacing[0].should == 10
+    expect(contents.character_spacing[0]).to eq(10)
   end
   it "should take character spacing into account when wrapping" do
     create_pdf
@@ -850,7 +850,7 @@ describe "Text::Box#render with :character_spacing option" do
                                     :character_spacing => 10,
                                     :document => @pdf)
     text_box.render
-    text_box.text.should == "hello\nworld"
+    expect(text_box.text).to eq("hello\nworld")
   end
 end
 
@@ -869,7 +869,7 @@ describe "Text::Box wrapping" do
                                     :overflow => :expand,
                                     :document => @pdf)
     text_box.render
-    text_box.text.should == expect
+    expect(text_box.text).to eq(expect)
   end
 
   # white space was being stripped after the entire line was generated, meaning
@@ -888,7 +888,7 @@ describe "Text::Box wrapping" do
                                     :overflow => :expand,
                                     :document => @pdf)
     text_box.render
-    text_box.text.should == expect
+    expect(text_box.text).to eq(expect)
   end
 
   it "should respect end of line when wrapping text" do
@@ -901,7 +901,7 @@ describe "Text::Box wrapping" do
                                     :overflow => :expand,
                                     :document => @pdf)
     text_box.render
-    text_box.text.should == expect
+    expect(text_box.text).to eq(expect)
   end
 
   it "should respect multiple newlines when wrapping text" do
@@ -914,7 +914,7 @@ describe "Text::Box wrapping" do
                                     :overflow => :expand,
                                     :document => @pdf)
     text_box.render
-    text_box.text.should == expect
+    expect(text_box.text).to eq(expect)
   end
 
   it "should respect multiple newlines when wrapping text when those newlines coincide with a line break" do
@@ -927,7 +927,7 @@ describe "Text::Box wrapping" do
                                     :overflow => :expand,
                                     :document => @pdf)
     text_box.render
-    text_box.text.should == expect
+    expect(text_box.text).to eq(expect)
   end
 
   it "should respect initial newlines" do
@@ -940,7 +940,7 @@ describe "Text::Box wrapping" do
                                     :overflow => :expand,
                                     :document => @pdf)
     text_box.render
-    text_box.text.should == expect
+    expect(text_box.text).to eq(expect)
   end
 
   it "should wrap lines comprised of a single word of the bounds when wrapping text" do
@@ -953,7 +953,7 @@ describe "Text::Box wrapping" do
                                     :overflow => :expand,
                                     :document => @pdf)
     text_box.render
-    text_box.text.should == expect
+    expect(text_box.text).to eq(expect)
   end
 
   it "should wrap lines comprised of a single word of the bounds when wrapping text" do
@@ -969,7 +969,7 @@ describe "Text::Box wrapping" do
     expected = "©" * 25 + "\n" + "©" * 5
     @pdf.font.normalize_encoding!(expected)
     expected = expected.force_encoding(Encoding::UTF_8)
-    text_box.text.should == expected
+    expect(text_box.text).to eq(expected)
   end
 
   it "should wrap non-unicode strings using single-byte word-wrapping" do
@@ -985,7 +985,7 @@ describe "Text::Box wrapping" do
     text_box.render
     results_without_accent = text_box.text
 
-    first_line(results_with_accent).length.should == first_line(results_without_accent).length
+    expect(first_line(results_with_accent).length).to eq(first_line(results_without_accent).length)
   end
 
   it "should allow you to disable wrapping by char" do
@@ -1013,7 +1013,7 @@ describe "Text::Box wrapping" do
                                     :disable_wrap_by_char => true,
                                     :document => @pdf)
     text_box.render
-    text_box.text.should == expect
+    expect(text_box.text).to eq(expect)
   end
 end
 
@@ -1025,7 +1025,7 @@ describe "Text::Box#render with :mode option" do
     text_box = Prawn::Text::Box.new(string, options)
     text_box.render
     contents = PDF::Inspector::Text.analyze(@pdf.render)
-    contents.text_rendering_mode.should == [2,0]
+    expect(contents.text_rendering_mode).to eq([2,0])
   end
 end
 

--- a/spec/text_rendering_mode_spec.rb
+++ b/spec/text_rendering_mode_spec.rb
@@ -9,7 +9,7 @@ describe "#text_rendering_mode" do
       @pdf.text("hello world")
     end
     contents = PDF::Inspector::Text.analyze(@pdf.render)
-    contents.text_rendering_mode.first.should == 1
+    expect(contents.text_rendering_mode.first).to eq(1)
   end
   it "should not draw the text rendering mode to the document" \
     " when the new mode matches the old" do
@@ -18,7 +18,7 @@ describe "#text_rendering_mode" do
       @pdf.text("hello world")
     end
     contents = PDF::Inspector::Text.analyze(@pdf.render)
-    contents.text_rendering_mode.should be_empty
+    expect(contents.text_rendering_mode).to be_empty
   end
   it "should restore character spacing to 0" do
     create_pdf
@@ -26,20 +26,20 @@ describe "#text_rendering_mode" do
       @pdf.text("hello world")
     end
     contents = PDF::Inspector::Text.analyze(@pdf.render)
-    contents.text_rendering_mode.should == [1,0]
+    expect(contents.text_rendering_mode).to eq([1,0])
   end
   it "should function as an accessor when no parameter given" do
     create_pdf
     @pdf.text_rendering_mode(:fill_stroke) do
       @pdf.text("hello world")
-      @pdf.text_rendering_mode.should == :fill_stroke
+      expect(@pdf.text_rendering_mode).to eq(:fill_stroke)
     end
-    @pdf.text_rendering_mode.should == :fill
+    expect(@pdf.text_rendering_mode).to eq(:fill)
   end
   it "should raise_error an exception when passed an invalid mode" do
     create_pdf
-    lambda { @pdf.text_rendering_mode(-1) }.should raise_error(ArgumentError)
-    lambda { @pdf.text_rendering_mode(8) }.should raise_error(ArgumentError)
-    lambda { @pdf.text_rendering_mode(:flil) }.should raise_error(ArgumentError)
+    expect { @pdf.text_rendering_mode(-1) }.to raise_error(ArgumentError)
+    expect { @pdf.text_rendering_mode(8) }.to raise_error(ArgumentError)
+    expect { @pdf.text_rendering_mode(:flil) }.to raise_error(ArgumentError)
   end
 end

--- a/spec/text_spacing_spec.rb
+++ b/spec/text_spacing_spec.rb
@@ -9,7 +9,7 @@ describe "#character_spacing" do
       @pdf.text("hello world")
     end
     contents = PDF::Inspector::Text.analyze(@pdf.render)
-    contents.character_spacing.first.should == 10.5556
+    expect(contents.character_spacing.first).to eq(10.5556)
   end
   it "should not draw the character spacing to the document" \
     " when the new character spacing matches the old" do
@@ -18,7 +18,7 @@ describe "#character_spacing" do
       @pdf.text("hello world")
     end
     contents = PDF::Inspector::Text.analyze(@pdf.render)
-    contents.character_spacing.should be_empty
+    expect(contents.character_spacing).to be_empty
   end
   it "should restore character spacing to 0" do
     create_pdf
@@ -26,15 +26,15 @@ describe "#character_spacing" do
       @pdf.text("hello world")
     end
     contents = PDF::Inspector::Text.analyze(@pdf.render)
-    contents.character_spacing.last.should == 0
+    expect(contents.character_spacing.last).to eq(0)
   end
   it "should function as an accessor when no parameter given" do
     create_pdf
     @pdf.character_spacing(10.555555) do
       @pdf.text("hello world")
-      @pdf.character_spacing.should == 10.555555
+      expect(@pdf.character_spacing).to eq(10.555555)
     end
-    @pdf.character_spacing.should == 0
+    expect(@pdf.character_spacing).to eq(0)
   end
 
   # ensure that we properly internationalize by using the number of characters
@@ -51,7 +51,7 @@ describe "#character_spacing" do
 
     @pdf.character_spacing(10) do
       # the new width should include seven 10-pt character spaces.
-      @pdf.width_of(str).should be_within(0.001).of(@raw_width + (10 * 7))
+      expect(@pdf.width_of(str)).to be_within(0.001).of(@raw_width + (10 * 7))
     end
   end
 end
@@ -63,7 +63,7 @@ describe "#word_spacing" do
       @pdf.text("hello world")
     end
     contents = PDF::Inspector::Text.analyze(@pdf.render)
-    contents.word_spacing.first.should == 10.5556
+    expect(contents.word_spacing.first).to eq(10.5556)
   end
   it "should draw the word spacing to the document" \
     " when the new word spacing matches the old" do
@@ -72,7 +72,7 @@ describe "#word_spacing" do
       @pdf.text("hello world")
     end
     contents = PDF::Inspector::Text.analyze(@pdf.render)
-    contents.word_spacing.should be_empty
+    expect(contents.word_spacing).to be_empty
   end
   it "should restore word spacing to 0" do
     create_pdf
@@ -80,14 +80,14 @@ describe "#word_spacing" do
       @pdf.text("hello world")
     end
     contents = PDF::Inspector::Text.analyze(@pdf.render)
-    contents.word_spacing.last.should == 0
+    expect(contents.word_spacing.last).to eq(0)
   end
   it "should function as an accessor when no parameter given" do
     create_pdf
     @pdf.word_spacing(10.555555) do
       @pdf.text("hello world")
-      @pdf.word_spacing.should == 10.555555
+      expect(@pdf.word_spacing).to eq(10.555555)
     end
-    @pdf.word_spacing.should == 0
+    expect(@pdf.word_spacing).to eq(0)
   end
 end

--- a/spec/text_spec.rb
+++ b/spec/text_spec.rb
@@ -4,7 +4,7 @@ require File.join(File.expand_path(File.dirname(__FILE__)), "spec_helper")
 
 describe "Prawn::Text::NBSP" do
   it "should be defined" do
-    Prawn::Text::NBSP.should == " "
+    expect(Prawn::Text::NBSP).to eq(" ")
   end
 end
 
@@ -16,7 +16,7 @@ describe "#height_of" do
     original_y = @pdf.y
     @pdf.text("Foo")
     new_y = @pdf.y
-    @pdf.height_of("Foo").should be_within(0.0001).of(original_y - new_y)
+    expect(@pdf.height_of("Foo")).to be_within(0.0001).of(original_y - new_y)
   end
 
   it "should omit the gap below the last descender if :final_gap => false " \
@@ -24,20 +24,20 @@ describe "#height_of" do
     original_y = @pdf.y
     @pdf.text("Foo", :final_gap => false)
     new_y = @pdf.y
-    @pdf.height_of("Foo", :final_gap => false).should be_within(0.0001).of(original_y - new_y)
+    expect(@pdf.height_of("Foo", :final_gap => false)).to be_within(0.0001).of(original_y - new_y)
   end
 
   it "should raise_error CannotFit if a too-small width is given" do
-    lambda do
+    expect do
       @pdf.height_of("text", :width => 1)
-    end.should raise_error(Prawn::Errors::CannotFit)
+    end.to raise_error(Prawn::Errors::CannotFit)
   end
 
   it "should raise_error NotImplementedError if :indent_paragraphs option is provided" do
-    lambda {
+    expect {
       @pdf.height_of("hai", :width => 300,
                             :indent_paragraphs => 60)
-    }.should raise_error(NotImplementedError)
+    }.to raise_error(NotImplementedError)
   end
 
   it "should_not raise_error Prawn::Errors::UnknownOption if :final_gap option is provided" do
@@ -59,45 +59,45 @@ describe "#text" do
     @pdf.text " "
     text = PDF::Inspector::Text.analyze(@pdf.render)
     # If anything is rendered to the page, it should be whitespace.
-    text.strings.each { |str| str.should =~ /\A\s*\z/ }
+    text.strings.each { |str| expect(str).to match(/\A\s*\z/) }
   end
 
   it "should ignore call when string is nil" do
-    @pdf.text(nil).should be_false
+    expect(@pdf.text(nil)).to be_false
   end
 
   it "should correctly render empty paragraphs" do
     @pdf.text "text\n\ntext"
     text = PDF::Inspector::Text.analyze(@pdf.render)
-    @pdf.page_count.should == 1
-    text.strings.reject(&:empty?).should == ["text", "text"]
+    expect(@pdf.page_count).to eq(1)
+    expect(text.strings.reject(&:empty?)).to eq(["text", "text"])
   end
 
   it "should correctly render empty paragraphs with :indent_paragraphs" do
     @pdf.text "text\n\ntext", :indent_paragraphs => 5
     text = PDF::Inspector::Text.analyze(@pdf.render)
-    @pdf.page_count.should == 1
-    text.strings.reject(&:empty?).should == ["text", "text"]
+    expect(@pdf.page_count).to eq(1)
+    expect(text.strings.reject(&:empty?)).to eq(["text", "text"])
   end
 
   it "should correctly render strings ending with empty paragraphs and " \
      ":inline_format and :indent_paragraphs" do
     @pdf.text "text\n\n", :inline_format => true, :indent_paragraphs => 5
     text = PDF::Inspector::Text.analyze(@pdf.render)
-    @pdf.page_count.should == 1
-    text.strings.should == ["text"]
+    expect(@pdf.page_count).to eq(1)
+    expect(text.strings).to eq(["text"])
   end
 
   it "should default to use kerning information" do
     @pdf.text "hello world"
     text = PDF::Inspector::Text.analyze(@pdf.render)
-    text.kerned[0].should be_true
+    expect(text.kerned[0]).to be_true
   end
 
   it "should be able to disable kerning with an option" do
     @pdf.text "hello world", :kerning => false
     text = PDF::Inspector::Text.analyze(@pdf.render)
-    text.kerned[0].should be_false
+    expect(text.kerned[0]).to be_false
   end
 
   it "should be able to disable kerning document-wide" do
@@ -105,29 +105,29 @@ describe "#text" do
     @pdf.default_kerning = false
     @pdf.text "hello world"
     text = PDF::Inspector::Text.analyze(@pdf.render)
-    text.kerned[0].should be_false
+    expect(text.kerned[0]).to be_false
   end
 
   it "option should be able to override document-wide kerning disabling" do
     @pdf.default_kerning = false
     @pdf.text "hello world", :kerning => true
     text = PDF::Inspector::Text.analyze(@pdf.render)
-    text.kerned[0].should be_true
+    expect(text.kerned[0]).to be_true
   end
 
   it "should raise_error ArgumentError if :at option included" do
-    lambda { @pdf.text("hai", :at => [0, 0]) }.should raise_error(ArgumentError)
+    expect { @pdf.text("hai", :at => [0, 0]) }.to raise_error(ArgumentError)
   end
 
   it "should advance down the document based on font_height" do
     position = @pdf.y
     @pdf.text "Foo"
 
-    @pdf.y.should be_within(0.0001).of(position - @pdf.font.height)
+    expect(@pdf.y).to be_within(0.0001).of(position - @pdf.font.height)
 
     position = @pdf.y
     @pdf.text "Foo\nBar\nBaz"
-    @pdf.y.should be_within(0.0001).of(position - 3 * @pdf.font.height)
+    expect(@pdf.y).to be_within(0.0001).of(position - 3 * @pdf.font.height)
   end
 
   it "should advance down the document based on font_height with size option" do
@@ -135,11 +135,11 @@ describe "#text" do
     @pdf.text "Foo", :size => 15
 
     @pdf.font_size = 15
-    @pdf.y.should be_within(0.0001).of(position - @pdf.font.height)
+    expect(@pdf.y).to be_within(0.0001).of(position - @pdf.font.height)
 
     position = @pdf.y
     @pdf.text "Foo\nBar\nBaz"
-    @pdf.y.should be_within(0.0001).of(position - 3 * @pdf.font.height)
+    expect(@pdf.y).to be_within(0.0001).of(position - 3 * @pdf.font.height)
   end
 
   it "should advance down the document based on font_height with leading option" do
@@ -147,50 +147,50 @@ describe "#text" do
     leading = 2
     @pdf.text "Foo", :leading => leading
 
-    @pdf.y.should be_within(0.0001).of(position - @pdf.font.height - leading)
+    expect(@pdf.y).to be_within(0.0001).of(position - @pdf.font.height - leading)
 
     position = @pdf.y
     @pdf.text "Foo\nBar\nBaz"
-    @pdf.y.should be_within(0.0001).of(position - 3 * @pdf.font.height)
+    expect(@pdf.y).to be_within(0.0001).of(position - 3 * @pdf.font.height)
   end
 
   it "should advance only to the bottom of the final descender if final_gap is false" do
     position = @pdf.y
     @pdf.text "Foo", :final_gap => false
 
-    @pdf.y.should be_within(0.0001).of(position - @pdf.font.ascender - @pdf.font.descender)
+    expect(@pdf.y).to be_within(0.0001).of(position - @pdf.font.ascender - @pdf.font.descender)
 
     position = @pdf.y
     @pdf.text "Foo\nBar\nBaz", :final_gap => false
-    @pdf.y.should be_within(0.0001).of(position - 2 * @pdf.font.height - @pdf.font.ascender - @pdf.font.descender)
+    expect(@pdf.y).to be_within(0.0001).of(position - 2 * @pdf.font.height - @pdf.font.ascender - @pdf.font.descender)
   end
 
   it "should be able to print text starting at the last line of a page" do
     @pdf.move_cursor_to(@pdf.font.height)
     @pdf.text("hello world")
     pages = PDF::Inspector::Page.analyze(@pdf.render).pages
-    pages.size.should == 1
+    expect(pages.size).to eq(1)
   end
 
   it "should default to 12 point helvetica" do
     @pdf.text "Blah"
     text = PDF::Inspector::Text.analyze(@pdf.render)
-    text.font_settings[0][:name].should == :Helvetica
-    text.font_settings[0][:size].should == 12
-    text.strings.first.should == "Blah"
+    expect(text.font_settings[0][:name]).to eq(:Helvetica)
+    expect(text.font_settings[0][:size]).to eq(12)
+    expect(text.strings.first).to eq("Blah")
   end
 
   it "should allow setting font size" do
     @pdf.text "Blah", :size => 16
     text = PDF::Inspector::Text.analyze(@pdf.render)
-    text.font_settings[0][:size].should == 16
+    expect(text.font_settings[0][:size]).to eq(16)
   end
 
   it "should allow setting a default font size" do
     @pdf.font_size = 16
     @pdf.text "Blah"
     text = PDF::Inspector::Text.analyze(@pdf.render)
-    text.font_settings[0][:size].should == 16
+    expect(text.font_settings[0][:size]).to eq(16)
   end
 
   it "should allow overriding default font for a single instance" do
@@ -199,8 +199,8 @@ describe "#text" do
     @pdf.text "Blah", :size => 11
     @pdf.text "Blaz"
     text = PDF::Inspector::Text.analyze(@pdf.render)
-    text.font_settings[0][:size].should == 11
-    text.font_settings[1][:size].should == 16
+    expect(text.font_settings[0][:size]).to eq(11)
+    expect(text.font_settings[1][:size]).to eq(16)
   end
 
   it "should allow setting a font size transaction with a block" do
@@ -211,8 +211,8 @@ describe "#text" do
     @pdf.text 'blah'
 
     text = PDF::Inspector::Text.analyze(@pdf.render)
-    text.font_settings[0][:size].should == 16
-    text.font_settings[1][:size].should == 12
+    expect(text.font_settings[0][:size]).to eq(16)
+    expect(text.font_settings[1][:size]).to eq(12)
   end
 
   it "should allow manual setting the font size when in a font size block" do
@@ -222,9 +222,9 @@ describe "#text" do
       @pdf.text 'Blaz'
     end
     text = PDF::Inspector::Text.analyze(@pdf.render)
-    text.font_settings[0][:size].should == 16
-    text.font_settings[1][:size].should == 11
-    text.font_settings[2][:size].should == 16
+    expect(text.font_settings[0][:size]).to eq(16)
+    expect(text.font_settings[1][:size]).to eq(11)
+    expect(text.font_settings[2][:size]).to eq(16)
   end
 
   it "should allow registering of built-in font_settings on the fly" do
@@ -233,8 +233,8 @@ describe "#text" do
     @pdf.font "Courier"
     @pdf.text "Blaz"
     text = PDF::Inspector::Text.analyze(@pdf.render)
-    text.font_settings[0][:name].should == :"Times-Roman"
-    text.font_settings[1][:name].should == :Courier
+    expect(text.font_settings[0][:name]).to eq(:"Times-Roman")
+    expect(text.font_settings[1][:name]).to eq(:Courier)
   end
 
   it "should utilise the same default font across multiple pages" do
@@ -243,13 +243,13 @@ describe "#text" do
     @pdf.text "Blaz"
     text = PDF::Inspector::Text.analyze(@pdf.render)
 
-    text.font_settings.size.should == 2
-    text.font_settings[0][:name].should == :Helvetica
-    text.font_settings[1][:name].should == :Helvetica
+    expect(text.font_settings.size).to eq(2)
+    expect(text.font_settings[0][:name]).to eq(:Helvetica)
+    expect(text.font_settings[1][:name]).to eq(:Helvetica)
   end
 
   it "should raise_error an exception when an unknown font is used" do
-    lambda { @pdf.font "Pao bu" }.should raise_error(Prawn::Errors::UnknownFont)
+    expect { @pdf.font "Pao bu" }.to raise_error(Prawn::Errors::UnknownFont)
   end
 
   it "should_not raise_error an exception when providing Pathname instance as font" do
@@ -262,7 +262,7 @@ describe "#text" do
 
     # grab the text from the rendered PDF and ensure it matches
     text = PDF::Inspector::Text.analyze(@pdf.render)
-    text.strings.first.should == str
+    expect(text.strings.first).to eq(str)
   end
 
   it "should correctly render a utf-8 string when using a TTF font" do
@@ -272,7 +272,7 @@ describe "#text" do
 
     # grab the text from the rendered PDF and ensure it matches
     text = PDF::Inspector::Text.analyze(@pdf.render)
-    text.strings.first.should == str
+    expect(text.strings.first).to eq(str)
   end
 
   it "subsets mixed low-ASCII and non-ASCII characters when they can be subsetted together" do
@@ -281,7 +281,7 @@ describe "#text" do
     @pdf.text str
 
     text = PDF::Inspector::Text.analyze(@pdf.render)
-    text.strings.first.should == str
+    expect(text.strings.first).to eq(str)
   end
 
   it "should correctly render a string with higher bit characters across a page break when using a built-in font" do
@@ -290,9 +290,9 @@ describe "#text" do
     @pdf.text(str + "\n" + str)
 
     pages = PDF::Inspector::Page.analyze(@pdf.render).pages
-    pages.size.should == 2
-    pages[0][:strings].should == [str]
-    pages[1][:strings].should == [str]
+    expect(pages.size).to eq(2)
+    expect(pages[0][:strings]).to eq([str])
+    expect(pages[1][:strings]).to eq([str])
   end
 
   it "should correctly render a string with higher bit characters across" \
@@ -302,14 +302,14 @@ describe "#text" do
     @pdf.text(str + "\n" + str, :indent_paragraphs => 20)
 
     pages = PDF::Inspector::Page.analyze(@pdf.render).pages
-    pages.size.should == 2
-    pages[0][:strings].should == [str]
-    pages[1][:strings].should == [str]
+    expect(pages.size).to eq(2)
+    expect(pages[0][:strings]).to eq([str])
+    expect(pages[1][:strings]).to eq([str])
   end
 
   it "should raise_error an exception when a utf-8 incompatible string is rendered" do
     str = "Blah \xDD"
-    lambda { @pdf.text str }.should raise_error(
+    expect { @pdf.text str }.to raise_error(
       Prawn::Errors::IncompatibleStringEncoding)
   end
 
@@ -328,9 +328,9 @@ describe "#text" do
     @pdf.text "Hello"
     @pdf.text "World"
     pages = PDF::Inspector::Page.analyze(@pdf.render).pages
-    pages.size.should == 2
-    pages[0][:strings].should == ["Hello"]
-    pages[1][:strings].should == ["World"]
+    expect(pages.size).to eq(2)
+    expect(pages[0][:strings]).to eq(["Hello"])
+    expect(pages[1][:strings]).to eq(["World"])
   end
 
   describe "with :indent_paragraphs option" do
@@ -339,10 +339,10 @@ describe "#text" do
       hello2 = "hello " * 50
       @pdf.text(hello + "\n" + hello2, :indent_paragraphs => 60)
       text = PDF::Inspector::Text.analyze(@pdf.render)
-      text.strings[0].should == ("hello " * 19).strip
-      text.strings[1].should == ("hello " * 21).strip
-      text.strings[3].should == ("hello " * 19).strip
-      text.strings[4].should == ("hello " * 21).strip
+      expect(text.strings[0]).to eq(("hello " * 19).strip)
+      expect(text.strings[1]).to eq(("hello " * 21).strip)
+      expect(text.strings[3]).to eq(("hello " * 19).strip)
+      expect(text.strings[4]).to eq(("hello " * 21).strip)
     end
 
     it "should indent from right side when using :rtl direction" do
@@ -360,19 +360,19 @@ describe "#text" do
       # text, which isn't necessarily correct. If we change that behavior,
       # this test will need to be updated.
 
-      x_positions[0].should(
+      expect(x_positions[0]).to(
         be_within(0.001).of(@pdf.bounds.absolute_right - 60 -
                             @pdf.width_of(lines[0].reverse, :kerning => true)))
 
-      x_positions[1].should(
+      expect(x_positions[1]).to(
         be_within(0.001).of(@pdf.bounds.absolute_right -
                             @pdf.width_of(lines[1].reverse, :kerning => true)))
 
-      x_positions[2].should(
+      expect(x_positions[2]).to(
         be_within(0.001).of(@pdf.bounds.absolute_right - 60 -
                             @pdf.width_of(lines[2].reverse, :kerning => true)))
 
-      x_positions[3].should(
+      expect(x_positions[3]).to(
         be_within(0.001).of(@pdf.bounds.absolute_right -
                             @pdf.width_of(lines[3].reverse, :kerning => true)))
     end
@@ -393,19 +393,19 @@ describe "#text" do
       # text, which isn't necessarily correct. If we change that behavior,
       # this test will need to be updated.
 
-      x_positions[0].should(
+      expect(x_positions[0]).to(
         be_within(0.001).of(@pdf.bounds.absolute_right - 60 -
                             @pdf.width_of(lines[0].reverse, :kerning => true)))
 
-      x_positions[1].should(
+      expect(x_positions[1]).to(
         be_within(0.001).of(@pdf.bounds.absolute_right -
                             @pdf.width_of(lines[1].reverse, :kerning => true)))
 
-      x_positions[2].should(
+      expect(x_positions[2]).to(
         be_within(0.001).of(@pdf.bounds.absolute_right - 60 -
                             @pdf.width_of(lines[2].reverse, :kerning => true)))
 
-      x_positions[3].should(
+      expect(x_positions[3]).to(
         be_within(0.001).of(@pdf.bounds.absolute_right -
                             @pdf.width_of(lines[3].reverse, :kerning => true)))
     end
@@ -420,11 +420,11 @@ describe "#text" do
 
       x_positions = text.positions.map { |e| e[0] }
 
-      x_positions[0].should == 60
-      x_positions[1].should == 0
+      expect(x_positions[0]).to eq(60)
+      expect(x_positions[1]).to eq(0)
 
-      x_positions[2].should == 60
-      x_positions[3].should == 0
+      expect(x_positions[2]).to eq(60)
+      expect(x_positions[3]).to eq(0)
     end
 
     it "should indent from left side when document has :ltr direction" do
@@ -438,11 +438,11 @@ describe "#text" do
 
       x_positions = text.positions.map { |e| e[0] }
 
-      x_positions[0].should == 60
-      x_positions[1].should == 0
+      expect(x_positions[0]).to eq(60)
+      expect(x_positions[1]).to eq(0)
 
-      x_positions[2].should == 60
-      x_positions[3].should == 0
+      expect(x_positions[2]).to eq(60)
+      expect(x_positions[3]).to eq(0)
     end
 
     describe "when wrap to new page, and first line of new page" \
@@ -454,10 +454,10 @@ describe "#text" do
         @pdf.move_cursor_to(@pdf.font.height)
         @pdf.text(hello + "\n" + hello2, :indent_paragraphs => 60)
         text = PDF::Inspector::Text.analyze(@pdf.render)
-        text.strings[0].should == ("hello " * 19).strip
-        text.strings[1].should == ("hello " * 21).strip
-        text.strings[3].should == ("hello " * 19).strip
-        text.strings[4].should == ("hello " * 21).strip
+        expect(text.strings[0]).to eq(("hello " * 19).strip)
+        expect(text.strings[1]).to eq(("hello " * 21).strip)
+        expect(text.strings[3]).to eq(("hello " * 19).strip)
+        expect(text.strings[4]).to eq(("hello " * 21).strip)
       end
     end
     describe "when wrap to new page, and first line of new page" \
@@ -469,10 +469,10 @@ describe "#text" do
         @pdf.move_cursor_to(@pdf.font.height * 3)
         @pdf.text(hello + "\n" + hello2, :indent_paragraphs => 60)
         text = PDF::Inspector::Text.analyze(@pdf.render)
-        text.strings[0].should == ("hello " * 19).strip
-        text.strings[1].should == ("hello " * 21).strip
-        text.strings[3].should == ("hello " * 19).strip
-        text.strings[4].should == ("hello " * 21).strip
+        expect(text.strings[0]).to eq(("hello " * 19).strip)
+        expect(text.strings[1]).to eq(("hello " * 21).strip)
+        expect(text.strings[3]).to eq(("hello " * 19).strip)
+        expect(text.strings[4]).to eq(("hello " * 21).strip)
       end
     end
   end
@@ -541,9 +541,9 @@ describe "#text" do
       text = PDF::Inspector::Text.analyze(@pdf.render)
       fonts_used = text.font_settings.map { |e| e[:name] }
 
-      fonts_used.length.should == 1
-      fonts_used[0].should == :"Times-Italic"
-      text.strings[0].should == "hello"
+      expect(fonts_used.length).to eq(1)
+      expect(fonts_used[0]).to eq(:"Times-Italic")
+      expect(text.strings[0]).to eq("hello")
     end
   end
 end

--- a/spec/text_with_inline_formatting_spec.rb
+++ b/spec/text_with_inline_formatting_spec.rb
@@ -10,7 +10,7 @@ describe "#formatted_text" do
     @pdf.formatted_text(format_array)
     # grab the text from the rendered PDF and ensure it matches
     text = PDF::Inspector::Text.analyze(@pdf.render)
-    text.strings.first.should == string
+    expect(text.strings.first).to eq(string)
   end
 end
 
@@ -24,12 +24,12 @@ describe "#text with inline styling" do
     formatted = "this contains <font size='24'>sized</font> text"
     @pdf.text(formatted, :inline_format => true)
     pages = PDF::Inspector::Page.analyze(@pdf.render).pages
-    pages.size.should == 2
+    expect(pages.size).to eq(2)
   end
 
   it "should embed links as literal strings" do
     @pdf.text "<link href='http://wiki.github.com/sandal/prawn/'>wiki</link>",
               :inline_format => true
-    @pdf.render.should =~ %r{/URI\s+\(http://wiki\.github\.com}
+    expect(@pdf.render).to match(%r{/URI\s+\(http://wiki\.github\.com})
   end
 end

--- a/spec/transparency_spec.rb
+++ b/spec/transparency_spec.rb
@@ -17,7 +17,7 @@ describe "Document with transparency" do
     create_pdf
     make_transparent(0.5)
     str = @pdf.render
-    str[0,8].should == "%PDF-1.4"
+    expect(str[0,8]).to eq("%PDF-1.4")
   end
 
   it "a new extended graphics state should be created for " \
@@ -27,7 +27,7 @@ describe "Document with transparency" do
       make_transparent(0.5, 0.75)
     end
     extgstates = PDF::Inspector::ExtGState.analyze(@pdf.render).extgstates
-    extgstates.length.should == 2
+    expect(extgstates.length).to eq(2)
   end
 
   it "a new extended graphics state should not be created for " \
@@ -37,7 +37,7 @@ describe "Document with transparency" do
       make_transparent(0.5, 0.75)
     end
     extgstates = PDF::Inspector::ExtGState.analyze(@pdf.render).extgstates
-    extgstates.length.should == 1
+    expect(extgstates.length).to eq(1)
   end
 
   it "setting the transparency with only one parameter sets the transparency" \
@@ -45,8 +45,8 @@ describe "Document with transparency" do
     create_pdf
     make_transparent(0.5)
     extgstate = PDF::Inspector::ExtGState.analyze(@pdf.render).extgstates[0]
-    extgstate[:opacity].should == 0.5
-    extgstate[:stroke_opacity].should == 0.5
+    expect(extgstate[:opacity]).to eq(0.5)
+    expect(extgstate[:stroke_opacity]).to eq(0.5)
   end
 
   it "setting the transparency with a numerical parameter and " \
@@ -55,22 +55,22 @@ describe "Document with transparency" do
     create_pdf
     make_transparent(0.5, 0.2)
     extgstate = PDF::Inspector::ExtGState.analyze(@pdf.render).extgstates[0]
-    extgstate[:opacity].should == 0.5
-    extgstate[:stroke_opacity].should == 0.2
+    expect(extgstate[:opacity]).to eq(0.5)
+    expect(extgstate[:stroke_opacity]).to eq(0.2)
   end
 
   it "should enforce the valid range of 0.0 to 1.0" do
     create_pdf
     make_transparent(-0.5, -0.2)
     extgstate = PDF::Inspector::ExtGState.analyze(@pdf.render).extgstates[0]
-    extgstate[:opacity].should == 0.0
-    extgstate[:stroke_opacity].should == 0.0
+    expect(extgstate[:opacity]).to eq(0.0)
+    expect(extgstate[:stroke_opacity]).to eq(0.0)
 
     create_pdf
     make_transparent(2.0, 3.0)
     extgstate = PDF::Inspector::ExtGState.analyze(@pdf.render).extgstates[0]
-    extgstate[:opacity].should == 1.0
-    extgstate[:stroke_opacity].should == 1.0
+    expect(extgstate[:opacity]).to eq(1.0)
+    expect(extgstate[:stroke_opacity]).to eq(1.0)
   end
 
   describe "with more than one page" do
@@ -83,9 +83,9 @@ describe "Document with transparency" do
       make_transparent(0.5, 0.2)
       extgstates = PDF::Inspector::ExtGState.analyze(@pdf.render).extgstates
       extgstate = extgstates[0]
-      extgstates.length.should == 2
-      extgstate[:opacity].should == 0.5
-      extgstate[:stroke_opacity].should == 0.2
+      expect(extgstates.length).to eq(2)
+      expect(extgstate[:opacity]).to eq(0.5)
+      expect(extgstate[:stroke_opacity]).to eq(0.2)
     end
   end
 end


### PR DESCRIPTION
This conversion is done by Transpec 3.1.0 with the following command:
    transpec

* 1013 conversions
    from: obj.should
      to: expect(obj).to

* 873 conversions
    from: == expected
      to: eq(expected)

* 40 conversions
    from: obj.should_not
      to: expect(obj).not_to

* 39 conversions
    from: lambda { }.should
      to: expect { }.to

* 25 conversions
    from: =~ /pattern/
      to: match(/pattern/)

* 4 conversions
    from: <= expected
      to: be <= expected

* 3 conversions
    from: obj.should have(n).entries
      to: expect(obj.entries.size).to eq(n)

* 2 conversions
    from: collection.should have(n).items
      to: expect(collection.size).to eq(n)

* 1 conversion
    from: < expected
      to: be < expected

* 1 conversion
    from: > expected
      to: be > expected

* 1 conversion
    from: >= expected
      to: be >= expected

* 1 conversion
    from: lambda { }.should_not
      to: expect { }.not_to

For more details: https://github.com/yujinakayama/transpec#supported-conversions