### PR TITLE
Fix IRB warnings on Ruby >= 2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 
 ## PrawnPDF master branch
 
+### Prawn no longer generates IRB warnings
+
+Fix a few issues with code style that were triggering warnings in IRB when run in verbose mode (`irb -w`).
+
+(Jesse Doyle, [#914](https://github.com/prawnpdf/prawn/pull/914))
+
 ### Gradients applied inside transformations are now correctly positioned
 
 PDF gradients/patterns take coordinates in the coordinate space of the

--- a/lib/prawn/graphics/patterns.rb
+++ b/lib/prawn/graphics/patterns.rb
@@ -76,7 +76,7 @@ module Prawn
       end
 
       def gradient_registry_key(gradient, opts)
-        x1, y1, x2, y2, transformation = gradient_coordinates(gradient, opts)
+        _x1, _y1, x2, y2, transformation = gradient_coordinates(gradient, opts)
 
         if gradient[1].is_a?(Array) # axial
           [

--- a/lib/prawn/text/formatted/arranger.rb
+++ b/lib/prawn/text/formatted/arranger.rb
@@ -16,6 +16,7 @@ module Prawn
         attr_reader :max_line_height
         attr_reader :max_descender
         attr_reader :max_ascender
+        attr_reader :finalized
         attr_accessor :consumed
 
         # The following present only for testing purposes
@@ -61,7 +62,7 @@ module Prawn
         end
 
         def finalize_line
-          self.finalized = true
+          @finalized = true
 
           omit_trailing_whitespace_from_line_width
           @fragments = []
@@ -89,7 +90,7 @@ module Prawn
         end
 
         def initialize_line
-          self.finalized = false
+          @finalized = false
           @max_line_height = 0
           @max_descender = 0
           @max_ascender = 0
@@ -218,8 +219,6 @@ module Prawn
         end
 
         private
-
-        attr_accessor :finalized
 
         def load_previous_format_state
           if @consumed.empty?

--- a/lib/prawn/text/formatted/line_wrap.rb
+++ b/lib/prawn/text/formatted/line_wrap.rb
@@ -21,6 +21,8 @@ module Prawn
 
         # The number of spaces in the last wrapped line
         attr_reader :space_count
+        attr_reader :soft_hyphen
+        attr_reader :zero_width_space
 
         # Whether this line is the last line in the paragraph
         def paragraph_finished?
@@ -149,9 +151,6 @@ module Prawn
         def hyphen
           "-"
         end
-
-        attr_reader :soft_hyphen
-        attr_reader :zero_width_space
 
         def line_empty?
           @line_empty && @accumulated_width == 0


### PR DESCRIPTION
I generally run IRB with all warnings enabled (I have an alias to `irb -w` setup in my shell).

After requiring the current master branch of `Prawn` in IRB on Ruby 2.2.0, the following warnings were logged:

```bash
> irb -w
2.2.0 :001 > require './lib/prawn'
/Users/jesse/development/ruby/prawn/lib/prawn/text/formatted/line_wrap.rb:153: warning: private attribute?
/Users/jesse/development/ruby/prawn/lib/prawn/text/formatted/line_wrap.rb:154: warning: private attribute?
/Users/jesse/development/ruby/prawn/lib/prawn/text/formatted/arranger.rb:222: warning: private attribute?
/Users/jesse/development/ruby/prawn/lib/prawn/graphics/patterns.rb:79: warning: assigned but unused variable - x1
/Users/jesse/development/ruby/prawn/lib/prawn/graphics/patterns.rb:79: warning: assigned but unused variable - y1
 => true
```

This patch simply fixes the issues the warnings are generated from.