### PR TITLE
Use font family name for caching in `#find_font`

### DIFF
--- a/lib/prawn/font.rb
+++ b/lib/prawn/font.rb
@@ -235,7 +235,7 @@ module Prawn
           name = options[:file]
         end
       end
-      key = "#{name}:#{options[:font] || 0}"
+      key = "#{family}:#{name}:#{options[:font] || 0}"
 
       if name.is_a? Prawn::Font
         font_registry[key] = name


### PR DESCRIPTION
I am not sure about this PR, so please feel free to discuss this.

Recently I ran into an issue I debugged which was caused to the font caching mechanism. So, let us say we have the following prawn code.

``` ruby
require "prawn"

Prawn::Document.generate("font_caching.pdf") do
  font_families.update({
    "foo" => {
      bold:   "OpenSans-Bold.ttf",
      normal: "OpenSans-Regular.ttf",
    },
    "bar" => {
      bold:   "OpenSans-Semibold.ttf",
      normal: "OpenSans-Regular.ttf",
    }
  })

  font "foo"

  text "Open Sans Regular"
  text "Open Sans Bold", style: :bold

  font "bar" do
    text "Open Sans Regular"
    text "Open Sans SemiBold", style: :bold
  end
end
```

After you have defined a default font family with, e.g. `font("foo")`, you will run into caching problems once you try to use `bar`. In particular you will never actually use the `OpenSans-Semibold.ttf` font, but always the `OpenSans-Bold.ttf`. Putting the family name in the key fixes this issue.
