### PR TITLE
Update to RSpec 3

### DIFF
--- a/prawn.gemspec
+++ b/prawn.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency('pdf-inspector', '~> 1.2.1')
   spec.add_development_dependency('yard')
-  spec.add_development_dependency('rspec', '2.14.1')
+  spec.add_development_dependency('rspec', '~> 3.0')
   spec.add_development_dependency('mocha')
   spec.add_development_dependency('rake')
   spec.add_development_dependency('simplecov')

--- a/spec/document_spec.rb
+++ b/spec/document_spec.rb
@@ -77,14 +77,14 @@ describe "when generating a document from a subclass" do
     Prawn::Document.extensions.delete(mod1)
     Prawn::Document.extensions.delete(mod2)
 
-    expect(Prawn::Document.new.respond_to?(:test_extensions1)).to be_false
-    expect(Prawn::Document.new.respond_to?(:test_extensions2)).to be_false
+    expect(Prawn::Document.new.respond_to?(:test_extensions1)).to eq false
+    expect(Prawn::Document.new.respond_to?(:test_extensions2)).to eq false
 
     # verify these still exist on custom class
     expect(custom_document.extensions).to eq([mod1, mod2])
 
-    expect(custom_document.new.respond_to?(:test_extensions1)).to be_true
-    expect(custom_document.new.respond_to?(:test_extensions2)).to be_true
+    expect(custom_document.new.respond_to?(:test_extensions1)).to eq true
+    expect(custom_document.new.respond_to?(:test_extensions2)).to eq true
   end
 end
 
@@ -176,7 +176,7 @@ describe "on_page_create callback" do
   end
 
   it "should be delegated from Document to renderer" do
-    expect(@pdf.respond_to?(:on_page_create)).to be_true
+    expect(@pdf.respond_to?(:on_page_create)).to eq true
   end
 
   it "should be invoked with document" do
@@ -304,30 +304,31 @@ describe "When reopening pages" do
   end
 
   it "should restore the layout of the page" do
-    Prawn::Document.new do
+    doc = Prawn::Document.new do
       start_new_page :layout => :landscape
-      lsize = [bounds.width, bounds.height]
-
-      [bounds.width, bounds.height].should == lsize
-      go_to_page 1
-      [bounds.width, bounds.height].should == lsize.reverse
     end
+
+    lsize = [doc.bounds.width, doc.bounds.height]
+
+    expect([doc.bounds.width, doc.bounds.height]).to eq lsize
+    doc.go_to_page 1
+    expect([doc.bounds.width, doc.bounds.height]).to eq lsize.reverse
   end
 
   it "should restore the margin box of the page" do
-    Prawn::Document.new(:margin => [100, 100]) do
-      page1_bounds = bounds
+    doc = Prawn::Document.new(:margin => [100, 100])
+    page1_bounds = doc.bounds
 
-      start_new_page(:margin => [200, 200])
+    doc.start_new_page(:margin => [200, 200])
 
-      [bounds.width, bounds.height].should == [page1_bounds.width - 200,
-                                               page1_bounds.height - 200]
+    expect([doc.bounds.width, doc.bounds.height]).to eq(
+      [page1_bounds.width - 200, page1_bounds.height - 200]
+    )
 
-      go_to_page(1)
+    doc.go_to_page(1)
 
-      bounds.width.should == page1_bounds.width
-      bounds.height.should == page1_bounds.height
-    end
+    expect(doc.bounds.width).to eq page1_bounds.width
+    expect(doc.bounds.height).to eq page1_bounds.height
   end
 end
 
@@ -712,17 +713,17 @@ describe "The page_match? method" do
   end
 
   it "returns nil given no filter" do
-    expect(@pdf.page_match?(:nil, 1)).to be_false
+    expect(@pdf.page_match?(:nil, 1)).to be_falsey
   end
 
   it "must provide an :all filter" do
-    expect((1..@pdf.page_count).all? { |i| @pdf.page_match?(:all, i) }).to be_true
+    expect((1..@pdf.page_count).all? { |i| @pdf.page_match?(:all, i) }).to eq true
   end
 
   it "must provide an :odd filter" do
     odd, even = (1..@pdf.page_count).partition(&:odd?)
-    expect(odd.all? { |i| @pdf.page_match?(:odd, i) }).to be_true
-    expect(even.any? { |i| @pdf.page_match?(:odd, i) }).to be_false
+    expect(odd.all? { |i| @pdf.page_match?(:odd, i) }).to eq true
+    expect(even.any? { |i| @pdf.page_match?(:odd, i) }).to be_falsey
   end
 
   it "must be able to filter by an array of page numbers" do

--- a/spec/font_spec.rb
+++ b/spec/font_spec.rb
@@ -265,11 +265,11 @@ describe "Document#page_fonts" do
   end
 
   def page_should_include_font(font)
-    expect(page_includes_font?(font)).to be_true
+    expect(page_includes_font?(font)).to eq true
   end
 
   def page_should_not_include_font(font)
