### PR TITLE
Manual spec

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -23,6 +23,7 @@ desc "Generate the 'Prawn by Example' manual"
 task :manual do
   puts 'Building manual...'
   require File.expand_path(File.join(__dir__, %w[manual contents]))
+  prawn_manual_document.render_file('manual.pdf')
   puts 'The Prawn manual is available at manual.pdf. Happy Prawning!'
 end
 

--- a/lib/prawn/graphics/patterns.rb
+++ b/lib/prawn/graphics/patterns.rb
@@ -164,13 +164,14 @@ module Prawn
         _x1, _y1, x2, y2, transformation = gradient_coordinates(gradient)
 
         key = [
-          gradient.type,
+          gradient.type.to_s,
           transformation,
           x2, y2,
-          gradient.r1, gradient.r2,
-          gradient.stops
-        ]
-        Digest::SHA1.hexdigest(Marshal.dump(key))
+          gradient.r1 || -1, gradient.r2 || -1,
+          gradient.stops.length,
+          gradient.stops.map { |s| [s.position, s.color] }
+        ].flatten
+        Digest::SHA1.hexdigest(key.pack('HC*'))
       end
 
       def gradient_registry

--- a/manual/contents.rb
+++ b/manual/contents.rb
@@ -2,28 +2,32 @@
 
 require_relative 'example_helper'
 
-Encoding.default_external = Encoding::UTF_8
+def prawn_manual_document
+  old_default_external_encoding = Encoding.default_external
+  Encoding.default_external = Encoding::UTF_8
 
-Prawn::ManualBuilder::Example.generate(
-  'manual.pdf',
-  skip_page_creation: true,
-  page_size: 'FOLIO'
-) do
-  load_page '', 'cover'
-  load_page '', 'how_to_read_this_manual'
+  Prawn::ManualBuilder::Example.new(
+    skip_page_creation: true,
+    page_size: 'FOLIO'
+  ) do
+    load_page '', 'cover'
+    load_page '', 'how_to_read_this_manual'
 
-  # Core chapters
-  load_package 'basic_concepts'
-  load_package 'graphics'
-  load_package 'text'
-  load_package 'bounding_box'
+    # Core chapters
+    load_package 'basic_concepts'
+    load_package 'graphics'
+    load_package 'text'
+    load_package 'bounding_box'
 
-  # Remaining chapters
-  load_package 'layout'
-  load_page '', 'table'
-  load_package 'images'
-  load_package 'document_and_page_options'
-  load_package 'outline'
-  load_package 'repeatable_content'
-  load_package 'security'
+    # Remaining chapters
+    load_package 'layout'
+    load_page '', 'table'
+    load_package 'images'
+    load_package 'document_and_page_options'
+    load_package 'outline'
+    load_package 'repeatable_content'
+    load_package 'security'
+  end
+ensure
+  Encoding.default_external = old_default_external_encoding
 end

--- a/manual/cover.rb
+++ b/manual/cover.rb
@@ -27,12 +27,14 @@ Prawn::ManualBuilder::Example.generate(filename) do
     git_commit = ''
   end
 
-  formatted_text_box(
-    [{
-      text: "Last Update: #{Time.now.strftime('%Y-%m-%d')}\n" \
-        "Prawn Version: #{Prawn::VERSION}\n#{git_commit}",
-      size: 12
-    }],
-    at: [390, cursor - 620]
-  )
+  unless ENV['CI']
+    formatted_text_box(
+      [{
+        text: "Last Update: #{Time.now.strftime('%Y-%m-%d')}\n" \
+          "Prawn Version: #{Prawn::VERSION}\n#{git_commit}",
+        size: 12
+      }],
+      at: [390, cursor - 620]
+    )
+  end
 end

--- a/manual/graphics/helper.rb
+++ b/manual/graphics/helper.rb
@@ -20,6 +20,6 @@ Prawn::ManualBuilder::Example.generate(filename) do
   )
   stroke_axis(
     at: [140, 140], width: 200, height: cursor.to_i - 140,
-    step_length: 20, negative_axes_length: 40, color: 'FF00'
+    step_length: 20, negative_axes_length: 40, color: 'FF0000'
   )
 end

--- a/prawn.gemspec
+++ b/prawn.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.rubyforge_project = 'prawn'
   spec.licenses = %w[PRAWN GPL-2.0 GPL-3.0]
 
-  spec.add_dependency('ttfunk', '~> 1.4.0')
+  spec.add_dependency('ttfunk', '~> 1.5')
   spec.add_dependency('pdf-core', '~> 0.6.1')
 
   spec.add_development_dependency('pdf-inspector', '~> 1.2.1')

--- a/spec/manual_spec.rb
+++ b/spec/manual_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+require 'digest/sha2'
+
+# rubocop: disable Metrics/LineLength
+MANUAL_HASH =
+  case RUBY_ENGINE
+  when 'ruby'
+    '6aae613c48e7d9f7d4f57f026fe7c70eddff0bda8698ce7e8720bcd8c72ba1ca48f795aff153c39669e9282ee7350aeeabc39dd7051269cba95ae4a06e7437c8'
+  when 'jruby'
+    '483874116106a5f6276a1f196c6e72f9f823c613108512431d4e805ef5f03387d7a1a05a481540eebde8f86cba254f231d5b56872857c2e27900effccd2804f9'
+  end
+# rubocop: enable Metrics/LineLength
+
+RSpec.describe Prawn do
+  describe 'manual' do
+    # JRuby's zlib is a bit quirky. It sometimes produces different output to
+    # libzlib (used by MRI). It's still a proper deflate stream and can be
+    # decompressed just fine but for whatever reason compressin produses
+    # different output.
+    #
+    # See: https://github.com/jruby/jruby/issues/4244
+    it 'contains no unexpected changes' do
+      ENV['CI'] ||= 'true'
+
+      require File.expand_path(File.join(__dir__, %w[.. manual contents]))
+      s = prawn_manual_document.render
+
+      hash = Digest::SHA512.hexdigest(s)
+
+      expect(hash).to eq MANUAL_HASH
+    end
+  end
+end


### PR DESCRIPTION
This is a spec checks if the manual has unexpectedly changed. Addresses #681.

The code for manual generation is changed to make it easier to write a spec for it. Also the manual itself doesn't include the version information when built in the CI environment because it's expected to change and is not essential really that important for the actual manual content.

Blockers:
- [x] Inconsistent subset font names. prawnpdf/ttfunk#30 (merged)
- [x] Inconsistent pattern naming. #948 (merged)
- [x] Inconsistent colour serialization. #991 (merged)
- [X] Inconsistent line wrapping. #993 (merged)
- [x] Inconsistent stream compression. For some inputs JRuby produces different outputs to MRI. jruby/jruby#4244
- [x] Bump TTFunk dep
