### PR TITLE
Use RSpec3 syntax for true/false

### DIFF
--- a/spec/document_spec.rb
+++ b/spec/document_spec.rb
@@ -77,14 +77,14 @@ describe "when generating a document from a subclass" do
     Prawn::Document.extensions.delete(mod1)
     Prawn::Document.extensions.delete(mod2)
 
-    expect(Prawn::Document.new.respond_to?(:test_extensions1)).to be_false
-    expect(Prawn::Document.new.respond_to?(:test_extensions2)).to be_false
+    expect(Prawn::Document.new.respond_to?(:test_extensions1)).to be_falsey
+    expect(Prawn::Document.new.respond_to?(:test_extensions2)).to be_falsey
 
     # verify these still exist on custom class
     expect(custom_document.extensions).to eq([mod1, mod2])
 
-    expect(custom_document.new.respond_to?(:test_extensions1)).to be_true
-    expect(custom_document.new.respond_to?(:test_extensions2)).to be_true
+    expect(custom_document.new.respond_to?(:test_extensions1)).to be_truthy
+    expect(custom_document.new.respond_to?(:test_extensions2)).to be_truthy
   end
 end
 
@@ -176,7 +176,7 @@ describe "on_page_create callback" do
   end
 
   it "should be delegated from Document to renderer" do
-    expect(@pdf.respond_to?(:on_page_create)).to be_true
+    expect(@pdf.respond_to?(:on_page_create)).to be_truthy
   end
 
   it "should be invoked with document" do
@@ -712,17 +712,17 @@ describe "The page_match? method" do
   end
 
   it "returns nil given no filter" do
-    expect(@pdf.page_match?(:nil, 1)).to be_false
+    expect(@pdf.page_match?(:nil, 1)).to be_falsey
   end
 
   it "must provide an :all filter" do
-    expect((1..@pdf.page_count).all? { |i| @pdf.page_match?(:all, i) }).to be_true
+    expect((1..@pdf.page_count).all? { |i| @pdf.page_match?(:all, i) }).to be_truthy
   end
 
   it "must provide an :odd filter" do
     odd, even = (1..@pdf.page_count).partition(&:odd?)
-    expect(odd.all? { |i| @pdf.page_match?(:odd, i) }).to be_true
-    expect(even.any? { |i| @pdf.page_match?(:odd, i) }).to be_false
+    expect(odd.all? { |i| @pdf.page_match?(:odd, i) }).to be_truthy
+    expect(even.any? { |i| @pdf.page_match?(:odd, i) }).to be_falsey
   end
 
   it "must be able to filter by an array of page numbers" do

--- a/spec/font_spec.rb
+++ b/spec/font_spec.rb
@@ -265,11 +265,11 @@ describe "Document#page_fonts" do
   end
 
   def page_should_include_font(font)
-    expect(page_includes_font?(font)).to be_true
+    expect(page_includes_font?(font)).to be_truthy
   end
 
   def page_should_not_include_font(font)
-    expect(page_includes_font?(font)).to be_false
+    expect(page_includes_font?(font)).to be_falsey
   end
 end
 
@@ -313,13 +313,13 @@ describe "AFM fonts" do
     it "should not modify the original string when normalize_encoding() is used" do
       original = "Foo"
       normalized = @times.normalize_encoding(original)
-      expect(original.equal?(normalized)).to be_false
+      expect(original.equal?(normalized)).to be_falsey
     end
 
     it "should modify the original string when normalize_encoding!() is used" do
       original = "Foo"
       normalized = @times.normalize_encoding!(original)
-      expect(original.equal?(normalized)).to be_true
+      expect(original.equal?(normalized)).to be_truthy
     end
   end
 
@@ -335,25 +335,25 @@ describe "#glyph_present" do
 
   it "should return true when present in an AFM font" do
     font = @pdf.find_font("Helvetica")
-    expect(font.glyph_present?("H")).to be_true
+    expect(font.glyph_present?("H")).to be_truthy
   end
 
   it "should return false when absent in an AFM font" do
     font = @pdf.find_font("Helvetica")
-    expect(font.glyph_present?("再")).to be_false
+    expect(font.glyph_present?("再")).to be_falsey
   end
 
   it "should return true when present in a TTF font" do
     font = @pdf.find_font("#{Prawn::DATADIR}/fonts/DejaVuSans.ttf")