-    expect(page_includes_font?(font)).to be_false
+    expect(page_includes_font?(font)).to eq false
   end
 end
 
@@ -313,13 +313,13 @@ describe "AFM fonts" do
     it "should not modify the original string when normalize_encoding() is used" do
       original = "Foo"
       normalized = @times.normalize_encoding(original)
-      expect(original.equal?(normalized)).to be_false
+      expect(original.equal?(normalized)).to eq false
     end
 
     it "should modify the original string when normalize_encoding!() is used" do
       original = "Foo"
       normalized = @times.normalize_encoding!(original)
-      expect(original.equal?(normalized)).to be_true
+      expect(original.equal?(normalized)).to eq true
     end
   end
 
@@ -335,25 +335,25 @@ describe "#glyph_present" do
 
   it "should return true when present in an AFM font" do
     font = @pdf.find_font("Helvetica")
-    expect(font.glyph_present?("H")).to be_true
+    expect(font.glyph_present?("H")).to eq true
   end
 
   it "should return false when absent in an AFM font" do
     font = @pdf.find_font("Helvetica")
-    expect(font.glyph_present?("再")).to be_false
+    expect(font.glyph_present?("再")).to eq false
   end
 
   it "should return true when present in a TTF font" do
     font = @pdf.find_font("#{Prawn::DATADIR}/fonts/DejaVuSans.ttf")
-    expect(font.glyph_present?("H")).to be_true
+    expect(font.glyph_present?("H")).to eq true
   end
 
   it "should return false when absent in a TTF font" do
     font = @pdf.find_font("#{Prawn::DATADIR}/fonts/DejaVuSans.ttf")
-    expect(font.glyph_present?("再")).to be_false
+    expect(font.glyph_present?("再")).to eq false
 
     font = @pdf.find_font("#{Prawn::DATADIR}/fonts/gkai00mp.ttf")
-    expect(font.glyph_present?("€")).to be_false
+    expect(font.glyph_present?("€")).to eq false
   end
 end
 
@@ -410,13 +410,13 @@ describe "TTF fonts" do
     it "should not modify the original string when normalize_encoding() is used" do
       original = "Foo"
       normalized = @font.normalize_encoding(original)
-      expect(original.equal?(normalized)).to be_false
+      expect(original.equal?(normalized)).to eq false
     end
 
     it "should modify the original string when normalize_encoding!() is used" do
       original = "Foo"
       normalized = @font.normalize_encoding!(original)
-      expect(original.equal?(normalized)).to be_true
+      expect(original.equal?(normalized)).to eq true
     end
   end
 end

--- a/spec/graphics_spec.rb
+++ b/spec/graphics_spec.rb
@@ -280,10 +280,10 @@ describe "Patterns" do
       expect(pattern[:Shading][:Coords]).to eq([0, 0, @pdf.bounds.width, 0])
       expect(pattern[:Shading][:Function][:C0].zip([1, 0, 0]).all?{ |x1, x2|
         (x1 - x2).abs < 0.01
-      }).to be_true
+      }).to eq true
       expect(pattern[:Shading][:Function][:C1].zip([0, 0, 1]).all?{ |x1, x2|
         (x1 - x2).abs < 0.01
-      }).to be_true
+      }).to eq true
     end
 
     it "fill_gradient should set fill color to the pattern" do
@@ -319,10 +319,10 @@ describe "Patterns" do
       expect(pattern[:Shading][:Coords]).to eq([0, 0, 10, @pdf.bounds.width, 0, 20])
       expect(pattern[:Shading][:Function][:C0].zip([1, 0, 0]).all?{ |x1, x2|
         (x1 - x2).abs < 0.01
-      }).to be_true
+      }).to eq true
       expect(pattern[:Shading][:Function][:C1].zip([0, 0, 1]).all?{ |x1, x2|
         (x1 - x2).abs < 0.01
-      }).to be_true
+      }).to eq true
     end
 
     it "fill_gradient should set fill color to the pattern" do

--- a/spec/repeater_spec.rb
+++ b/spec/repeater_spec.rb
@@ -18,7 +18,7 @@ describe "Repeaters" do
     doc = sample_document
     r = repeater(doc, :all) { :do_nothing }
 
-    expect((1..doc.page_count).all? { |i| r.match?(i) }).to be_true
+    expect((1..doc.page_count).all? { |i| r.match?(i) }).to eq true
   end
 
   it "must provide an :odd filter" do
@@ -27,8 +27,8 @@ describe "Repeaters" do
 
     odd, even = (1..doc.page_count).partition(&:odd?)
 
-    expect(odd.all? { |i| r.match?(i) }).to be_true
-    expect(even.any? { |i| r.match?(i) }).to be_false
+    expect(odd.all? { |i| r.match?(i) }).to eq true
+    expect(even.any? { |i| r.match?(i) }).to eq false
   end
 
   it "must be able to filter by an array of page numbers" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,7 +29,6 @@ Dir[File.dirname(__FILE__) + "/extensions/**/*.rb"].each { |f| require f }
 RSpec.configure do |config|
   config.mock_framework = :mocha
   config.include EncodingHelpers
