### PR TITLE
Add pixel conversion

### DIFF
--- a/lib/prawn/measurement_extensions.rb
+++ b/lib/prawn/measurement_extensions.rb
@@ -47,4 +47,8 @@ class Numeric
   def pt
     return pt2pt(self)
   end
+
+  def px
+    return px2pt(self)
+  end
 end

--- a/lib/prawn/measurement_extensions.rb
+++ b/lib/prawn/measurement_extensions.rb
@@ -48,7 +48,7 @@ class Numeric
     return pt2pt(self)
   end
 
-  def px
-    return px2pt(self)
+  def css_px
+    return csspx2pt(self)
   end
 end

--- a/lib/prawn/measurements.rb
+++ b/lib/prawn/measurements.rb
@@ -66,5 +66,13 @@ module Prawn
     def pt2mm(pt)
       return pt * 1 / mm2pt(1) # (25.4 / 72)
     end
+
+    def px2pt(px)
+      return px * 0.75
+    end
+
+    def pt2px(pt)
+      return pt / 1.333333
+    end
   end
 end

--- a/lib/prawn/measurements.rb
+++ b/lib/prawn/measurements.rb
@@ -67,11 +67,11 @@ module Prawn
       return pt * 1 / mm2pt(1) # (25.4 / 72)
     end
 
-    def px2pt(px)
+    def csspx2pt(px)
       return px * 0.75
     end
 
-    def pt2px(pt)
+    def pt2csspx(pt)
       return pt / 1.333333
     end
   end

--- a/spec/measurement_units_spec.rb
+++ b/spec/measurement_units_spec.rb
@@ -18,5 +18,6 @@ describe "Measurement units" do
     1.ft.should == 72 * 12
     1.yd.should == 72 * 12 * 3
     1.pt.should == 1
+    1.px.should == 0.75
   end
 end

--- a/spec/measurement_units_spec.rb
+++ b/spec/measurement_units_spec.rb
@@ -18,6 +18,6 @@ describe "Measurement units" do
     1.ft.should == 72 * 12
     1.yd.should == 72 * 12 * 3
     1.pt.should == 1
-    1.px.should == 0.75
+    1.css_px.should == 0.75
   end
 end


### PR DESCRIPTION
Hi,

I'm working in the generation of  PDF's. Nothing too complex, I've gotten a few html templates then I need to sure the pdf's looks as similar as possible the templates.

A several facts don't allow me to use gems like  wickedpdf,  pdfkit, imgkit.

So, I did miss the `px2pt` conversion method, was wondering why it didn't exist? I think I'm not the first looking for method.  

Anyway I thought would be good to ask you guys with a PR.

http://endmemo.com/sconvert/pixelpoint.php
http://stackoverflow.com/questions/139655/convert-pixels-to-points

Thanks!