-    expect(font.glyph_present?("H")).to be_true
+    expect(font.glyph_present?("H")).to be_truthy
   end
 
   it "should return false when absent in a TTF font" do
     font = @pdf.find_font("#{Prawn::DATADIR}/fonts/DejaVuSans.ttf")
-    expect(font.glyph_present?("再")).to be_false
+    expect(font.glyph_present?("再")).to be_falsey
 
     font = @pdf.find_font("#{Prawn::DATADIR}/fonts/gkai00mp.ttf")
-    expect(font.glyph_present?("€")).to be_false
+    expect(font.glyph_present?("€")).to be_falsey
   end
 end
 
@@ -410,13 +410,13 @@ describe "TTF fonts" do
     it "should not modify the original string when normalize_encoding() is used" do
       original = "Foo"
       normalized = @font.normalize_encoding(original)
-      expect(original.equal?(normalized)).to be_false
+      expect(original.equal?(normalized)).to be_falsey
     end
 
     it "should modify the original string when normalize_encoding!() is used" do
       original = "Foo"
       normalized = @font.normalize_encoding!(original)
-      expect(original.equal?(normalized)).to be_true
+      expect(original.equal?(normalized)).to be_truthy
     end
   end
 end

--- a/spec/graphics_spec.rb
+++ b/spec/graphics_spec.rb
@@ -280,10 +280,10 @@ describe "Patterns" do
       expect(pattern[:Shading][:Coords]).to eq([0, 0, @pdf.bounds.width, 0])
       expect(pattern[:Shading][:Function][:C0].zip([1, 0, 0]).all?{ |x1, x2|
         (x1 - x2).abs < 0.01
-      }).to be_true
+      }).to be_truthy
       expect(pattern[:Shading][:Function][:C1].zip([0, 0, 1]).all?{ |x1, x2|
         (x1 - x2).abs < 0.01
-      }).to be_true
+      }).to be_truthy
     end
 
     it "fill_gradient should set fill color to the pattern" do
@@ -319,10 +319,10 @@ describe "Patterns" do
       expect(pattern[:Shading][:Coords]).to eq([0, 0, 10, @pdf.bounds.width, 0, 20])
       expect(pattern[:Shading][:Function][:C0].zip([1, 0, 0]).all?{ |x1, x2|
         (x1 - x2).abs < 0.01
-      }).to be_true
+      }).to be_truthy
       expect(pattern[:Shading][:Function][:C1].zip([0, 0, 1]).all?{ |x1, x2|
         (x1 - x2).abs < 0.01
-      }).to be_true
+      }).to be_truthy
     end
 
     it "fill_gradient should set fill color to the pattern" do

--- a/spec/repeater_spec.rb
+++ b/spec/repeater_spec.rb
@@ -18,7 +18,7 @@ describe "Repeaters" do
     doc = sample_document
     r = repeater(doc, :all) { :do_nothing }
 
-    expect((1..doc.page_count).all? { |i| r.match?(i) }).to be_true
+    expect((1..doc.page_count).all? { |i| r.match?(i) }).to be_truthy
   end
 
   it "must provide an :odd filter" do
@@ -27,8 +27,8 @@ describe "Repeaters" do
 
     odd, even = (1..doc.page_count).partition(&:odd?)
 
-    expect(odd.all? { |i| r.match?(i) }).to be_true
-    expect(even.any? { |i| r.match?(i) }).to be_false
+    expect(odd.all? { |i| r.match?(i) }).to be_truthy
+    expect(even.any? { |i| r.match?(i) }).to be_falsey
   end
 
   it "must be able to filter by an array of page numbers" do

--- a/spec/text_at_spec.rb
+++ b/spec/text_at_spec.rb
@@ -58,7 +58,7 @@ describe "#draw_text" do
 
     text = rotated_text_inspector.analyze(@pdf.render)
 
-    expect(text.tm_operator_used).to(be_true)
+    expect(text.tm_operator_used).to(be_truthy)
   end
 
   it "should not use rotation matrix by default" do
@@ -66,7 +66,7 @@ describe "#draw_text" do
 
     text = rotated_text_inspector.analyze(@pdf.render)
 
