### PR TITLE
Consistent Pattern naming

### DIFF
--- a/lib/prawn/graphics/patterns.rb
+++ b/lib/prawn/graphics/patterns.rb
@@ -1,4 +1,4 @@
-# encoding: utf-8
+require "digest/sha1"
 
 # patterns.rb : Implements axial & radial gradients
 #
@@ -138,13 +138,14 @@ module Prawn
       def gradient_registry_key(gradient)
         x1, y1, x2, y2, transformation = gradient_coordinates(gradient)
 
-        [
+        key = [
           gradient.type,
           transformation,
           x2, y2,
           gradient.r1, gradient.r2,
           gradient.stops
-        ].hash
+        ]
+        Digest::SHA1.hexdigest(Marshal.dump(key))
       end
 
       def gradient_registry

--- a/spec/graphics_spec.rb
+++ b/spec/graphics_spec.rb
@@ -292,7 +292,7 @@ describe "Patterns" do
                          'FF0000', '0000FF'
 
       str = @pdf.render
-      expect(str).to match(%r{/Pattern\s+cs\s*/SP-?\d+\s+scn})
+      expect(str).to match(%r{/Pattern\s+cs\s*/SP\h{40}\s+scn})
     end
 
     it "stroke_gradient should set stroke color to the pattern" do
@@ -301,7 +301,7 @@ describe "Patterns" do
                            'FF0000', '0000FF'
 
       str = @pdf.render
-      expect(str).to match(%r{/Pattern\s+CS\s*/SP-?\d+\s+SCN})
+      expect(str).to match(%r{/Pattern\s+CS\s*/SP\h{40}\s+SCN})
     end
 
     it "uses a stitching function to render a gradient with multiple stops" do
@@ -368,7 +368,7 @@ describe "Patterns" do
                          'FF0000', '0000FF'
 
       str = @pdf.render
-      expect(str).to match(%r{/Pattern\s+cs\s*/SP-?\d+\s+scn})
+      expect(str).to match(%r{/Pattern\s+cs\s*/SP\h{40}\s+scn})
     end
 
     it "stroke_gradient should set stroke color to the pattern" do
@@ -377,7 +377,7 @@ describe "Patterns" do
                            'FF0000', '0000FF'
 
       str = @pdf.render
-      expect(str).to match(%r{/Pattern\s+CS\s*/SP-?\d+\s+SCN})
+      expect(str).to match(%r{/Pattern\s+CS\s*/SP\h{40}\s+SCN})
     end
   end
 


### PR DESCRIPTION
`hash` method returns same hash value for the same object but that only works in the same process. The resulting hash is not consistent between processes. This resulted in a different pattern name each time the process would restart.

New way of pattern name derivation is consistent between runs.