### PR TITLE
Install latest bundler before bundling the build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ rvm:
   - 2.1
   - 2.2
   - rbx-2
-  - jruby
+  - jruby-1.7.22
 env:
   JRUBY_OPTS=--2.0
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,12 @@ before_install:
   - gem install bundler
   - bundle --version
 rvm:
-  - 2.0
-  - 2.1
-  - 2.2
+  - 2.0.0-p0
+  - 2.0.0-p648
+  - 2.1.0-p0
+  - 2.1.8
+  - 2.2.0-p0
+  - 2.2.4
   - rbx-2
   - jruby-9.0.4.0
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: ruby
+before_install:
+  - gem install bundler
+  - bundle --version
 rvm:
   - 2.0
   - 2.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ rvm:
   - 2.1
   - 2.2
   - rbx-2
-  - jruby-1.7.22
-env:
-  JRUBY_OPTS=--2.0
 matrix:
+  include:
+    - rvm: jruby-1.7.22
+      env: JRUBY_ORTS=--2.0
   allow_failures:
     - rvm: rbx-2

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ rvm:
   - 2.1
   - 2.2
   - rbx-2
+  - jruby-9.0.4.0
 matrix:
   include:
     - rvm: jruby-1.7.22


### PR DESCRIPTION
We have a few failing builds on master because of conflict between new rubygems and older bundler.

This PR fixes build of master branch after merge of #920. 