### PR TITLE
Add :dry_run to text_box and formatted_text_box

### DIFF
--- a/lib/prawn/text/box.rb
+++ b/lib/prawn/text/box.rb
@@ -94,7 +94,7 @@ module Prawn
     #
     # == Returns
     #
-    # Returns any text that did not print under the current settings.
+    # Returns the Text::Box object or Text::Formatted::Box if <tt>:inline_format</tt> is true
     #
     # == Exceptions
     #
@@ -113,7 +113,8 @@ module Prawn
               Text::Box.new(string, options)
             end
 
-      box.render
+      box.render(:dry_run => options[:dry_run])
+      box
     end
 
     # @group Experimental API

--- a/lib/prawn/text/formatted/box.rb
+++ b/lib/prawn/text/formatted/box.rb
@@ -64,6 +64,10 @@ module Prawn
       #     #render_behind and #render_in_front, which are called immediately
       #     prior to and immediately after rendring the text fragment and which
       #     are passed the fragment as an argument
+      # <tt>:dry_run</tt>::
+      #     <tt>boolean</tt>. Prevents the text from being printed to the PDF
+      #     and is useful in conjunction with <tt>:shrink_to_fit</tt> to
+      #     determine the font size and height of the box
       #
       # == Example
       #
@@ -78,8 +82,7 @@ module Prawn
       #
       # == Returns
       #
-      # Returns a formatted text array representing any text that did not print
-      # under the current settings.
+      # Returns the Text::Formatted::Box object after render is called
       #
       # == Exceptions
       #
@@ -89,7 +92,9 @@ module Prawn
       # any text
       #
       def formatted_text_box(array, options = {})
-        Text::Formatted::Box.new(array, options.merge(:document => self)).render
+        box = Text::Formatted::Box.new(array, options.merge(:document => self))
+        box.render(:dry_run => options[:dry_run])
+        box
       end
 
       # Generally, one would use the Prawn::Text::Formatted#formatted_text_box
@@ -129,6 +134,8 @@ module Prawn
         attr_reader :descender
         # The leading used during printing
         attr_reader :leading
+        # The font size which may have changed if <tt>shrink_to_fit</tt> is true
+        attr_reader :font_size
 
         def line_gap
           line_height - (ascender + descender)
@@ -341,7 +348,8 @@ module Prawn
             :document,
             :direction,
             :fallback_fonts,
-            :draw_text_callback
+            :draw_text_callback,
+            :dry_run
           ]
         end
 

--- a/spec/formatted_text_box_spec.rb
+++ b/spec/formatted_text_box_spec.rb
@@ -671,6 +671,57 @@ describe "Text::Formatted::Box#render with :valign => :bottom" do
   end
 end
 
+describe "formatted_text_box with :dry_run option" do
+  before(:each) do
+    create_pdf
+    @formatted_text = [{ :text => "This is amazing. " * 10 }]
+  end
+
+  it "should return instance of Prawn::Text::Formatted::Box" do
+    box = @pdf.formatted_text_box(@formatted_text, :dry_run => true)
+    expect(box).to be_instance_of(Prawn::Text::Formatted::Box)
+  end
+
+  it "should draw content to the page when :dry_run => nil" do
+    @pdf.formatted_text_box(@formatted_text)
+    text = PDF::Inspector::Text.analyze(@pdf.render)
+    expect(text.strings).not_to be_empty
+  end
+
+  it "should not draw any content to the page when :dry_run => true" do
+    @pdf.formatted_text_box(@formatted_text, :dry_run => true)
+    text = PDF::Inspector::Text.analyze(@pdf.render)
+    expect(text.strings).to be_empty
+  end
+
+  it "should allow accessing font_size when testing :shrink_to_fit" do
+    options = {
+      :at => [0, 300],
+      :disable_wrap_by_char => true,
+      :dry_run => true,
+      :overflow => :shrink_to_fit,
+      :size => 50,
+      :width => 70
+    }
+
+    box = @pdf.formatted_text_box([{ :text => "Some shorter text" }], options)
+    expect(box.font_size).to eq(22)
+  end
+
+  it "should allow accessing height" do
+    options = {
+      :at => [0, @pdf.bounds.height],
+      :dry_run => true,
+      :width => @pdf.bounds.width
+    }
+
+    box1 = @pdf.formatted_text_box([{ :text => "A lot of text. " * 100 }], options)
+    box2 = @pdf.formatted_text_box([{ :text => "A lot of text. " * 200 }], options)
+
+    expect(box2.height).to be > box1.height
+  end
+end
+
 class TestFragmentCallback
   def initialize(string, number, options)
     @document = options[:document]

--- a/spec/text_box_spec.rb
+++ b/spec/text_box_spec.rb
@@ -1029,6 +1029,57 @@ describe "Text::Box#render with :mode option" do
   end
 end
 
+describe "text_box with :dry_run option" do
+  before(:each) do
+    create_pdf
+    @text = "This is amazing. " * 10
+  end
+
+  it "should return instance of Prawn::Text::Formatted::Box" do
+    box = @pdf.text_box(@text, :dry_run => true)
+    expect(box).to be_instance_of(Prawn::Text::Box)
+  end
+
+  it "should draw content to the page when :dry_run => nil" do
+    @pdf.text_box(@text)
+    text = PDF::Inspector::Text.analyze(@pdf.render)
+    expect(text.strings).not_to be_empty
+  end
+
+  it "should not draw any content to the page when :dry_run => true" do
+    @pdf.text_box(@text, :dry_run => true)
+    text = PDF::Inspector::Text.analyze(@pdf.render)
+    expect(text.strings).to be_empty
+  end
+
+  it "should allow accessing font_size when testing :shrink_to_fit" do
+    options = {
+      :at => [0, 300],
+      :disable_wrap_by_char => true,
+      :dry_run => true,
+      :overflow => :shrink_to_fit,
+      :size => 50,
+      :width => 70
+    }
+
+    box = @pdf.text_box("Some shorter text", options)
+    expect(box.font_size).to eq(22)
+  end
+
+  it "should allow accessing height" do
+    options = {
+      :at => [0, @pdf.bounds.height],
+      :dry_run => true,
+      :width => @pdf.bounds.width
+    }
+
+    box1 = @pdf.text_box("A lot of text. " * 100, options)
+    box2 = @pdf.text_box("A lot of text " * 200, options)
+
+    expect(box2.height).to be > box1.height
+  end
+end
+
 def reduce_precision(float)
   ("%.5f" % float).to_f
 end


### PR DESCRIPTION
I made a patch based on @practicingruby's suggestions on issue #763. The main changes are that text_box and formatted_text_box return the box object and allow access to attributes such as font_size and height. Passing :dry_run => true provides a way to get font sizes from :shrink_to_fit and box heights before rendering text to the pdf.