### PR TITLE
Gradients can have multiple stops to blend more than two colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,22 @@ Fix a few issues with code style that were triggering warnings in IRB when run i
 
 (Jesse Doyle, [#914](https://github.com/prawnpdf/prawn/pull/914))
 
+### Gradients can have multiple stops to blend more than two colors
+
+Previously, only two colors could be specified in a gradient: the start
+and end colors.  This change allows any number of colors to be specified,
+along with the position between 0 and 1 as to where they should be displayed.
+
+This change also comes with a change to the format of the `fill_gradient`
+and `stroke_gradient` methods.  You can continue to use the old method
+parameters and only specify two colors, or use the new keyword arguments
+to specify arbitrary stops.
+
+As a bonus, if you use the new method style, `apply_transformations` is
+set true automatically (see below).
+
+(Roger Nesbitt)
+
 ### Gradients applied inside transformations are now correctly positioned
 
 PDF gradients/patterns take coordinates in the coordinate space of the

--- a/lib/prawn/graphics/patterns.rb
+++ b/lib/prawn/graphics/patterns.rb
@@ -10,52 +10,75 @@
 module Prawn
   module Graphics
     module Patterns
+      GradientStop = Struct.new(:position, :color)
+      Gradient = Struct.new(:type, :apply_transformations, :stops, :from, :to, :r1, :r2)
+
       # @group Stable API
 
-      # Sets the fill gradient from color1 to color2.
-      # old arguments: point, width, height, color1, color2, options = {}
-      # new arguments: from, to, color1, color1, options = {}
-      #            or  from, r1, to, r2, color1, color2, options = {}
+      # Sets the fill gradient.
+      # old arguments: from, to, color1, color2
+      #            or  from, r1, to, r2, color1, color2
+      # new arguments:
+      #      from: [x, y]
+      #      to: [x, y]
+      #      r1: radius
+      #      r2: radius
+      #      stops: [[position, color], ...]
+      #      apply_transformations: true
       #
-      # Option :apply_transformations, if set true, will transform the
+      # Examples:
+      #     # draws a horizontal axial gradient that starts at red on the left and ends at blue on the right
+      #     fill_gradient from: [0, 0], to: [100, 0], stops: ['red', 'blue']
+      #
+      #     # draws a horizontal radial gradient that starts at red, is green 80% of the way through, and finishes blue
+      #     fill_gradient from: [0, 0], r1: 0, to: [100, 0], r2: 180, stops: [[0, 'red'], [0.8, 'green'], [1, 'blue']]
+      #
+      # <tt>from</tt> and <tt>to</tt> specify the axis of where the gradient
+      # should be painted.
+      #
+      # <tt>r1</tt> and <tt>r2</tt>, if specified, make a radial gradient with
+      # the starting circle of radius <tt>r1</tt> centered at <tt>from</tt>
+      # and ending at a circle of radius <tt>r2</tt> centered at <tt>to</tt>.
+      # If <tt>r1</tt> is not specified, a axial gradient will be drawn.
+      #
+      # <tt>stops</tt> is an array of stops.  Each stop is either just a
+      # string indicating the color, in which case the stops will be evenly
+      # distributed across the gradient, or an array with two elements:
+      # a position between 0 and 1 indicating what distance through the
+      # gradient the color should change, and the color string.
+      #
+      # Option <tt>apply_transformations</tt>, if set true, will transform the
       # gradient's co-ordinate space so it matches the current co-ordinate
-      # space of the document.  This option will be the default from Prawn v3.
-      # The current default, false, will mean if you (for example) scale your
-      # document by 2 and put a gradient inside, you will have to manually
-      # multiply your co-ordinates by 2 so the gradient is correctly positioned.
-      def fill_gradient(*args)
-        set_gradient(:fill, *args)
+      # space of the document.  This option will be the default from Prawn v3,
+      # and is default true if you use the new arguments format.
+      # The default for the old arguments format, false, will mean if you
+      # (for example) scale your document by 2 and put a gradient inside, you
+      # will have to manually multiply your co-ordinates by 2 so the gradient
+      # is correctly positioned.
+      def fill_gradient(*args, **kwargs)
+        set_gradient(:fill, *args, **kwargs)
       end
 
-      # Sets the stroke gradient from color1 to color2.
-      # old arguments: point, width, height, color1, color2, options = {}
-      # new arguments: from, to, color1, color2, options = {}
-      #            or  from, r1, to, r2, color1, color2, options = {}
-      #
-      # Option :apply_transformations, if set true, will transform the
-      # gradient's co-ordinate space so it matches the current co-ordinate
-      # space of the document.  This option will be the default from Prawn v3.
-      # The current default, false, will mean if you (for example) scale your
-      # document by 2 and put a gradient inside, you will have to manually
-      # multiply your co-ordinates by 2 so the gradient is correctly positioned.
-      def stroke_gradient(*args)
-        set_gradient(:stroke, *args)
+      # Sets the stroke gradient.
+      # See fill_gradient for a description of the arguments to this method.
+      def stroke_gradient(*args, **kwargs)
+        set_gradient(:stroke, *args, **kwargs)
       end
 
       private
 
-      def set_gradient(type, *grad)
-        opts = grad.last.is_a?(Hash) ? grad.pop : {}
+      def set_gradient(type, *grad, **kwargs)
+        gradient = parse_gradient_arguments(*grad, **kwargs)
 
         patterns = page.resources[:Pattern] ||= {}
 
-        registry_key = gradient_registry_key grad, opts
+        registry_key = gradient_registry_key gradient
 
         if patterns["SP#{registry_key}"]
           shading = patterns["SP#{registry_key}"]
         else
           unless shading = gradient_registry[registry_key]
-            shading = gradient(grad, opts)
+            shading = create_gradient_pattern(gradient)
             gradient_registry[registry_key] = shading
           end
 
@@ -75,68 +98,99 @@ module Prawn
         renderer.add_content "/SP#{registry_key} #{operator}"
       end
 
-      def gradient_registry_key(gradient, opts)
-        _x1, _y1, x2, y2, transformation = gradient_coordinates(gradient, opts)
+      def parse_gradient_arguments(*arguments, from: nil, to: nil, r1: nil, r2: nil, stops: nil, apply_transformations: nil)
+        case arguments.length
+        when 0
+          apply_transformations = true if apply_transformations.nil?
+        when 4
+          from, to, *stops = arguments
+        when 6
+          from, r1, to, r2, *stops = arguments
+        else
+          fail ArgumentError, "Unknown type of gradient: #{arguments.inspect}"
+        end
 
-        if gradient[1].is_a?(Array) # axial
-          [
-            transformation,
-            x2, y2,
-            gradient[2], gradient[3]
-          ]
-        else # radial
-          [
-            transformation,
-            x2, y2,
-            gradient[1],
-            gradient[3],
-            gradient[4], gradient[5]
-          ]
-        end.hash
+        fail ArgumentError, "At least two stops must be specified" if stops.length < 2
+
+        stops = stops.map.with_index do |stop, index|
+          case stop
+          when Array
+            position, color = stop
+          else
+            position = index / (stops.length.to_f - 1)
+            color = stop
+          end
+
+          fail ArgumentError, "position must be between 0 and 1" unless (0..1).include?(position)
+          GradientStop.new(position, normalize_color(color))
+        end
+
+        fail ArgumentError, "The first stop must have a position of 0" if stops.first.position != 0
+        fail ArgumentError, "The last stop must have a position of 1" if stops.last.position != 1
+
+        if stops.map { |stop| color_type(stop.color) }.uniq.length > 1
+          fail ArgumentError, "All colors must be of the same color space"
+        end
+
+        Gradient.new(r1 ? :radial : :axial, apply_transformations, stops, from, to, r1, r2)
+      end
+
+      def gradient_registry_key(gradient)
+        x1, y1, x2, y2, transformation = gradient_coordinates(gradient)
+
+        [
+          gradient.type,
+          transformation,
+          x2, y2,
+          gradient.r1, gradient.r2,
+          gradient.stops
+        ].hash
       end
 
       def gradient_registry
         @gradient_registry ||= {}
       end
 
-      def gradient(args, opts)
-        if args.length != 4 && args.length != 6
-          fail ArgumentError, "Unknown type of gradient: #{args.inspect}"
-        end
-
-        if opts[:apply_transformations].nil? && current_transformation_matrix_with_translation(0, 0) != [1, 0, 0, 1, 0, 0]
+      def create_gradient_pattern(gradient)
+        if gradient.apply_transformations.nil? && current_transformation_matrix_with_translation(0, 0) != [1, 0, 0, 1, 0, 0]
           warn "Gradients in Prawn 2.x and lower are not correctly positioned when a transformation has been made to the document.  Pass 'apply_transformations: true' to correctly transform the gradient, or see https://github.com/prawnpdf/prawn/wiki/Gradient-Transformations for more information."
         end
 
-        color1 = normalize_color(args[-2]).dup.freeze
-        color2 = normalize_color(args[-1]).dup.freeze
-
-        if color_type(color1) != color_type(color2)
-          fail ArgumentError, "Both colors must be of the same color space: #{color1.inspect} and #{color2.inspect}"
+        shader_stops = gradient.stops.each_cons(2).map do |first, second|
+          ref!(
+            :FunctionType => 2,
+            :Domain => [0.0, 1.0],
+            :C0 => first.color,
+            :C1 => second.color,
+            :N => 1.0
+          )
         end
 
-        process_color color1
-        process_color color2
+        # If there's only two stops, we can use the single shader.
+        # Otherwise we stitch the multiple shaders together.
+        if shader_stops.length == 1
+          shader = shader_stops.first
+        else
+          shader = ref!(
+            :FunctionType => 3, # stitching function
+            :Domain => [0.0, 1.0],
+            :Functions => shader_stops,
+            :Bounds => gradient.stops[1..-2].map(&:position),
+            :Encode => [0.0, 1.0] * shader_stops.length
+          )
+        end
 
-        shader = ref!(
-          :FunctionType => 2,
-          :Domain => [0.0, 1.0],
-          :C0 => color1,
-          :C1 => color2,
-          :N => 1.0
-        )
+        x1, y1, x2, y2, transformation = gradient_coordinates(gradient)
 
-        x1, y1, x2, y2, transformation = gradient_coordinates(args, opts)
-
-        if args.length == 4
+        if gradient.type == :axial
           coords = [0, 0, x2 - x1, y2 - y1]
         else
-          coords = [0, 0, args[1], x2 - x1, y2 - y1, args[3]]
+          coords = [0, 0, gradient.r1, x2 - x1, y2 - y1, gradient.r2]
         end
 
         shading = ref!(
-          :ShadingType => args.length == 4 ? 2 : 3, # axial : radial shading
-          :ColorSpace => color_space(color1),
+          :ShadingType => gradient.type == :axial ? 2 : 3,
+          :ColorSpace => color_space(gradient.stops.first.color),
           :Coords => coords,
           :Function => shader,
           :Extend => [true, true]
@@ -149,11 +203,11 @@ module Prawn
         )
       end
 
-      def gradient_coordinates(args, opts)
-        x1, y1 = map_to_absolute(args[0])
-        x2, y2 = map_to_absolute(args[args.length == 4 ? 1 : 2])
+      def gradient_coordinates(gradient)
+        x1, y1 = map_to_absolute(gradient.from)
+        x2, y2 = map_to_absolute(gradient.to)
 
-        transformation = if opts[:apply_transformations]
+        transformation = if gradient.apply_transformations
                            current_transformation_matrix_with_translation(x1, y1)
                          else
                            [1, 0, 0, 1, x1, y1]

--- a/lib/prawn/graphics/patterns.rb
+++ b/lib/prawn/graphics/patterns.rb
@@ -23,7 +23,7 @@ module Prawn
       #      to: [x, y]
       #      r1: radius
       #      r2: radius
-      #      stops: [[position, color], ...]
+      #      stops: [color, color, ...] or { position => color, position => color, ... }
       #      apply_transformations: true
       #
       # Examples:
@@ -31,7 +31,7 @@ module Prawn
       #     fill_gradient from: [0, 0], to: [100, 0], stops: ['red', 'blue']
       #
       #     # draws a horizontal radial gradient that starts at red, is green 80% of the way through, and finishes blue
-      #     fill_gradient from: [0, 0], r1: 0, to: [100, 0], r2: 180, stops: [[0, 'red'], [0.8, 'green'], [1, 'blue']]
+      #     fill_gradient from: [0, 0], r1: 0, to: [100, 0], r2: 180, stops: { 0 => 'red', 0.8 => 'green', 1 => 'blue' }
       #
       # <tt>from</tt> and <tt>to</tt> specify the axis of where the gradient
       # should be painted.
@@ -41,11 +41,11 @@ module Prawn
       # and ending at a circle of radius <tt>r2</tt> centered at <tt>to</tt>.
       # If <tt>r1</tt> is not specified, a axial gradient will be drawn.
       #
-      # <tt>stops</tt> is an array of stops.  Each stop is either just a
+      # <tt>stops</tt> is an array or hash of stops.  Each stop is either just a
       # string indicating the color, in which case the stops will be evenly
-      # distributed across the gradient, or an array with two elements:
+      # distributed across the gradient, or a hash where the key is
       # a position between 0 and 1 indicating what distance through the
-      # gradient the color should change, and the color string.
+      # gradient the color should change, and the value is a color string.
       #
       # Option <tt>apply_transformations</tt>, if set true, will transform the
       # gradient's co-ordinate space so it matches the current co-ordinate
@@ -114,7 +114,7 @@ module Prawn
 
         stops = stops.map.with_index do |stop, index|
           case stop
-          when Array
+          when Array, Hash
             position, color = stop
           else
             position = index / (stops.length.to_f - 1)

--- a/manual/graphics/gradients.rb
+++ b/manual/graphics/gradients.rb
@@ -34,4 +34,10 @@ Prawn::ManualBuilder::Example.generate(filename) do
 
   fill_gradient [500, 300], 15, [500, 50], 0, 'ff0000', '0000ff'
   fill_rectangle [485, 300], 30, 250
+
+  rotate 45, origin: [100, 400] do
+    stops = [[0, 'ff0000'], [0.6, '999900'], [0.8, '00cc00'], [1, '4444ff']]
+    fill_gradient from: [50, 450], to: [150, 350], stops: stops
+    fill_rectangle [50, 450], 100, 100
+  end
 end

--- a/manual/graphics/gradients.rb
+++ b/manual/graphics/gradients.rb
@@ -36,7 +36,7 @@ Prawn::ManualBuilder::Example.generate(filename) do
   fill_rectangle [485, 300], 30, 250
 
   rotate 45, origin: [100, 400] do
-    stops = [[0, 'ff0000'], [0.6, '999900'], [0.8, '00cc00'], [1, '4444ff']]
+    stops = { 0 => 'ff0000', 0.6 => '999900', 0.8 => '00cc00', 1 => '4444ff' }
     fill_gradient from: [50, 450], to: [150, 350], stops: stops
     fill_rectangle [50, 450], 100, 100
   end

--- a/spec/graphics_spec.rb
+++ b/spec/graphics_spec.rb
@@ -303,6 +303,25 @@ describe "Patterns" do
       str = @pdf.render
       expect(str).to match(%r{/Pattern\s+CS\s*/SP-?\d+\s+SCN})
     end
+
+    it "uses a stitching function to render a gradient with multiple stops" do
+      @pdf.fill_gradient from: [0, @pdf.bounds.height],
+                         to: [@pdf.bounds.width, @pdf.bounds.height],
+                         stops: [[0, 'FF0000'], [0.8, '00FF00'], [1, '0000FF']]
+
+      grad = PDF::Inspector::Graphics::Pattern.analyze(@pdf.render)
+      pattern = grad.patterns.values.first
+
+      expect(pattern).not_to be_nil
+
+      stitching = pattern[:Shading][:Function]
+      expect(stitching[:FunctionType]).to eq(3)
+      expect(stitching[:Functions]).to be_an(Array)
+      expect(stitching[:Functions].map { |f| f[:C0] }).to eq([[1, 0, 0], [0, 1, 0]])
+      expect(stitching[:Functions].map { |f| f[:C1] }).to eq([[0, 1, 0], [0, 0, 1]])
+      expect(stitching[:Bounds]).to eq([0.8])
+      expect(stitching[:Encode]).to eq([0, 1, 0, 1])
+    end
   end
 
   describe 'radial gradients' do

--- a/spec/graphics_spec.rb
+++ b/spec/graphics_spec.rb
@@ -307,7 +307,7 @@ describe "Patterns" do
     it "uses a stitching function to render a gradient with multiple stops" do
       @pdf.fill_gradient from: [0, @pdf.bounds.height],
                          to: [@pdf.bounds.width, @pdf.bounds.height],
-                         stops: [[0, 'FF0000'], [0.8, '00FF00'], [1, '0000FF']]
+                         stops: { 0 => 'FF0000', 0.8 => '00FF00', 1 => '0000FF' }
 
       grad = PDF::Inspector::Graphics::Pattern.analyze(@pdf.render)
       pattern = grad.patterns.values.first
@@ -321,6 +321,24 @@ describe "Patterns" do
       expect(stitching[:Functions].map { |f| f[:C1] }).to eq([[0, 1, 0], [0, 0, 1]])
       expect(stitching[:Bounds]).to eq([0.8])
       expect(stitching[:Encode]).to eq([0, 1, 0, 1])
+    end
+
+    it "uses a stitching function to render a gradient with equally spaced stops" do
+      @pdf.fill_gradient from: [0, @pdf.bounds.height],
+                         to: [@pdf.bounds.width, @pdf.bounds.height],
+                         stops: %w(FF0000 00FF00 0000FF)
+
+      grad = PDF::Inspector::Graphics::Pattern.analyze(@pdf.render)
+      pattern = grad.patterns.values.first
+
+      expect(pattern).not_to be_nil
+
+      stitching = pattern[:Shading][:Function]
+      expect(stitching[:FunctionType]).to eq(3)
+      expect(stitching[:Functions]).to be_an(Array)
+      expect(stitching[:Functions].map { |f| f[:C0] }).to eq([[1, 0, 0], [0, 1, 0]])
+      expect(stitching[:Functions].map { |f| f[:C1] }).to eq([[0, 1, 0], [0, 0, 1]])
+      expect(stitching[:Bounds]).to eq([0.5])
     end
   end
 


### PR DESCRIPTION
Another change towards getting SVG support going.  From the changelog:

> Previously, only two colors could be specified in a gradient: the start
> and end colors.  This change allows any number of colors to be specified,
> along with the position between 0 and 1 as to where they should be displayed.
> 
> This change also comes with a change to the format of the `fill_gradient`
> and `stroke_gradient` methods.  You can continue to use the old method
> parameters and only specify two colors, or use the new keyword arguments
> to specify arbitrary stops.
> 
> As a bonus, if you use the new method style, `apply_transformations` is
> set true automatically (see below).

Two things you might be curious about:

1. The original code calls `.dup.freeze` after calling `normalize_color`.  I can't see any reason to do this, as `normalize_color` always returns a new array, and nothing modifies it.
2. The original code calls `process_color`, which has no side effects, and does nothing with the return value.

So in both of these cases I've just stripped that code out.

I wasn't sure about implementing the kwargs for the new version of the calls, but it reads a lot better IMO, especially that you can use it in both axial and radial modes.  More than happy to entertain different method signatures if you don't like it!