-    expect(text.tm_operator_used).to(be_false)
+    expect(text.tm_operator_used).to(be_falsey)
   end
 
   it "should allow overriding default font for a single instance" do

--- a/spec/text_box_spec.rb
+++ b/spec/text_box_spec.rb
@@ -3,43 +3,43 @@
 require File.join(File.expand_path(File.dirname(__FILE__)), "spec_helper")
 
 describe "Text::Box#nothing_printed?" do
-  it "should be_true when nothing printed" do
+  it "should be_truthy when nothing printed" do
     create_pdf
     string = "Hello world, how are you?\nI'm fine, thank you."
     text_box = Prawn::Text::Box.new(string,
                                     :height => 2,
                                     :document => @pdf)
     text_box.render
-    expect(text_box.nothing_printed?).to be_true
+    expect(text_box.nothing_printed?).to be_truthy
   end
-  it "should be_false when something printed" do
+  it "should be_falsey when something printed" do
     create_pdf
     string = "Hello world, how are you?\nI'm fine, thank you."
     text_box = Prawn::Text::Box.new(string,
                                     :height => 14,
                                     :document => @pdf)
     text_box.render
-    expect(text_box.nothing_printed?).to be_false
+    expect(text_box.nothing_printed?).to be_falsey
   end
 end
 
 describe "Text::Box#everything_printed?" do
-  it "should be_false when not everything printed" do
+  it "should be_falsey when not everything printed" do
     create_pdf
     string = "Hello world, how are you?\nI'm fine, thank you."
     text_box = Prawn::Text::Box.new(string,
                                     :height => 14,
                                     :document => @pdf)
     text_box.render
-    expect(text_box.everything_printed?).to be_false
+    expect(text_box.everything_printed?).to be_falsey
   end
-  it "should be_true when everything printed" do
+  it "should be_truthy when everything printed" do
     create_pdf
     string = "Hello world, how are you?\nI'm fine, thank you."
     text_box = Prawn::Text::Box.new(string,
                                     :document => @pdf)
     text_box.render
-    expect(text_box.everything_printed?).to be_true
+    expect(text_box.everything_printed?).to be_truthy
   end
 end
 

--- a/spec/text_spec.rb
+++ b/spec/text_spec.rb
@@ -63,7 +63,7 @@ describe "#text" do
   end
 
   it "should ignore call when string is nil" do
-    expect(@pdf.text(nil)).to be_false
+    expect(@pdf.text(nil)).to be_falsey
   end
 
   it "should correctly render empty paragraphs" do
@@ -91,13 +91,13 @@ describe "#text" do
   it "should default to use kerning information" do
     @pdf.text "hello world"
     text = PDF::Inspector::Text.analyze(@pdf.render)
-    expect(text.kerned[0]).to be_true
+    expect(text.kerned[0]).to be_truthy
   end
 
   it "should be able to disable kerning with an option" do
     @pdf.text "hello world", :kerning => false
     text = PDF::Inspector::Text.analyze(@pdf.render)
-    expect(text.kerned[0]).to be_false
+    expect(text.kerned[0]).to be_falsey
   end
 
   it "should be able to disable kerning document-wide" do
@@ -105,14 +105,14 @@ describe "#text" do
     @pdf.default_kerning = false
     @pdf.text "hello world"
     text = PDF::Inspector::Text.analyze(@pdf.render)
-    expect(text.kerned[0]).to be_false
+    expect(text.kerned[0]).to be_falsey
   end
 
   it "option should be able to override document-wide kerning disabling" do
     @pdf.default_kerning = false
     @pdf.text "hello world", :kerning => true
     text = PDF::Inspector::Text.analyze(@pdf.render)
-    expect(text.kerned[0]).to be_true
+    expect(text.kerned[0]).to be_truthy
   end
 
   it "should raise_error ArgumentError if :at option included" do


### PR DESCRIPTION
In RSpec, 'be_true' and 'be_false' have been renamed to 'be_truthy' and 'be_falsey' two years ago. This naming scheme has been enforced in RSpec3. The following patch enforces this convention:

- replace 'be_true' by 'be_truthy'
- replace 'be_false' by 'be_falsey'