### PR TITLE
Syntax update for manual

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -72,7 +72,8 @@ Void:
 StringLiterals:
   Enabled: false
 HashSyntax:
-  Enabled: false
+  Include:
+    - manual/**/*
 UselessAssignment:
   Enabled: false
 Lambda:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 
 ## PrawnPDF master branch
 
+### Hash syntax update for manual
+
+The hash syntax in the manual changed from the old format (:symbol => value) 
+to the new syntax (symbol: value) being implementented with ruby 1.9.2 .
+(Christof Spies, [#890](https://github.com/prawnpdf/prawn/pull/890))
+
 ## PrawnPDF 2.0.2 -- 2015-07-15
 
 ### Links in repeaters/stamps are now clickable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
+
 ## PrawnPDF master branch
+
+## PrawnPDF 2.0.2 -- 2015-07-15
 
 ### Links in repeaters/stamps are now clickable
 

--- a/lib/prawn/version.rb
+++ b/lib/prawn/version.rb
@@ -1,5 +1,5 @@
 # encoding: utf-8
 
 module Prawn
-  VERSION = "2.0.2"
+  VERSION = "2.0.3"
 end

--- a/manual/basic_concepts/basic_concepts.rb
+++ b/manual/basic_concepts/basic_concepts.rb
@@ -5,15 +5,15 @@
 
 require_relative "../example_helper"
 
-Prawn::ManualBuilder::Example.generate("basic_concepts.pdf", :page_size => "FOLIO") do
+Prawn::ManualBuilder::Example.generate("basic_concepts.pdf", page_size: "FOLIO") do
   package "basic_concepts" do |p|
-    p.example "creation", :eval_source => false, :full_source => true
+    p.example "creation", eval_source: false, full_source: true
     p.example "origin"
     p.example "cursor"
     p.example "other_cursor_helpers"
     p.example "adding_pages"
     p.example "measurement"
-    p.example "view", :eval_source => false, :full_source => true
+    p.example "view", eval_source: false, full_source: true
 
     p.intro do
       prose("This chapter covers the minimum amount of functionality you'll need to start using Prawn.

--- a/manual/basic_concepts/origin.rb
+++ b/manual/basic_concepts/origin.rb
@@ -31,7 +31,7 @@ Prawn::ManualBuilder::Example.generate(filename) do
 
   stroke_circle [0, 0], 10
 
-  bounding_box([100, 300], :width => 300, :height => 200) do
+  bounding_box([100, 300], width: 300, height: 200) do
     stroke_bounds
     stroke_circle [0, 0], 10
   end

--- a/manual/basic_concepts/other_cursor_helpers.rb
+++ b/manual/basic_concepts/other_cursor_helpers.rb
@@ -30,7 +30,7 @@ Prawn::ManualBuilder::Example.generate(filename) do
 
   float do
     move_down 30
-    bounding_box([0, cursor], :width => 200) do
+    bounding_box([0, cursor], width: 200) do
       text "Text written inside the float block."
       stroke_bounds
     end

--- a/manual/bounding_box/bounding_box.rb
+++ b/manual/bounding_box/bounding_box.rb
@@ -5,7 +5,7 @@
 require File.expand_path(File.join(File.dirname(__FILE__),
                                    %w[.. example_helper]))
 
-Prawn::ManualBuilder::Example.generate("bounding_box.pdf", :page_size => "FOLIO") do
+Prawn::ManualBuilder::Example.generate("bounding_box.pdf", page_size: "FOLIO") do
   package "bounding_box" do |p|
     p.section "Basics" do |s|
       s.example "creation"

--- a/manual/bounding_box/bounds.rb
+++ b/manual/bounding_box/bounds.rb
@@ -40,7 +40,7 @@ Prawn::ManualBuilder::Example.generate(filename) do
   move_down 5
   print_coordinates
 
-  bounding_box([250, cursor + 140], :width => 200, :height => 150) do
+  bounding_box([250, cursor + 140], width: 200, height: 150) do
     text "This bounding box bounds:"
     move_down 5
     print_coordinates

--- a/manual/bounding_box/creation.rb
+++ b/manual/bounding_box/creation.rb
@@ -15,7 +15,7 @@ require File.expand_path(File.join(File.dirname(__FILE__),
 
 filename = File.basename(__FILE__).gsub('.rb', '.pdf')
 Prawn::ManualBuilder::Example.generate(filename) do
-  bounding_box([200, cursor - 100], :width => 200, :height => 100) do
+  bounding_box([200, cursor - 100], width: 200, height: 100) do
     text "Just your regular bounding box"
 
     transparent(0.5) { stroke_bounds }

--- a/manual/bounding_box/indentation.rb
+++ b/manual/bounding_box/indentation.rb
@@ -18,7 +18,7 @@ Prawn::ManualBuilder::Example.generate(filename) do
   end
   move_down 20
 
-  bounding_box([50, cursor], :width => 400, :height => cursor) do
+  bounding_box([50, cursor], width: 400, height: cursor) do
     transparent(0.5) { stroke_bounds }
 
     move_down 10
@@ -35,7 +35,7 @@ Prawn::ManualBuilder::Example.generate(filename) do
     indent(60) do
       text "Another indent block."
 
-      bounding_box([0, cursor], :width => 200) do
+      bounding_box([0, cursor], width: 200) do
         text "Note that this bounding box coordinates are relative to the " +
              "indent block"
 

--- a/manual/bounding_box/nesting.rb
+++ b/manual/bounding_box/nesting.rb
@@ -20,25 +20,25 @@ Prawn::ManualBuilder::Example.generate(filename) do
   end
 
   gap = 20
-  bounding_box([50, cursor], :width => 400, :height => 200) do
+  bounding_box([50, cursor], width: 400, height: 200) do
     box_content("Fixed height")
 
-    bounding_box([gap, cursor - gap], :width => 300) do
+    bounding_box([gap, cursor - gap], width: 300) do
       text "Stretchy height"
 
-      bounding_box([gap, bounds.top - gap], :width => 100) do
+      bounding_box([gap, bounds.top - gap], width: 100) do
         text "Stretchy height"
         transparent(0.5) { dash(1); stroke_bounds; undash }
       end
 
-      bounding_box([gap * 7, bounds.top - gap], :width => 100, :height => 50) do
+      bounding_box([gap * 7, bounds.top - gap], width: 100, height: 50) do
         box_content("Fixed height")
       end
 
       transparent(0.5) { dash(1); stroke_bounds; undash }
     end
 
-    bounding_box([gap, cursor - gap], :width => 300, :height => 50) do
+    bounding_box([gap, cursor - gap], width: 300, height: 50) do
       box_content("Fixed height")
     end
   end

--- a/manual/bounding_box/russian_boxes.rb
+++ b/manual/bounding_box/russian_boxes.rb
@@ -25,7 +25,7 @@ Prawn::ManualBuilder::Example.generate(filename) do
     left_top_corners = combine([5, bounds.right - width - 5],
                                [bounds.top - 5, height + 5])
     left_top_corners.each do |lt|
-      bounding_box(lt, :width => width, :height => height) do
+      bounding_box(lt, width: width, height: height) do
         stroke_bounds
         recurse_bounding_box(max_depth, depth + 1) if depth < max_depth
       end
@@ -33,7 +33,7 @@ Prawn::ManualBuilder::Example.generate(filename) do
   end
 
   # Set up a bbox from the dashed line to the bottom of the page
-  bounding_box([0, cursor], :width => bounds.width, :height => cursor) do
+  bounding_box([0, cursor], width: bounds.width, height: cursor) do
     recurse_bounding_box
   end
 end

--- a/manual/bounding_box/stretchy.rb
+++ b/manual/bounding_box/stretchy.rb
@@ -10,14 +10,14 @@ require File.expand_path(File.join(File.dirname(__FILE__),
 filename = File.basename(__FILE__).gsub('.rb', '.pdf')
 Prawn::ManualBuilder::Example.generate(filename) do
   y_position = cursor
-  bounding_box([0, y_position], :width => 200, :height => 100) do
+  bounding_box([0, y_position], width: 200, height: 100) do
     text "This bounding box has a height of 100. If this text gets too large " +
          "it will flow to the next page."
 
     transparent(0.5) { stroke_bounds }
   end
 
-  bounding_box([300, y_position], :width => 200) do
+  bounding_box([300, y_position], width: 200) do
     text "This bounding box has variable height. No matter how much text is " +
          "written here, the height will expand to fit."
 

--- a/manual/contents.rb
+++ b/manual/contents.rb
@@ -7,8 +7,8 @@ require_relative "example_helper"
 Encoding.default_external = Encoding::UTF_8
 
 Prawn::ManualBuilder::Example.generate("manual.pdf",
-                                       :skip_page_creation => true,
-                                       :page_size => "FOLIO") do
+                                       skip_page_creation: true,
+                                       page_size: "FOLIO") do
   load_page "", "cover"
   load_page "", "how_to_read_this_manual"
 

--- a/manual/cover.rb
+++ b/manual/cover.rb
@@ -10,18 +10,18 @@ Prawn::ManualBuilder::Example.generate(filename) do
   move_down 200
 
   image "#{Prawn::DATADIR}/images/prawn.png",
-        :scale => 0.9,
-        :at => [10, cursor]
+        scale: 0.9,
+        at: [10, cursor]
 
-  formatted_text_box([ { :text => "Prawn\n",
-                         :styles => [:bold],
-                         :size => 100 }
-                     ], :at => [170, cursor - 50])
+  formatted_text_box([ { text: "Prawn\n",
+                         styles: [:bold],
+                         size: 100 }
+                     ], at: [170, cursor - 50])
 
-  formatted_text_box([ { :text => "by example",
-                         :font => 'Courier',
-                         :size => 60 }
-                     ], :at => [170, cursor - 160])
+  formatted_text_box([ { text: "by example",
+                         font: 'Courier',
+                         size: 60 }
+                     ], at: [170, cursor - 160])
 
   if Dir.exist?("#{Prawn::BASEDIR}/.git")
     commit = `git show --pretty=%h`
@@ -30,9 +30,9 @@ Prawn::ManualBuilder::Example.generate(filename) do
     git_commit = ""
   end
 
-  formatted_text_box([  { :text => "Last Update: #{Time.now.strftime("%Y-%m-%d")}\n" +
-                                   "Prawn Version: #{Prawn::VERSION}\n" +
-                                   git_commit,
-                          :size => 12 }
-                     ], :at => [390, cursor - 620])
+  formatted_text_box([  { text: "Last Update: #{Time.now.strftime("%Y-%m-%d")}\n" +
+                                "Prawn Version: #{Prawn::VERSION}\n" +
+                                git_commit,
+                          size: 12 }
+                     ], at: [390, cursor - 620])
 end

--- a/manual/document_and_page_options/background.rb
+++ b/manual/document_and_page_options/background.rb
@@ -10,18 +10,18 @@ require File.expand_path(File.join(File.dirname(__FILE__),
 img = "#{Prawn::DATADIR}/images/letterhead.jpg"
 
 Prawn::Document.generate("background.pdf",
-                         :background => img,
-                         :margin => 100
+                         background: img,
+                         margin: 100
 ) do
-  text "My report caption", :size => 18, :align => :right
+  text "My report caption", size: 18, align: :right
 
   move_down font.height * 2
 
   text "Here is my text explaning this report. " * 20,
-       :size => 12, :align => :left, :leading => 2
+       size: 12, align: :left, leading: 2
 
   move_down font.height
 
   text "I'm using a soft background. " * 40,
-       :size => 12, :align => :left, :leading => 2
+       size: 12, align: :left, leading: 2
 end

--- a/manual/document_and_page_options/document_and_page_options.rb
+++ b/manual/document_and_page_options/document_and_page_options.rb
@@ -8,10 +8,10 @@ require File.expand_path(File.join(File.dirname(__FILE__),
 Prawn::ManualBuilder::Example.generate("document_and_page_options.pdf",
                                        page_size: "FOLIO") do
   package "document_and_page_options" do |p|
-    p.example "page_size",    eval_source: false, full_source: true
-    p.example "page_margins", eval_source: false, full_source: true
-    p.example "background",   eval_source: false, full_source: true
-    p.example "metadata",     eval_source: false, full_source: true
+    p.example "page_size",     eval_source: false, full_source: true
+    p.example "page_margins",  eval_source: false, full_source: true
+    p.example "background",    eval_source: false, full_source: true
+    p.example "metadata",      eval_source: false, full_source: true
     p.example "print_scaling", eval_source: false, full_source: true
 
     p.intro do

--- a/manual/document_and_page_options/document_and_page_options.rb
+++ b/manual/document_and_page_options/document_and_page_options.rb
@@ -6,13 +6,13 @@ require File.expand_path(File.join(File.dirname(__FILE__),
                                    %w[.. example_helper]))
 
 Prawn::ManualBuilder::Example.generate("document_and_page_options.pdf",
-                                       :page_size => "FOLIO") do
+                                       page_size: "FOLIO") do
   package "document_and_page_options" do |p|
-    p.example "page_size",    :eval_source => false, :full_source => true
-    p.example "page_margins", :eval_source => false, :full_source => true
-    p.example "background",   :eval_source => false, :full_source => true
-    p.example "metadata",     :eval_source => false, :full_source => true
-    p.example "print_scaling", :eval_source => false, :full_source => true
+    p.example "page_size",    eval_source: false, full_source: true
+    p.example "page_margins", eval_source: false, full_source: true
+    p.example "background",   eval_source: false, full_source: true
+    p.example "metadata",     eval_source: false, full_source: true
+    p.example "print_scaling", eval_source: false, full_source: true
 
     p.intro do
       prose("So far we've already seen how to create new documents and start new pages. This chapter expands on the previous examples by showing other options avialable. Some of the options are only available when creating new documents.

--- a/manual/document_and_page_options/metadata.rb
+++ b/manual/document_and_page_options/metadata.rb
@@ -8,12 +8,12 @@ require File.expand_path(File.join(File.dirname(__FILE__),
                                    %w[.. example_helper]))
 
 info = {
-  :Title        => "My title",
-  :Author       => "John Doe",
-  :Subject      => "My Subject",
-  :Keywords     => "test metadata ruby pdf dry",
-  :Creator      => "ACME Soft App",
-  :Producer     => "Prawn",
+  Title:        "My title",
+  Author:       "John Doe",
+  Subject:      "My Subject",
+  Keywords:     "test metadata ruby pdf dry",
+  Creator:      "ACME Soft App",
+  Producer:     "Prawn",
   CreationDate: Time.now
 }
 

--- a/manual/document_and_page_options/metadata.rb
+++ b/manual/document_and_page_options/metadata.rb
@@ -14,10 +14,10 @@ info = {
   :Keywords     => "test metadata ruby pdf dry",
   :Creator      => "ACME Soft App",
   :Producer     => "Prawn",
-  :CreationDate => Time.now
+  CreationDate: Time.now
 }
 
-Prawn::Document.generate("metadata.pdf", :info => info) do
+Prawn::Document.generate("metadata.pdf", info: info) do
   text "This is a test of setting metadata properties via the info option."
   text "While the keys are arbitrary, the above example sets common attributes."
 end

--- a/manual/document_and_page_options/page_margins.rb
+++ b/manual/document_and_page_options/page_margins.rb
@@ -12,27 +12,27 @@ require File.expand_path(File.join(File.dirname(__FILE__),
                                    %w[.. example_helper]))
 
 Prawn::Document.generate("page_margins.pdf",
-                         :margin => 100
+                         margin: 100
 ) do
   text "100 pts margins."
   stroke_bounds
 
-  start_new_page(:left_margin => 300)
+  start_new_page(left_margin: 300)
   text "300 pts margin on the left."
   stroke_bounds
 
-  start_new_page(:top_margin => 300)
+  start_new_page(top_margin: 300)
   text "300 pts margin both on the top and on the left. Notice that whenever " +
        "you set an option for a new page it will remain the default for the " +
        "following pages."
   stroke_bounds
 
-  start_new_page(:margin => 50)
+  start_new_page(margin: 50)
   text "50 pts margins. Using the margin option will reset previous specific " +
        "calls to left, right, top and bottom margins."
   stroke_bounds
 
-  start_new_page(:margin => [50, 100, 150, 200])
+  start_new_page(margin: [50, 100, 150, 200])
   text "There is also the shorthand CSS like syntax used here."
   stroke_bounds
 end

--- a/manual/document_and_page_options/page_size.rb
+++ b/manual/document_and_page_options/page_size.rb
@@ -16,7 +16,7 @@ require File.expand_path(File.join(File.dirname(__FILE__),
                                    %w[.. example_helper]))
 
 Prawn::Document.generate("page_size.pdf",
-                         :page_size   => "EXECUTIVE",
+                         page_size:   "EXECUTIVE",
                          page_layout: :landscape
 ) do
   text "EXECUTIVE landscape page."

--- a/manual/document_and_page_options/page_size.rb
+++ b/manual/document_and_page_options/page_size.rb
@@ -17,17 +17,17 @@ require File.expand_path(File.join(File.dirname(__FILE__),
 
 Prawn::Document.generate("page_size.pdf",
                          :page_size   => "EXECUTIVE",
-                         :page_layout => :landscape
+                         page_layout: :landscape
 ) do
   text "EXECUTIVE landscape page."
 
   custom_size = [275, 326]
 
   ["A4", "TABLOID", "B7", custom_size ].each do |size|
-    start_new_page(:size => size, :layout => :portrait)
+    start_new_page(size: size, layout: :portrait)
     text "#{size} portrait page."
 
-    start_new_page(:size => size, :layout => :landscape)
+    start_new_page(size: size, layout: :landscape)
     text "#{size} landscape page."
   end
 end

--- a/manual/document_and_page_options/print_scaling.rb
+++ b/manual/document_and_page_options/print_scaling.rb
@@ -13,8 +13,8 @@ require File.expand_path(File.join(File.dirname(__FILE__),
                                    %w[.. example_helper]))
 
 Prawn::Document.generate("print_scaling.pdf",
-                         :page_layout => :landscape,
-                         :print_scaling => :none
+                         page_layout: :landscape,
+                         print_scaling: :none
 ) do
   text "When you print this document, the scale to fit in print preview should be disabled by default."
 end

--- a/manual/graphics/common_lines.rb
+++ b/manual/graphics/common_lines.rb
@@ -23,8 +23,8 @@ Prawn::ManualBuilder::Example.generate(filename) do
     move_down 50
     horizontal_rule
 
-    vertical_line   100, 300, :at => 50
+    vertical_line   100, 300, at: 50
 
-    horizontal_line 200, 500, :at => 150
+    horizontal_line 200, 500, at: 150
   end
 end

--- a/manual/graphics/fill_rules.rb
+++ b/manual/graphics/fill_rules.rb
@@ -26,13 +26,13 @@ Prawn::ManualBuilder::Example.generate(filename) do
   stroke_color 'ff0000'
   line_width 2
 
-  text_box "Nonzero Winding Number", :at => [50, 215],
-                                     :width => 170,
-                                     :align => :center
+  text_box "Nonzero Winding Number", at: [50, 215],
+                                     width: 170,
+                                     align: :center
   polygon(*pentagram.map { |x, y| [x + 50, y] })
   fill_and_stroke
 
-  text_box "Even-Odd", :at => [330, 215], :width => 170, :align => :center
+  text_box "Even-Odd", at: [330, 215], width: 170, align: :center
   polygon(*pentagram.map { |x, y| [x + 330, y] })
-  fill_and_stroke(:fill_rule => :even_odd)
+  fill_and_stroke(fill_rule: :even_odd)
 end

--- a/manual/graphics/graphics.rb
+++ b/manual/graphics/graphics.rb
@@ -5,7 +5,7 @@
 require File.expand_path(File.join(File.dirname(__FILE__),
                                    %w[.. example_helper]))
 
-Prawn::ManualBuilder::Example.generate("graphics.pdf", :page_size => "FOLIO") do
+Prawn::ManualBuilder::Example.generate("graphics.pdf", page_size: "FOLIO") do
   package "graphics" do |p|
     p.section "Basics" do |s|
       s.example "helper"

--- a/manual/graphics/helper.rb
+++ b/manual/graphics/helper.rb
@@ -17,8 +17,8 @@ require File.expand_path(File.join(File.dirname(__FILE__),
 filename = File.basename(__FILE__).gsub('.rb', '.pdf')
 Prawn::ManualBuilder::Example.generate(filename) do
   stroke_axis
-  stroke_axis(:at => [70, 70], :height => 200, :step_length => 50,
-              :negative_axes_length => 5, :color => '0000FF')
-  stroke_axis(:at => [140, 140], :width => 200, :height => cursor.to_i - 140,
-              :step_length => 20, :negative_axes_length => 40, :color => 'FF00')
+  stroke_axis(at: [70, 70], height: 200, step_length: 50,
+              negative_axes_length: 5, color: '0000FF')
+  stroke_axis(at: [140, 140], width: 200, height: cursor.to_i - 140,
+              step_length: 20, negative_axes_length: 40, color: 'FF00')
 end

--- a/manual/graphics/line_width.rb
+++ b/manual/graphics/line_width.rb
@@ -25,7 +25,7 @@ Prawn::ManualBuilder::Example.generate(filename) do
     end
 
     stroke do
-      horizontal_line 50, 150, :at => y
+      horizontal_line 50, 150, at: y
       rectangle [275, y + 25], 50, 50
       circle [500, y], 25
     end

--- a/manual/graphics/lines_and_curves.rb
+++ b/manual/graphics/lines_and_curves.rb
@@ -29,13 +29,13 @@ Prawn::ManualBuilder::Example.generate(filename) do
     line_to 100, 100
     line_to 0, 100
 
-    curve_to [150, 250], :bounds => [[20, 200], [120, 200]]
-    curve_to [200, 0],   :bounds => [[150, 200], [450, 10]]
+    curve_to [150, 250], bounds: [[20, 200], [120, 200]]
+    curve_to [200, 0],   bounds: [[150, 200], [450, 10]]
   end
 
   # line and curve
   stroke do
     line [300, 200], [400, 50]
-    curve [500, 0], [400, 200], :bounds => [[600, 300], [300, 390]]
+    curve [500, 0], [400, 200], bounds: [[600, 300], [300, 390]]
   end
 end

--- a/manual/graphics/rotate.rb
+++ b/manual/graphics/rotate.rb
@@ -18,9 +18,9 @@ Prawn::ManualBuilder::Example.generate(filename) do
   fill_circle [250, 200], 2
 
   12.times do |i|
-    rotate(i * 30, :origin => [250, 200]) do
+    rotate(i * 30, origin: [250, 200]) do
       stroke_rectangle [350, 225], 100, 50
-      draw_text "Rotated #{i * 30}°", :size => 10, :at => [360, 205]
+      draw_text "Rotated #{i * 30}°", size: 10, at: [360, 205]
     end
   end
 end

--- a/manual/graphics/scale.rb
+++ b/manual/graphics/scale.rb
@@ -20,24 +20,24 @@ Prawn::ManualBuilder::Example.generate(filename) do
   y = 200
 
   stroke_rectangle [x, y], width, height
-  text_box "reference rectangle", :at => [x + 10, y - 10], :width => width - 20
+  text_box "reference rectangle", at: [x + 10, y - 10], width: width - 20
 
-  scale(2, :origin => [x, y]) do
+  scale(2, origin: [x, y]) do
     stroke_rectangle [x, y], width, height
     text_box "rectangle scaled from upper-left corner",
-             :at => [x, y - height - 5],
-             :width => width
+             at: [x, y - height - 5],
+             width: width
   end
 
   x = 350
 
   stroke_rectangle [x, y], width, height
-  text_box "reference rectangle", :at => [x + 10, y - 10], :width => width - 20
+  text_box "reference rectangle", at: [x + 10, y - 10], width: width - 20
 
-  scale(2, :origin => [x + width / 2, y - height / 2]) do
+  scale(2, origin: [x + width / 2, y - height / 2]) do
     stroke_rectangle [x, y], width, height
     text_box "rectangle scaled from center",
-             :at => [x, y - height - 5],
-             :width => width
+             at: [x, y - height - 5],
+             width: width
   end
 end

--- a/manual/graphics/stroke_cap.rb
+++ b/manual/graphics/stroke_cap.rb
@@ -25,7 +25,7 @@ Prawn::ManualBuilder::Example.generate(filename) do
     self.cap_style = cap
 
     y = 250 - i * 100
-    stroke_horizontal_line 100, 300, :at => y
+    stroke_horizontal_line 100, 300, at: y
     stroke_circle [400, y], 15
   end
 end

--- a/manual/graphics/stroke_dash.rb
+++ b/manual/graphics/stroke_dash.rb
@@ -20,10 +20,10 @@ filename = File.basename(__FILE__).gsub('.rb', '.pdf')
 Prawn::ManualBuilder::Example.generate(filename) do
   stroke_axis
 
-  dash([1, 2, 3, 2, 1, 5], :phase => 6)
-  stroke_horizontal_line 50, 500, :at => 230
+  dash([1, 2, 3, 2, 1, 5], phase: 6)
+  stroke_horizontal_line 50, 500, at: 230
   dash([1, 2, 3, 4, 5, 6, 7, 8])
-  stroke_horizontal_line 50, 500, :at => 220
+  stroke_horizontal_line 50, 500, at: 220
 
   base_y = 210
 
@@ -42,7 +42,7 @@ Prawn::ManualBuilder::Example.generate(filename) do
     end
     base_y -= 5
 
-    dash(length, :space => space, :phase => phase)
-    stroke_horizontal_line 50, 500, :at => base_y - (2 * i)
+    dash(length, space: space, phase: phase)
+    stroke_horizontal_line 50, 500, at: base_y - (2 * i)
   end
 end

--- a/manual/graphics/translate.rb
+++ b/manual/graphics/translate.rb
@@ -17,13 +17,13 @@ Prawn::ManualBuilder::Example.generate(filename) do
       # Draw a point on the new origin
       fill_circle [0, 0], 2
       draw_text "New origin after translation to [#{x}, #{y}]",
-                :at => [5, -2], :size => 8
+                at: [5, -2], size: 8
 
       stroke_rectangle [100, 75], 100, 50
       text_box "Top left corner at [100,75]",
-               :at => [110, 65],
-               :width => 80,
-               :size => 8
+               at: [110, 65],
+               width: 80,
+               size: 8
     end
   end
 end

--- a/manual/images/absolute_position.rb
+++ b/manual/images/absolute_position.rb
@@ -17,7 +17,7 @@ Prawn::ManualBuilder::Example.generate(filename) do
   y_position = cursor
   text "The image won't go below this line of text."
 
-  image "#{Prawn::DATADIR}/images/fractal.jpg", :at => [200, y_position]
+  image "#{Prawn::DATADIR}/images/fractal.jpg", at: [200, y_position]
 
   text "And this line of text will go just below the previous one."
 end

--- a/manual/images/fit.rb
+++ b/manual/images/fit.rb
@@ -14,8 +14,8 @@ Prawn::ManualBuilder::Example.generate(filename) do
   size = 300
 
   text "Using the fit option"
-  bounding_box([0, cursor], :width => size, :height => size) do
-    image "#{Prawn::DATADIR}/images/pigs.jpg", :fit => [size, size]
+  bounding_box([0, cursor], width: size, height: size) do
+    image "#{Prawn::DATADIR}/images/pigs.jpg", fit: [size, size]
     stroke_bounds
   end
 end

--- a/manual/images/horizontal.rb
+++ b/manual/images/horizontal.rb
@@ -11,15 +11,15 @@ require File.expand_path(File.join(File.dirname(__FILE__),
 
 filename = File.basename(__FILE__).gsub('.rb', '.pdf')
 Prawn::ManualBuilder::Example.generate(filename) do
-  bounding_box([50, cursor], :width => 400, :height => 450) do
+  bounding_box([50, cursor], width: 400, height: 450) do
     stroke_bounds
 
     [:left, :center, :right].each do |position|
       text  "Image aligned to the #{position}."
-      image "#{Prawn::DATADIR}/images/stef.jpg", :position => position
+      image "#{Prawn::DATADIR}/images/stef.jpg", position: position
     end
 
     text  "The next image has a 50 point offset from the left boundary"
-    image "#{Prawn::DATADIR}/images/stef.jpg", :position => 50
+    image "#{Prawn::DATADIR}/images/stef.jpg", position: 50
   end
 end

--- a/manual/images/images.rb
+++ b/manual/images/images.rb
@@ -5,7 +5,7 @@
 require File.expand_path(File.join(File.dirname(__FILE__),
                                    %w[.. example_helper]))
 
-Prawn::ManualBuilder::Example.generate("images.pdf", :page_size => "FOLIO") do
+Prawn::ManualBuilder::Example.generate("images.pdf", page_size: "FOLIO") do
   package "images" do |p|
     p.section "Basics" do |s|
       s.example "plain_image"

--- a/manual/images/scale.rb
+++ b/manual/images/scale.rb
@@ -14,9 +14,9 @@ Prawn::ManualBuilder::Example.generate(filename) do
   move_down 20
 
   text  "Scaled to 50%"
-  image "#{Prawn::DATADIR}/images/stef.jpg", :scale => 0.5
+  image "#{Prawn::DATADIR}/images/stef.jpg", scale: 0.5
   move_down 20
 
   text  "Scaled to 200%"
-  image "#{Prawn::DATADIR}/images/stef.jpg", :scale => 2
+  image "#{Prawn::DATADIR}/images/stef.jpg", scale: 2
 end

--- a/manual/images/vertical.rb
+++ b/manual/images/vertical.rb
@@ -16,13 +16,16 @@ Prawn::ManualBuilder::Example.generate(filename) do
 
     [:top, :center, :bottom].each do |vposition|
       text "Image vertically aligned to the #{vposition}.", valign: vposition
-      image "#{Prawn::DATADIR}/images/stef.jpg", :position  => 250,
-                                                 vposition: vposition
+      image "#{Prawn::DATADIR}/images/stef.jpg",
+            position:  250,
+            vposition: vposition
     end
 
     text_box "The next image has a 100 point offset from the top boundary",
-             at: [bounds.width - 110, bounds.top - 10], width: 100
-    image "#{Prawn::DATADIR}/images/stef.jpg", :position  => :right,
-                                               vposition: 100
+             at: [bounds.width - 110, bounds.top - 10],
+             width: 100
+    image "#{Prawn::DATADIR}/images/stef.jpg",
+          position:  :right,
+          vposition: 100
   end
 end

--- a/manual/images/vertical.rb
+++ b/manual/images/vertical.rb
@@ -11,18 +11,18 @@ require File.expand_path(File.join(File.dirname(__FILE__),
 
 filename = File.basename(__FILE__).gsub('.rb', '.pdf')
 Prawn::ManualBuilder::Example.generate(filename) do
-  bounding_box([0, cursor], :width => 500, :height => 450) do
+  bounding_box([0, cursor], width: 500, height: 450) do
     stroke_bounds
 
     [:top, :center, :bottom].each do |vposition|
-      text "Image vertically aligned to the #{vposition}.", :valign => vposition
+      text "Image vertically aligned to the #{vposition}.", valign: vposition
       image "#{Prawn::DATADIR}/images/stef.jpg", :position  => 250,
-                                                 :vposition => vposition
+                                                 vposition: vposition
     end
 
     text_box "The next image has a 100 point offset from the top boundary",
-             :at => [bounds.width - 110, bounds.top - 10], :width => 100
+             at: [bounds.width - 110, bounds.top - 10], width: 100
     image "#{Prawn::DATADIR}/images/stef.jpg", :position  => :right,
-                                               :vposition => 100
+                                               vposition: 100
   end
 end

--- a/manual/images/width_and_height.rb
+++ b/manual/images/width_and_height.rb
@@ -13,13 +13,13 @@ require File.expand_path(File.join(File.dirname(__FILE__),
 filename = File.basename(__FILE__).gsub('.rb', '.pdf')
 Prawn::ManualBuilder::Example.generate(filename) do
   text  "Scale by setting only the width"
-  image "#{Prawn::DATADIR}/images/pigs.jpg", :width => 150
+  image "#{Prawn::DATADIR}/images/pigs.jpg", width: 150
   move_down 20
 
   text  "Scale by setting only the height"
-  image "#{Prawn::DATADIR}/images/pigs.jpg", :height => 100
+  image "#{Prawn::DATADIR}/images/pigs.jpg", height: 100
   move_down 20
 
   text  "Stretch to fit the width and height provided"
-  image "#{Prawn::DATADIR}/images/pigs.jpg", :width => 500, :height => 100
+  image "#{Prawn::DATADIR}/images/pigs.jpg", width: 500, height: 100
 end

--- a/manual/layout/boxes.rb
+++ b/manual/layout/boxes.rb
@@ -15,7 +15,7 @@ filename = File.basename(__FILE__).gsub('.rb', '.pdf')
 Prawn::ManualBuilder::Example.generate(filename) do
   # The grid only need to be defined once, but since all the examples should be
   # able to run alone we are repeating it on every example
-  define_grid(:columns => 5, :rows => 8, :gutter => 10)
+  define_grid(columns: 5, rows: 8, gutter: 10)
 
   grid(4, 0).show
   grid(5, 1).show

--- a/manual/layout/content.rb
+++ b/manual/layout/content.rb
@@ -13,7 +13,7 @@ filename = File.basename(__FILE__).gsub('.rb', '.pdf')
 Prawn::ManualBuilder::Example.generate(filename) do
   # The grid only need to be defined once, but since all the examples should be
   # able to run alone we are repeating it on every example
-  define_grid(:columns => 5, :rows => 8, :gutter => 10)
+  define_grid(columns: 5, rows: 8, gutter: 10)
 
   grid([5, 0], [7, 1]).bounding_box do
     text "Adding some content to this multi_box.\n" + " _ " * 200

--- a/manual/layout/layout.rb
+++ b/manual/layout/layout.rb
@@ -5,7 +5,7 @@
 require File.expand_path(File.join(File.dirname(__FILE__),
                                    %w[.. example_helper]))
 
-Prawn::ManualBuilder::Example.generate("layout.pdf", :page_size => "FOLIO") do
+Prawn::ManualBuilder::Example.generate("layout.pdf", page_size: "FOLIO") do
   package "layout" do |p|
     p.example "simple_grid"
     p.example "boxes"

--- a/manual/layout/simple_grid.rb
+++ b/manual/layout/simple_grid.rb
@@ -15,7 +15,7 @@ filename = File.basename(__FILE__).gsub('.rb', '.pdf')
 Prawn::ManualBuilder::Example.generate(filename) do
   # The grid only need to be defined once, but since all the examples should be
   # able to run alone we are repeating it on every example
-  define_grid(:columns => 5, :rows => 8, :gutter => 10)
+  define_grid(columns: 5, rows: 8, gutter: 10)
   text "We defined the grid, roll over to the next page to see its outline"
 
   start_new_page

--- a/manual/outline/add_subsection_to.rb
+++ b/manual/outline/add_subsection_to.rb
@@ -29,33 +29,33 @@ Prawn::ManualBuilder::Example.generate(filename) do
   end
 
   outline.define do
-    section("Section 1", :destination => 1) do
-      page :title => "Page 2", :destination => 2
-      page :title => "Page 3", :destination => 3
+    section("Section 1", destination: 1) do
+      page title: "Page 2", destination: 2
+      page title: "Page 3", destination: 3
     end
   end
 
   # Now we will start adding nodes to the previous outline
   outline.add_subsection_to("Section 1", :first) do
     outline.section("Added later - first position") do
-      outline.page :title => "Page 4", :destination => 4
-      outline.page :title => "Page 5", :destination => 5
+      outline.page title: "Page 4", destination: 4
+      outline.page title: "Page 5", destination: 5
     end
   end
 
   outline.add_subsection_to("Section 1") do
-    outline.page :title => "Added later - last position",
-                 :destination => 6
+    outline.page title: "Added later - last position",
+                 destination: 6
   end
 
   outline.add_subsection_to("Added later - first position") do
-    outline.page :title => "Another page added later",
-                 :destination => 7
+    outline.page title: "Another page added later",
+                 destination: 7
   end
 
   # The title provided is for a page which will be converted into a section
   outline.add_subsection_to("Page 3") do
-    outline.page :title => "Last page added",
-                 :destination => 8
+    outline.page title: "Last page added",
+                 destination: 8
   end
 end

--- a/manual/outline/insert_section_after.rb
+++ b/manual/outline/insert_section_after.rb
@@ -21,27 +21,27 @@ Prawn::ManualBuilder::Example.generate(filename) do
   end
 
   outline.define do
-    section("Section 1", :destination => 1) do
-      page :title => "Page 2", :destination => 2
-      page :title => "Page 3", :destination => 3
+    section("Section 1", destination: 1) do
+      page title: "Page 2", destination: 2
+      page title: "Page 3", destination: 3
     end
   end
 
   # Now we will start adding nodes to the previous outline
   outline.insert_section_after("Page 2") do
     outline.section("Section after Page 2") do
-      outline.page :title => "Page 4", :destination => 4
+      outline.page title: "Page 4", destination: 4
     end
   end
 
   outline.insert_section_after("Section 1") do
     outline.section("Section after Section 1") do
-      outline.page :title => "Page 5", :destination => 5
+      outline.page title: "Page 5", destination: 5
     end
   end
 
   # Adding just a page
   outline.insert_section_after("Page 3") do
-    outline.page :title => "Page after Page 3", :destination => 6
+    outline.page title: "Page after Page 3", destination: 6
   end
 end

--- a/manual/outline/outline.rb
+++ b/manual/outline/outline.rb
@@ -5,15 +5,15 @@
 require File.expand_path(File.join(File.dirname(__FILE__),
                                    %w[.. example_helper]))
 
-Prawn::ManualBuilder::Example.generate("outline.pdf", :page_size => "FOLIO") do
+Prawn::ManualBuilder::Example.generate("outline.pdf", page_size: "FOLIO") do
   package "outline" do |p|
     p.section "Basics" do |s|
-      s.example "sections_and_pages", :eval_source => false
+      s.example "sections_and_pages", eval_source: false
     end
 
     p.section "Adding nodes later" do |s|
-      s.example "add_subsection_to",    :eval_source => false
-      s.example "insert_section_after", :eval_source => false
+      s.example "add_subsection_to",    eval_source: false
+      s.example "insert_section_after", eval_source: false
     end
 
     p.intro do

--- a/manual/outline/sections_and_pages.rb
+++ b/manual/outline/sections_and_pages.rb
@@ -36,32 +36,32 @@ Prawn::ManualBuilder::Example.generate(filename) do
   end
 
   outline.define do
-    section("Section 1", :destination => 1) do
-      page :title => "Page 2", :destination => 2
-      page :title => "Page 3", :destination => 3
+    section("Section 1", destination: 1) do
+      page title: "Page 2", destination: 2
+      page title: "Page 3", destination: 3
     end
 
-    section("Section 2", :destination => 4) do
-      page :title => "Page 5", :destination => 5
+    section("Section 2", destination: 4) do
+      page title: "Page 5", destination: 5
 
-      section("Subsection 2.1", :destination => 6, :closed => true) do
-        page :title => "Page 7", :destination => 7
+      section("Subsection 2.1", destination: 6, closed: true) do
+        page title: "Page 7", destination: 7
       end
     end
   end
 
   # Outside of the define block
-  outline.section("Section 3", :destination => 8) do
-    outline.page :title => "Page 9", :destination => 9
+  outline.section("Section 3", destination: 8) do
+    outline.page title: "Page 9", destination: 9
   end
 
-  outline.page :title => "Page 10", :destination => 10
+  outline.page title: "Page 10", destination: 10
 
   # Section and Pages without links. While a section without a link may be
   # useful to group some pages, a page without a link is useless
   outline.update do  # update is an alias to define
     section("Section without link") do
-      page :title => "Page without link"
+      page title: "Page without link"
     end
   end
 end

--- a/manual/repeatable_content/alternate_page_numbering.rb
+++ b/manual/repeatable_content/alternate_page_numbering.rb
@@ -17,16 +17,16 @@ Prawn::ManualBuilder::Example.generate(filename) do
   end
 
   string = "<page>"
-  odd_options = { :at => [bounds.right - 150, 0],
-                  :width => 150,
-                  :align => :right,
-                  :page_filter => :odd,
-                  :start_count_at => 1 }
-  even_options = { :at => [0, bounds.left],
-                   :width => 150,
-                   :align => :left,
-                   :page_filter => :even,
-                   :start_count_at => 2 }
+  odd_options = { at: [bounds.right - 150, 0],
+                  width: 150,
+                  align: :right,
+                  page_filter: :odd,
+                  start_count_at: 1 }
+  even_options = { at: [0, bounds.left],
+                   width: 150,
+                   align: :left,
+                   page_filter: :even,
+                   start_count_at: 2 }
   number_pages string, odd_options
   number_pages string, even_options
 end

--- a/manual/repeatable_content/page_numbering.rb
+++ b/manual/repeatable_content/page_numbering.rb
@@ -35,12 +35,12 @@ Prawn::ManualBuilder::Example.generate(filename) do
 
   string = "page <page> of <total>"
   # Green page numbers 1 to 7
-  options = { :at => [bounds.right - 150, 0],
-              :width => 150,
-              :align => :right,
-              :page_filter => (1..7),
-              :start_count_at => 1,
-              :color => "007700" }
+  options = { at: [bounds.right - 150, 0],
+              width: 150,
+              align: :right,
+              page_filter: (1..7),
+              start_count_at: 1,
+              color: "007700" }
   number_pages string, options
 
   # Gray page numbers from 8 on up

--- a/manual/repeatable_content/repeatable_content.rb
+++ b/manual/repeatable_content/repeatable_content.rb
@@ -5,12 +5,12 @@
 require File.expand_path(File.join(File.dirname(__FILE__),
                                    %w[.. example_helper]))
 
-Prawn::ManualBuilder::Example.generate("repeatable_content.pdf", :page_size => "FOLIO") do
+Prawn::ManualBuilder::Example.generate("repeatable_content.pdf", page_size: "FOLIO") do
   package "repeatable_content" do |p|
-    p.example "repeater",       :eval_source => false
+    p.example "repeater",       eval_source: false
     p.example "stamp"
-    p.example "page_numbering", :eval_source => false
-    p.example "alternate_page_numbering", :eval_source => false
+    p.example "page_numbering", eval_source: false
+    p.example "alternate_page_numbering", eval_source: false
 
     p.intro do
       prose("Prawn offers two ways to handle repeatable content blocks. Repeater is useful for content that gets repeated at well defined intervals while Stamp is more appropriate if you need better control of when to repeat it.

--- a/manual/repeatable_content/repeater.rb
+++ b/manual/repeatable_content/repeater.rb
@@ -21,35 +21,35 @@ require File.expand_path(File.join(File.dirname(__FILE__),
 filename = File.basename(__FILE__).gsub('.rb', '.pdf')
 Prawn::ManualBuilder::Example.generate(filename) do
   repeat(:all) do
-    draw_text "All pages", :at => bounds.top_left
+    draw_text "All pages", at: bounds.top_left
   end
 
   repeat(:odd) do
-    draw_text "Only odd pages", :at => [0, 0]
+    draw_text "Only odd pages", at: [0, 0]
   end
 
   repeat(:even) do
-    draw_text "Only even pages", :at => [0, 0]
+    draw_text "Only even pages", at: [0, 0]
   end
 
   repeat([1, 3, 7]) do
-    draw_text "Only on pages 1, 3 and 7", :at => [100, 0]
+    draw_text "Only on pages 1, 3 and 7", at: [100, 0]
   end
 
   repeat(2..4) do
-    draw_text "From the 2nd to the 4th page", :at => [300, 0]
+    draw_text "From the 2nd to the 4th page", at: [300, 0]
   end
 
   repeat(lambda { |pg| pg % 3 == 0 }) do
-    draw_text "Every third page", :at => [250, 20]
+    draw_text "Every third page", at: [250, 20]
   end
 
-  repeat(:all, :dynamic => true) do
-    draw_text page_number, :at => [500, 0]
+  repeat(:all, dynamic: true) do
+    draw_text page_number, at: [500, 0]
   end
 
   10.times do
     start_new_page
-    draw_text "A wonderful page", :at => [400, 400]
+    draw_text "A wonderful page", at: [400, 400]
   end
 end

--- a/manual/repeatable_content/stamp.rb
+++ b/manual/repeatable_content/stamp.rb
@@ -22,14 +22,14 @@ require File.expand_path(File.join(File.dirname(__FILE__),
 filename = File.basename(__FILE__).gsub('.rb', '.pdf')
 Prawn::ManualBuilder::Example.generate(filename) do
   create_stamp("approved") do
-    rotate(30, :origin => [-5, -5]) do
+    rotate(30, origin: [-5, -5]) do
       stroke_color "FF3333"
       stroke_ellipse [0, 0], 29, 15
       stroke_color "000000"
 
       fill_color "993333"
       font("Times-Roman") do
-        draw_text "Approved", :at => [-23, -3]
+        draw_text "Approved", at: [-23, -3]
       end
       fill_color "000000"
     end

--- a/manual/security/encryption.rb
+++ b/manual/security/encryption.rb
@@ -25,5 +25,5 @@ end
 # Simple password. All permissions granted.
 Prawn::ManualBuilder::Example.generate("simple_password.pdf") do
   text "You was asked for a password."
-  encrypt_document(:user_password => 'foo', :owner_password => 'bar')
+  encrypt_document(user_password: 'foo', owner_password: 'bar')
 end

--- a/manual/security/permissions.rb
+++ b/manual/security/permissions.rb
@@ -29,8 +29,8 @@ end
 Prawn::ManualBuilder::Example.generate("no_permissions.pdf") do
   text "You may only view this and won't be able to use the owner password."
   encrypt_document(user_password: 'foo', owner_password: :random,
-                   permissions: { :print_document     => false,
-                                     :modify_contents    => false,
-                                     :copy_contents      => false,
-                                     modify_annotations: false })
+                   permissions: { print_document:     false,
+                                  modify_contents:    false,
+                                  copy_contents:      false,
+                                  modify_annotations: false })
 end

--- a/manual/security/permissions.rb
+++ b/manual/security/permissions.rb
@@ -21,16 +21,16 @@ require File.expand_path(File.join(File.dirname(__FILE__),
 # User cannot print the document.
 Prawn::ManualBuilder::Example.generate("cannot_print.pdf") do
   text "If you used the user password you won't be able to print the doc."
-  encrypt_document(:user_password => 'foo', :owner_password => 'bar',
-                   :permissions => { :print_document => false })
+  encrypt_document(user_password: 'foo', owner_password: 'bar',
+                   permissions: { print_document: false })
 end
 
 # All permissions revoked and owner password set to random
 Prawn::ManualBuilder::Example.generate("no_permissions.pdf") do
   text "You may only view this and won't be able to use the owner password."
-  encrypt_document(:user_password => 'foo', :owner_password => :random,
-                   :permissions => { :print_document     => false,
+  encrypt_document(user_password: 'foo', owner_password: :random,
+                   permissions: { :print_document     => false,
                                      :modify_contents    => false,
                                      :copy_contents      => false,
-                                     :modify_annotations => false })
+                                     modify_annotations: false })
 end

--- a/manual/security/security.rb
+++ b/manual/security/security.rb
@@ -5,10 +5,10 @@
 require File.expand_path(File.join(File.dirname(__FILE__),
                                    %w[.. example_helper]))
 
-Prawn::ManualBuilder::Example.generate("security.pdf", :page_size => "FOLIO") do
+Prawn::ManualBuilder::Example.generate("security.pdf", page_size: "FOLIO") do
   package "security" do |p|
-    p.example "encryption",  :eval_source => false, :full_source => true
-    p.example "permissions", :eval_source => false, :full_source => true
+    p.example "encryption",  eval_source: false, full_source: true
+    p.example "permissions", eval_source: false, full_source: true
 
     p.intro do
       prose("Security lets you control who can read the document by defining a password.

--- a/manual/text/alignment.rb
+++ b/manual/text/alignment.rb
@@ -18,27 +18,27 @@ require File.expand_path(File.join(File.dirname(__FILE__),
 filename = File.basename(__FILE__).gsub('.rb', '.pdf')
 Prawn::ManualBuilder::Example.generate(filename) do
   text "This text should be left aligned"
-  text "This text should be centered",      :align => :center
-  text "This text should be right aligned", :align => :right
+  text "This text should be centered",      align: :center
+  text "This text should be right aligned", align: :right
 
-  bounding_box([0, 220], :width => 250, :height => 220) do
+  bounding_box([0, 220], width: 250, height: 220) do
     text "This text is flowing from the left. " * 4
 
     move_down 15
-    text "This text is flowing from the center. " * 3, :align => :center
+    text "This text is flowing from the center. " * 3, align: :center
 
     move_down 15
-    text "This text is flowing from the right. " * 4, :align => :right
+    text "This text is flowing from the right. " * 4, align: :right
 
     move_down 15
-    text "This text is justified. " * 6, :align => :justify
+    text "This text is justified. " * 6, align: :justify
     transparent(0.5) { stroke_bounds }
   end
 
-  bounding_box([300, 220], :width => 250, :height => 220) do
+  bounding_box([300, 220], width: 250, height: 220) do
     text "This text should be vertically top aligned"
-    text "This text should be vertically centered",       :valign => :center
-    text "This text should be vertically bottom aligned", :valign => :bottom
+    text "This text should be vertically centered",       valign: :center
+    text "This text should be vertically bottom aligned", valign: :bottom
     transparent(0.5) { stroke_bounds }
   end
 end

--- a/manual/text/color.rb
+++ b/manual/text/color.rb
@@ -11,13 +11,13 @@ Prawn::ManualBuilder::Example.generate(filename) do
   text "Default color is black"
   move_down 25
 
-  text "Changed to red", :color => "FF0000"
+  text "Changed to red", color: "FF0000"
   move_down 25
 
-  text "CMYK color", :color => [22, 55, 79, 30]
+  text "CMYK color", color: [22, 55, 79, 30]
   move_down 25
 
   text "Also works with <color rgb='ff0000'>inline</color> formatting",
-       :color => "0000FF",
-       :inline_format => true
+       color: "0000FF",
+       inline_format: true
 end

--- a/manual/text/column_box.rb
+++ b/manual/text/column_box.rb
@@ -10,11 +10,11 @@ require File.expand_path(File.join(File.dirname(__FILE__),
 
 filename = File.basename(__FILE__).gsub('.rb', '.pdf')
 Prawn::ManualBuilder::Example.generate(filename) do
-  text "The Prince",          :align => :center, :size => 18
-  text "Niccolò Machiavelli", :align => :center, :size => 14
+  text "The Prince",          align: :center, size: 18
+  text "Niccolò Machiavelli", align: :center, size: 14
   move_down 12
 
-  column_box([0, cursor], :columns => 2, :width => bounds.width) do
+  column_box([0, cursor], columns: 2, width: bounds.width) do
     text((<<-END.gsub(/\s+/, ' ') + "\n\n") * 3)
       All the States and Governments by which men are or ever have been ruled,
       have been and are either Republics or Princedoms. Princedoms are either

--- a/manual/text/fallback_fonts.rb
+++ b/manual/text/fallback_fonts.rb
@@ -11,12 +11,12 @@ filename = File.basename(__FILE__).gsub('.rb', '.pdf')
 Prawn::ManualBuilder::Example.generate(filename) do
   file = "#{Prawn::DATADIR}/fonts/gkai00mp.ttf"
   font_families["Kai"] = {
-    :normal => { :file => file, :font => "Kai" }
+    normal: { file: file, font: "Kai" }
   }
 
   file = "#{Prawn::DATADIR}/fonts/Panic+Sans.dfont"
   font_families["Panic Sans"] = {
-    :normal => { :file => file, :font => "PanicSans" }
+    normal: { file: file, font: "PanicSans" }
   }
 
   font("Panic Sans") do
@@ -26,12 +26,12 @@ Prawn::ManualBuilder::Example.generate(filename) do
          "to right." +
          "\n\n" +
          "hello ƒ 你好\n再见 ƒ goodbye",
-         :fallback_fonts => ["Times-Roman", "Kai"])
+         fallback_fonts: ["Times-Roman", "Kai"])
   end
   move_down 20
 
-  formatted_text([ { :text => "Fallback fonts can even override" },
-                   { :text => "fragment fonts (你好)", :font => "Times-Roman" }
+  formatted_text([ { text: "Fallback fonts can even override" },
+                   { text: "fragment fonts (你好)", font: "Times-Roman" }
                  ],
-                 :fallback_fonts => ["Times-Roman", "Kai"])
+                 fallback_fonts: ["Times-Roman", "Kai"])
 end

--- a/manual/text/font_size.rb
+++ b/manual/text/font_size.rb
@@ -29,17 +29,17 @@ Prawn::ManualBuilder::Example.generate(filename) do
   text "Back to 16 again."
 
   move_down 10
-  text "Single line on 20 using the :size option.", :size => 20
+  text "Single line on 20 using the :size option.", size: 20
 
   move_down 10
   text "Back to 16 once more."
 
   move_down 10
-  font("Courier", :size => 10) do
+  font("Courier", size: 10) do
     text "Yeah, using Courier 10 courtesy of the font method."
   end
 
   move_down 10
-  font("Helvetica", :size => 12)
+  font("Helvetica", size: 12)
   text "Back to normal"
 end

--- a/manual/text/font_style.rb
+++ b/manual/text/font_style.rb
@@ -16,7 +16,7 @@ Prawn::ManualBuilder::Example.generate(filename) do
     move_down 20
 
     [:bold, :bold_italic, :italic, :normal].each do |style|
-      font example_font, :style => style
+      font example_font, style: style
       text "I'm writing in #{example_font} (#{style})"
     end
   end

--- a/manual/text/formatted_callbacks.rb
+++ b/manual/text/formatted_callbacks.rb
@@ -49,13 +49,13 @@ Prawn::ManualBuilder::Example.generate(filename) do
     end
   end
 
-  highlight = HighlightCallback.new(:color => 'ffff00', :document => self)
-  border    = ConnectedBorderCallback.new(:radius => 2.5, :document => self)
+  highlight = HighlightCallback.new(color: 'ffff00', document: self)
+  border    = ConnectedBorderCallback.new(radius: 2.5, document: self)
 
-  formatted_text [ { :text => "hello", :callback => highlight },
-                   { :text => "     " },
-                   { :text => "world", :callback => border },
-                   { :text => "     " },
-                   { :text => "hello world", :callback => [highlight, border] }
-                 ], :size => 20
+  formatted_text [ { text: "hello", callback: highlight },
+                   { text: "     " },
+                   { text: "world", callback: border },
+                   { text: "     " },
+                   { text: "hello world", callback: [highlight, border] }
+                 ], size: 20
 end

--- a/manual/text/formatted_text.rb
+++ b/manual/text/formatted_text.rb
@@ -28,9 +28,9 @@ Prawn::ManualBuilder::Example.generate(filename) do
   formatted_text [ { text: "Some bold. ",      styles: [:bold] },
                    { text: "Some italic. ",    styles: [:italic] },
                    { text: "Bold italic. ",    styles: [:bold, :italic] },
-                   { text: "Bigger Text. ",    :size  => 20 },
+                   { text: "Bigger Text. ",    size:   20 },
                    { text: "More spacing. ",   character_spacing: 3 },
-                   { text: "Different Font. ", font: "Courier" },
+                   { text: "Different Font. ", font:  "Courier" },
                    { text: "Some coloring. ",  color: "FF00FF" },
                    { text: "Link to the wiki. ",
                      color: "0000FF",
@@ -43,8 +43,8 @@ Prawn::ManualBuilder::Example.generate(filename) do
   formatted_text_box [ { text: "Just your regular" },
                        { text: " text_box ", font: "Courier" },
                        { text: "with some additional formatting options " +
-                                  "added to the mix.",
-                         color: [50, 100, 0, 0],
+                               "added to the mix.",
+                         color:  [50, 100, 0, 0],
                          styles: [:italic] }
                      ], at: [100, 100], width: 200, height: 100
 end

--- a/manual/text/formatted_text.rb
+++ b/manual/text/formatted_text.rb
@@ -25,26 +25,26 @@ require File.expand_path(File.join(File.dirname(__FILE__),
 
 filename = File.basename(__FILE__).gsub('.rb', '.pdf')
 Prawn::ManualBuilder::Example.generate(filename) do
-  formatted_text [ { :text => "Some bold. ",      :styles => [:bold] },
-                   { :text => "Some italic. ",    :styles => [:italic] },
-                   { :text => "Bold italic. ",    :styles => [:bold, :italic] },
-                   { :text => "Bigger Text. ",    :size  => 20 },
-                   { :text => "More spacing. ",   :character_spacing => 3 },
-                   { :text => "Different Font. ", :font => "Courier" },
-                   { :text => "Some coloring. ",  :color => "FF00FF" },
-                   { :text => "Link to the wiki. ",
-                     :color => "0000FF",
-                     :link => "https://github.com/prawnpdf/prawn/wiki" },
-                   { :text => "Link to a local file. ",
-                     :color => "0000FF",
-                     :local => "./local_file.txt" }
+  formatted_text [ { text: "Some bold. ",      styles: [:bold] },
+                   { text: "Some italic. ",    styles: [:italic] },
+                   { text: "Bold italic. ",    styles: [:bold, :italic] },
+                   { text: "Bigger Text. ",    :size  => 20 },
+                   { text: "More spacing. ",   character_spacing: 3 },
+                   { text: "Different Font. ", font: "Courier" },
+                   { text: "Some coloring. ",  color: "FF00FF" },
+                   { text: "Link to the wiki. ",
+                     color: "0000FF",
+                     link: "https://github.com/prawnpdf/prawn/wiki" },
+                   { text: "Link to a local file. ",
+                     color: "0000FF",
+                     local: "./local_file.txt" }
                  ]
 
-  formatted_text_box [ { :text => "Just your regular" },
-                       { :text => " text_box ", :font => "Courier" },
-                       { :text => "with some additional formatting options " +
+  formatted_text_box [ { text: "Just your regular" },
+                       { text: " text_box ", font: "Courier" },
+                       { text: "with some additional formatting options " +
                                   "added to the mix.",
-                         :color => [50, 100, 0, 0],
-                         :styles => [:italic] }
-                     ], :at => [100, 100], :width => 200, :height => 100
+                         color: [50, 100, 0, 0],
+                         styles: [:italic] }
+                     ], at: [100, 100], width: 200, height: 100
 end

--- a/manual/text/free_flowing_text.rb
+++ b/manual/text/free_flowing_text.rb
@@ -22,12 +22,12 @@ Prawn::ManualBuilder::Example.generate(filename) do
   text "This text will flow to the next page. " * 20
 
   y_position = cursor - 50
-  bounding_box([0, y_position], :width => 200, :height => 150) do
+  bounding_box([0, y_position], width: 200, height: 150) do
     transparent(0.5) { stroke_bounds }
     text "This text will flow along this bounding box we created for it. " * 5
   end
 
-  bounding_box([300, y_position], :width => 200, :height => 150) do
+  bounding_box([300, y_position], width: 200, height: 150) do
     transparent(0.5) { stroke_bounds }  # This will stroke on one page
 
     text "Now look what happens when the free flowing text reaches the end " +
@@ -41,7 +41,7 @@ Prawn::ManualBuilder::Example.generate(filename) do
   end
 
   move_cursor_to 200
-  span(350, :position => :center) do
+  span(350, position: :center) do
     text "Span is a different kind of bounding box as it lets the text " +
          "flow gracefully onto the next page. It doesn't matter if the text " +
          "started on the middle of the previous page, when it flows to the " +

--- a/manual/text/inline.rb
+++ b/manual/text/inline.rb
@@ -19,23 +19,23 @@ Prawn::ManualBuilder::Example.generate(filename) do
   %w[b i u strikethrough sub sup].each do |tag|
     text "Just your regular text <#{tag}>except this portion</#{tag}> " +
          "is using the #{tag} tag",
-         :inline_format => true
+         inline_format: true
     move_down 10
   end
 
   text "This <font size='18'>line</font> uses " +
        "<font name='Courier'>all the font tag</font> attributes in " +
        "<font character_spacing='2'>a single line</font>. ",
-       :inline_format => true
+       inline_format: true
   move_down 10
 
   text "Coloring in <color rgb='FF00FF'>both RGB</color> " +
        "<color c='100' m='0' y='0' k='0'>and CMYK</color>",
-       :inline_format => true
+       inline_format: true
   move_down 10
 
   text "This an external link to the " +
        "<u><link href='https://github.com/prawnpdf/prawn/wiki'>Prawn wiki" +
        "</link></u>",
-       :inline_format => true
+       inline_format: true
 end

--- a/manual/text/kerning_and_character_spacing.rb
+++ b/manual/text/kerning_and_character_spacing.rb
@@ -15,17 +15,17 @@ require File.expand_path(File.join(File.dirname(__FILE__),
 filename = File.basename(__FILE__).gsub('.rb', '.pdf')
 Prawn::ManualBuilder::Example.generate(filename) do
   font_size(30) do
-    text_box "With kerning:",    :kerning => true,  :at => [0, y - 40]
-    text_box "Without kerning:", :kerning => false, :at => [0, y - 80]
+    text_box "With kerning:",    kerning: true,  at: [0, y - 40]
+    text_box "Without kerning:", kerning: false, at: [0, y - 80]
 
-    text_box "Tomato", :kerning => true,  :at => [250, y - 40]
-    text_box "Tomato", :kerning => false, :at => [250, y - 80]
+    text_box "Tomato", kerning: true,  at: [250, y - 40]
+    text_box "Tomato", kerning: false, at: [250, y - 80]
 
-    text_box "WAR", :kerning => true,  :at => [400, y - 40]
-    text_box "WAR", :kerning => false, :at => [400, y - 80]
+    text_box "WAR", kerning: true,  at: [400, y - 40]
+    text_box "WAR", kerning: false, at: [400, y - 80]
 
-    text_box "F.", :kerning => true,  :at => [500, y - 40]
-    text_box "F.", :kerning => false, :at => [500, y - 80]
+    text_box "F.", kerning: true,  at: [500, y - 40]
+    text_box "F.", kerning: false, at: [500, y - 80]
   end
 
   move_down 80
@@ -34,6 +34,6 @@ Prawn::ManualBuilder::Example.generate(filename) do
   [-2, -1, 0, 0.5, 1, 2].each do |spacing|
     move_down 20
     text "#{string} (character_spacing: #{spacing})",
-         :character_spacing => spacing
+         character_spacing: spacing
   end
 end

--- a/manual/text/leading.rb
+++ b/manual/text/leading.rb
@@ -14,12 +14,12 @@ require File.expand_path(File.join(File.dirname(__FILE__),
 filename = File.basename(__FILE__).gsub('.rb', '.pdf')
 Prawn::ManualBuilder::Example.generate(filename) do
   string = "Hey, what did you do with the space between my lines? " * 10
-  text string, :leading => 0
+  text string, leading: 0
 
   move_down 20
   default_leading 5
   text string
 
   move_down 20
-  text string, :leading => 10
+  text string, leading: 10
 end

--- a/manual/text/line_wrapping.rb
+++ b/manual/text/line_wrapping.rb
@@ -29,7 +29,7 @@ Prawn::ManualBuilder::Example.generate(filename) do
        "nearer your destination the more you're slip#{nbsp}sliding away."
   move_down 20
 
-  font("#{Prawn::DATADIR}/fonts/gkai00mp.ttf", :size => 16) do
+  font("#{Prawn::DATADIR}/fonts/gkai00mp.ttf", size: 16) do
     long_text = "No word boundaries:\n更可怕的是，同质化竞争对手可以按照URL中后面这个ID来遍历您的DB中的内容，写个小爬虫把你的页面上的关键信息顺次爬下来也不是什么难事，这样的话，你就非常被动了。更可怕的是，同质化竞争对手可以按照URL中后面这个ID来遍历您的DB中的内容，写个小爬虫把你的页面上的关键信息顺次爬下来也不是什么难事，这样的话，你就非常被动了。"
     text long_text
     move_down 20

--- a/manual/text/paragraph_indentation.rb
+++ b/manual/text/paragraph_indentation.rb
@@ -22,12 +22,12 @@ Prawn::ManualBuilder::Example.generate(filename) do
   move_down 20
   text "This paragraph will be indented. " * 10 +
        "\n" + "This one will too. " * 10,
-       :indent_paragraphs => 60
+       indent_paragraphs: 60
 
   move_down 20
 
   text "FROM RIGHT TO LEFT:"
   text "This paragraph will be indented. " * 10 +
        "\n" + "This one will too. " * 10,
-       :indent_paragraphs => 60, :direction => :rtl
+       indent_paragraphs: 60, direction: :rtl
 end

--- a/manual/text/positioned_text.rb
+++ b/manual/text/positioned_text.rb
@@ -24,15 +24,15 @@ filename = File.basename(__FILE__).gsub('.rb', '.pdf')
 Prawn::ManualBuilder::Example.generate(filename) do
   draw_text "This draw_text line is absolute positioned. However don't " +
             "expect it to flow even if it hits the document border",
-            :at => [200, 300]
+            at: [200, 300]
 
   text_box "This is a text box, you can control where it will flow by " +
            "specifying the :height and :width options",
-           :at => [100, 250],
-           :height => 100,
-           :width => 100
+           at: [100, 250],
+           height: 100,
+           width: 100
 
   text_box "Another text box with no :width option passed, so it will " +
            "flow to a new line whenever it reaches the right margin. ",
-           :at => [200, 100]
+           at: [200, 100]
 end

--- a/manual/text/registering_families.rb
+++ b/manual/text/registering_families.rb
@@ -16,7 +16,7 @@ Prawn::ManualBuilder::Example.generate(filename) do
   # Registering a single TTF font
   font_families.update(
     "DejaVu Sans" => {
-      :normal => "#{Prawn::DATADIR}/fonts/DejaVuSans.ttf"
+      normal: "#{Prawn::DATADIR}/fonts/DejaVuSans.ttf"
     }
   )
 
@@ -29,10 +29,10 @@ Prawn::ManualBuilder::Example.generate(filename) do
   font_path = "#{Prawn::DATADIR}/fonts/Panic+Sans.dfont"
   font_families.update(
     "Panic Sans" => {
-      :normal      => { :file => font_path, :font => "PanicSans" },
-      :italic      => { :file => font_path, :font => "PanicSans-Italic" },
-      :bold        => { :file => font_path, :font => "PanicSans-Bold" },
-      :bold_italic => { :file => font_path, :font => "PanicSans-BoldItalic" }
+      :normal      => { file: font_path, font: "PanicSans" },
+      :italic      => { file: font_path, font: "PanicSans-Italic" },
+      :bold        => { file: font_path, font: "PanicSans-Bold" },
+      bold_italic: { file: font_path, font: "PanicSans-BoldItalic" }
     }
   )
 
@@ -41,12 +41,12 @@ Prawn::ManualBuilder::Example.generate(filename) do
   move_down 20
 
   text "Taking <b>advantage</b> of the <i>inline formatting</i>",
-       :inline_format => true
+       inline_format: true
   move_down 20
 
   [:bold, :bold_italic, :italic, :normal].each do |style|
     text "Using the #{style} style option.",
-         :style => style
+         style: style
     move_down 10
   end
 end

--- a/manual/text/registering_families.rb
+++ b/manual/text/registering_families.rb
@@ -29,9 +29,9 @@ Prawn::ManualBuilder::Example.generate(filename) do
   font_path = "#{Prawn::DATADIR}/fonts/Panic+Sans.dfont"
   font_families.update(
     "Panic Sans" => {
-      :normal      => { file: font_path, font: "PanicSans" },
-      :italic      => { file: font_path, font: "PanicSans-Italic" },
-      :bold        => { file: font_path, font: "PanicSans-Bold" },
+      normal:      { file: font_path, font: "PanicSans" },
+      italic:      { file: font_path, font: "PanicSans-Italic" },
+      bold:        { file: font_path, font: "PanicSans-Bold" },
       bold_italic: { file: font_path, font: "PanicSans-BoldItalic" }
     }
   )

--- a/manual/text/rendering_and_color.rb
+++ b/manual/text/rendering_and_color.rb
@@ -26,7 +26,7 @@ Prawn::ManualBuilder::Example.generate(filename) do
     move_down 20
 
     # inline rendering mode: stroke
-    text "This text is stroked with blue", :mode => :stroke
+    text "This text is stroked with blue", mode: :stroke
     move_down 20
 
     # block rendering mode: fill and stroke

--- a/manual/text/right_to_left_text.rb
+++ b/manual/text/right_to_left_text.rb
@@ -21,27 +21,27 @@ Prawn::ManualBuilder::Example.generate(filename) do
   # set the direction document-wide
   self.text_direction = :rtl
 
-  font("#{Prawn::DATADIR}/fonts/gkai00mp.ttf", :size => 16) do
+  font("#{Prawn::DATADIR}/fonts/gkai00mp.ttf", size: 16) do
     long_text = "写个小爬虫把你的页面上的关键信息顺次爬下来也不是什么难事写个小爬虫把你的页面上的关键信息顺次爬下来也不是什么难事写个小爬虫把你的页面上的关键信息顺次爬下来也不是什么难事写个小"
     text long_text
     move_down 20
 
-    text "You can override the document direction.", :direction => :ltr
+    text "You can override the document direction.", direction: :ltr
     move_down 20
 
-    formatted_text [{ :text => "更可怕的是，同质化竞争对手可以按照" },
-                    { :text => "URL", :direction => :ltr },
-                    { :text => "中后面这个" },
-                    { :text => "ID",  :direction => :ltr },
-                    { :text => "来遍历您的" },
-                    { :text => "DB",  :direction => :ltr },
-                    { :text => "中的内容，写个小爬虫把你的页面上的关键信息顺次爬下来也不是什么难事，这样的话，你就非常被动了。" }]
+    formatted_text [{ text: "更可怕的是，同质化竞争对手可以按照" },
+                    { text: "URL", direction: :ltr },
+                    { text: "中后面这个" },
+                    { text: "ID",  direction: :ltr },
+                    { text: "来遍历您的" },
+                    { text: "DB",  direction: :ltr },
+                    { text: "中的内容，写个小爬虫把你的页面上的关键信息顺次爬下来也不是什么难事，这样的话，你就非常被动了。" }]
     move_down 20
 
-    formatted_text [{ :text => "更可怕的是，同质化竞争对手可以按照" },
-                    { :text => "this",  :direction => :ltr },
-                    { :text => "won't", :direction => :ltr, :size => 24 },
-                    { :text => "work",  :direction => :ltr },
-                    { :text => "中的内容，写个小爬虫把你的页面上的关键信息顺次爬下来也不是什么难事" }]
+    formatted_text [{ text: "更可怕的是，同质化竞争对手可以按照" },
+                    { text: "this",  direction: :ltr },
+                    { text: "won't", direction: :ltr, size: 24 },
+                    { text: "work",  direction: :ltr },
+                    { text: "中的内容，写个小爬虫把你的页面上的关键信息顺次爬下来也不是什么难事" }]
   end
 end

--- a/manual/text/rotation.rb
+++ b/manual/text/rotation.rb
@@ -25,18 +25,21 @@ Prawn::ManualBuilder::Example.generate(filename) do
 
   stroke_rectangle [0, y - 100], width, height
   text_box("This text was rotated around the center",
-           at: [0, y - 100], width: width, height: height,
-           rotate: angle, rotate_around: :center)
+           at:            [0, y - 100],
+           width:         width,
+           height:        height,
+           rotate:        angle,
+           rotate_around: :center)
 
   [:lower_left, :upper_left,
    :lower_right, :upper_right].each_with_index do |corner, index|
     y = y - 100 if index == 2
     stroke_rectangle [x + (index % 2) * 200, y], width, height
     text_box("This text was rotated around the #{corner} corner.",
-             :at     => [x + (index % 2) * 200, y],
-             :width  => width,
-             height: height,
-             rotate: angle,
+             at:            [x + (index % 2) * 200, y],
+             width:         width,
+             height:        height,
+             rotate:        angle,
              rotate_around: corner)
   end
 end

--- a/manual/text/rotation.rb
+++ b/manual/text/rotation.rb
@@ -21,12 +21,12 @@ Prawn::ManualBuilder::Example.generate(filename) do
 
   stroke_rectangle [0, y], width, height
   text_box("This text was not rotated",
-           :at => [0, y], :width => width, :height => height)
+           at: [0, y], width: width, height: height)
 
   stroke_rectangle [0, y - 100], width, height
   text_box("This text was rotated around the center",
-           :at => [0, y - 100], :width => width, :height => height,
-           :rotate => angle, :rotate_around => :center)
+           at: [0, y - 100], width: width, height: height,
+           rotate: angle, rotate_around: :center)
 
   [:lower_left, :upper_left,
    :lower_right, :upper_right].each_with_index do |corner, index|
@@ -35,8 +35,8 @@ Prawn::ManualBuilder::Example.generate(filename) do
     text_box("This text was rotated around the #{corner} corner.",
              :at     => [x + (index % 2) * 200, y],
              :width  => width,
-             :height => height,
-             :rotate => angle,
-             :rotate_around => corner)
+             height: height,
+             rotate: angle,
+             rotate_around: corner)
   end
 end

--- a/manual/text/text.rb
+++ b/manual/text/text.rb
@@ -5,7 +5,7 @@
 require File.expand_path(File.join(File.dirname(__FILE__),
                                    %w[.. example_helper]))
 
-Prawn::ManualBuilder::Example.generate("text.pdf", :page_size => "FOLIO") do
+Prawn::ManualBuilder::Example.generate("text.pdf", page_size: "FOLIO") do
   package "text" do |p|
     p.section "Basics" do |s|
       s.example "free_flowing_text"

--- a/manual/text/text_box_excess.rb
+++ b/manual/text/text_box_excess.rb
@@ -20,11 +20,11 @@ Prawn::ManualBuilder::Example.generate(filename) do
 
   y_position  = cursor - 20
   excess_text = text_box string,
-                width:    300,
-                height:   50,
-                overflow: :truncate,
-                at:       [100, y_position],
-                size:     18
+                         width:    300,
+                         height:   50,
+                         overflow: :truncate,
+                         at:       [100, y_position],
+                         size:     18
 
   text_box excess_text,
            width: 300,

--- a/manual/text/text_box_excess.rb
+++ b/manual/text/text_box_excess.rb
@@ -22,7 +22,7 @@ Prawn::ManualBuilder::Example.generate(filename) do
   excess_text = text_box string,
                          :width    => 300,
                          :height   => 50,
-                         :overflow => :truncate,
+                         overflow: :truncate,
                          :at       => [100, y_position],
                          :size     => 18
 

--- a/manual/text/text_box_excess.rb
+++ b/manual/text/text_box_excess.rb
@@ -18,15 +18,15 @@ Prawn::ManualBuilder::Example.generate(filename) do
            "the rest of the text will procede to be rendered this time by " +
            "calling another method." + " . " * 50
 
-  y_position = cursor - 20
+  y_position  = cursor - 20
   excess_text = text_box string,
-                         :width    => 300,
-                         :height   => 50,
-                         overflow: :truncate,
-                         :at       => [100, y_position],
-                         :size     => 18
+                width:    300,
+                height:   50,
+                overflow: :truncate,
+                at:       [100, y_position],
+                size:     18
 
   text_box excess_text,
-           :width    => 300,
-           :at       => [100, y_position - 100]
+           width: 300,
+           at:    [100, y_position - 100]
 end

--- a/manual/text/text_box_extensions.rb
+++ b/manual/text/text_box_extensions.rb
@@ -28,16 +28,16 @@ Prawn::ManualBuilder::Example.generate(filename) do
   Prawn::Text::Box.extensions << TriangleBox
   stroke_rectangle([0, y_position], width, height)
   text_box("A" * 100,
-           :at => [0, y_position],
-           :width => width,
-           :height => height)
+           at: [0, y_position],
+           width: width,
+           height: height)
 
   Prawn::Text::Formatted::Box.extensions << TriangleBox
   stroke_rectangle([200, y_position], width, height)
-  formatted_text_box([:text => "A" * 100, :color => "009900"],
-                     :at => [200, y_position],
-                     :width => width,
-                     :height => height)
+  formatted_text_box([text: "A" * 100, color: "009900"],
+                     at: [200, y_position],
+                     width: width,
+                     height: height)
 
   # Here we clear the extensions array
   Prawn::Text::Box.extensions.clear

--- a/manual/text/text_box_overflow.rb
+++ b/manual/text/text_box_overflow.rb
@@ -28,10 +28,10 @@ Prawn::ManualBuilder::Example.generate(filename) do
 
   y_position = cursor - 20
   [:truncate, :expand, :shrink_to_fit].each_with_index do |mode, i|
-    text_box string, :at => [i * 150, y_position],
-                     :width => 100,
-                     :height => 50,
-                     :overflow => mode
+    text_box string, at: [i * 150, y_position],
+                     width: 100,
+                     height: 50,
+                     overflow: mode
   end
 
   string = "If the box is too small for the text, :shrink_to_fit " +
@@ -41,10 +41,10 @@ Prawn::ManualBuilder::Example.generate(filename) do
   text string
   y_position = cursor - 20
   [nil, 8, 10, 12].each_with_index do |value, index|
-    text_box string, :at => [index * 150, y_position],
-                     :width => 50,
-                     :height => 50,
-                     :overflow => :shrink_to_fit,
-                     :min_font_size => value
+    text_box string, at: [index * 150, y_position],
+                     width: 50,
+                     height: 50,
+                     overflow: :shrink_to_fit,
+                     min_font_size: value
   end
 end

--- a/manual/text/utf8.rb
+++ b/manual/text/utf8.rb
@@ -10,7 +10,7 @@ require File.expand_path(File.join(File.dirname(__FILE__),
 filename = File.basename(__FILE__).gsub('.rb', '.pdf')
 Prawn::ManualBuilder::Example.generate(filename) do
   text "Take this example, a simple Euro sign:"
-  text "€", :size => 32
+  text "€", size: 32
   move_down 20
 
   text "This works, because €  is one of the few " +

--- a/manual/text/win_ansi_charset.rb
+++ b/manual/text/win_ansi_charset.rb
@@ -17,10 +17,10 @@ Prawn::ManualBuilder::Example.generate(filename) do
   fields = [[20, :right], [8, :left], [12, :center], [30, :right], [8, :left],
             [0, :left]]
 
-  font "Helvetica", :size => FONT_SIZE
+  font "Helvetica", size: FONT_SIZE
 
   move_down 30
-  text "(See next page for WinAnsi table)", :align => :center
+  text "(See next page for WinAnsi table)", align: :center
   start_new_page
 
   Prawn::Encoding::WinAnsi::CHARACTERS.each_with_index do |name, index|
@@ -35,14 +35,14 @@ Prawn::ManualBuilder::Example.generate(filename) do
     code = "%d." % index
     char = index.chr
 
-    width = 1000 * width_of(char, :size => FONT_SIZE) / FONT_SIZE
+    width = 1000 * width_of(char, size: FONT_SIZE) / FONT_SIZE
     size  = "%d" % width
 
     data = [code, nil, char, size, nil, name]
     dx   = x
     fields.zip(data).each do |(total_width, align), field|
       if field
-        width = width_of(field, :size => FONT_SIZE)
+        width = width_of(field, size: FONT_SIZE)
 
         case align
         when :left   then offset = 0
@@ -51,7 +51,7 @@ Prawn::ManualBuilder::Example.generate(filename) do
         end
 
         text_box(field.force_encoding("windows-1252").encode("UTF-8"),
-                 :at => [dx + offset, y])
+                 at: [dx + offset, y])
       end
 
       dx += total_width

--- a/prawn.gemspec
+++ b/prawn.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.licenses = ['RUBY', 'GPL-2', 'GPL-3']
 
   spec.add_dependency('ttfunk', '~> 1.4.0')
-  spec.add_dependency('pdf-core', "~> 0.5.1")
+  spec.add_dependency('pdf-core', "~> 0.6.0")
 
   spec.add_development_dependency('pdf-inspector', '~> 1.2.0')
   spec.add_development_dependency('yard')


### PR DESCRIPTION
The patch replaces the old hash syntax (:symbol => value) with the new syntax (symbol: value) being implementented with ruby 1.9.2 in the manual.