-  config.treat_symbols_as_metadata_keys_with_true_values = true
 end
 
 def create_pdf(klass = Prawn::Document)
@@ -41,7 +40,7 @@ RSpec::Matchers.define :have_parseable_xobjects do
     expect { PDF::Inspector::XObject.analyze(actual.render) }.not_to raise_error
     true
   end
-  failure_message_for_should do |actual|
+  failure_message do |actual|
     "expected that #{actual}'s XObjects could be successfully parsed"
   end
 end

--- a/spec/text_at_spec.rb
+++ b/spec/text_at_spec.rb
@@ -58,7 +58,7 @@ describe "#draw_text" do
 
     text = rotated_text_inspector.analyze(@pdf.render)
 
-    expect(text.tm_operator_used).to(be_true)
+    expect(text.tm_operator_used).to eq true
   end
 
   it "should not use rotation matrix by default" do
@@ -66,7 +66,7 @@ describe "#draw_text" do
 
     text = rotated_text_inspector.analyze(@pdf.render)
 
-    expect(text.tm_operator_used).to(be_false)
+    expect(text.tm_operator_used).to eq false
   end
 
   it "should allow overriding default font for a single instance" do

--- a/spec/text_box_spec.rb
+++ b/spec/text_box_spec.rb
@@ -3,43 +3,45 @@
 require File.join(File.expand_path(File.dirname(__FILE__)), "spec_helper")
 
 describe "Text::Box#nothing_printed?" do
-  it "should be_true when nothing printed" do
+  it "returns true when nothing printed" do
     create_pdf
     string = "Hello world, how are you?\nI'm fine, thank you."
     text_box = Prawn::Text::Box.new(string,
                                     :height => 2,
                                     :document => @pdf)
     text_box.render
-    expect(text_box.nothing_printed?).to be_true
+    expect(text_box.nothing_printed?).to eq true
   end
-  it "should be_false when something printed" do
+
+  it "returns false when something printed" do
     create_pdf
     string = "Hello world, how are you?\nI'm fine, thank you."
     text_box = Prawn::Text::Box.new(string,
                                     :height => 14,
                                     :document => @pdf)
     text_box.render
-    expect(text_box.nothing_printed?).to be_false
+    expect(text_box.nothing_printed?).to eq false
   end
 end
 
 describe "Text::Box#everything_printed?" do
-  it "should be_false when not everything printed" do
+  it "returns false when not everything printed" do
     create_pdf
     string = "Hello world, how are you?\nI'm fine, thank you."
     text_box = Prawn::Text::Box.new(string,
                                     :height => 14,
                                     :document => @pdf)
     text_box.render
-    expect(text_box.everything_printed?).to be_false
+    expect(text_box.everything_printed?).to eq false
   end
-  it "should be_true when everything printed" do
+
+  it "returns true when everything printed" do
     create_pdf
     string = "Hello world, how are you?\nI'm fine, thank you."
     text_box = Prawn::Text::Box.new(string,
                                     :document => @pdf)
     text_box.render
-    expect(text_box.everything_printed?).to be_true
+    expect(text_box.everything_printed?).to eq true
   end
 end
 

--- a/spec/text_spec.rb
+++ b/spec/text_spec.rb
@@ -63,7 +63,7 @@ describe "#text" do
   end
 
   it "should ignore call when string is nil" do
-    expect(@pdf.text(nil)).to be_false
+    expect(@pdf.text(nil)).to eq false
   end
 
   it "should correctly render empty paragraphs" do
@@ -91,13 +91,13 @@ describe "#text" do
   it "should default to use kerning information" do
     @pdf.text "hello world"
     text = PDF::Inspector::Text.analyze(@pdf.render)
-    expect(text.kerned[0]).to be_true
+    expect(text.kerned[0]).to eq true
   end
 
   it "should be able to disable kerning with an option" do
     @pdf.text "hello world", :kerning => false
     text = PDF::Inspector::Text.analyze(@pdf.render)
-    expect(text.kerned[0]).to be_false
+    expect(text.kerned[0]).to eq false
   end
 
   it "should be able to disable kerning document-wide" do
@@ -105,14 +105,14 @@ describe "#text" do
     @pdf.default_kerning = false
     @pdf.text "hello world"
     text = PDF::Inspector::Text.analyze(@pdf.render)
-    expect(text.kerned[0]).to be_false
+    expect(text.kerned[0]).to eq false
   end
 
   it "option should be able to override document-wide kerning disabling" do
     @pdf.default_kerning = false
     @pdf.text "hello world", :kerning => true
     text = PDF::Inspector::Text.analyze(@pdf.render)
-    expect(text.kerned[0]).to be_true
+    expect(text.kerned[0]).to eq true
   end
 
   it "should raise_error ArgumentError if :at option included" do


### PR DESCRIPTION
This is mostly a mechanical changes.

* Replaced all `.should` with `expect()`
* Removed deprecated options
* Unrolled some blocks
* Cleaned up everything that RSpec complained about