### PR TITLE
Formatted text has wrong leading with one line paragraphs

### DIFF
--- a/lib/prawn/text.rb
+++ b/lib/prawn/text.rb
@@ -208,8 +208,10 @@ module Prawn
             end
           end
 
-          remaining_text = fill_formatted_text_box(remaining_text, options)
-          draw_remaining_formatted_text_on_new_pages(remaining_text, options)
+          unless @all_text_printed
+            remaining_text = fill_formatted_text_box(remaining_text, options)
+            draw_remaining_formatted_text_on_new_pages(remaining_text, options)
+          end
         end
       else
         remaining_text = fill_formatted_text_box(array, options)

--- a/spec/text_spec.rb
+++ b/spec/text_spec.rb
@@ -445,6 +445,17 @@ describe "#text" do
       expect(x_positions[3]).to eq(0)
     end
 
+    describe "when paragraph has only one line, it should not add" \
+             " additional leading" do
+      let(:leading) { 100 }
+
+      it 'should add leading only once' do
+        original_y = @pdf.y
+        @pdf.text("hello", indent_paragraphs: 10, leading: leading)
+        expect(original_y - @pdf.y).to be < leading * 2
+      end
+    end
+
     describe "when wrap to new page, and first line of new page" \
              " is not the start of a new paragraph, that line should" \
              " not be indented" do


### PR DESCRIPTION
_What's wrong_: If you are indenting a paragraph, but have only one line to print, it will be printed by `draw_indented_formatted_line` completely. Thus, `remaining_text` is empty, but Prawn tries to print it anyway. The problem is that `fill_formatted_text_box` is still changing the `y` value of the document if you specify leading:

``` ruby
      self.y -= box.height
      self.y -= box.line_gap + box.leading if @final_gap
```

`box.height` and `box.line_gap` are zero for an empty remaining text, but box.leading is not. This causes a wrong leading in your text if you have single line paragraphs.

_Example_:

``` ruby
require "prawn"

Prawn::Document.generate("too_much_leading.pdf") do
  text_options = {
    indent_paragraphs: 30,
    leading: 20
  }
  text "Hello World!", text_options
  text "Second paragraph on more than one line!"*5, text_options
  text "Third paragraph on more than one line!"*5, text_options
end
```

Space between the first paragraphs is too large. It should have the same leading as between the second and third paragraph.
