### PR TITLE
Fix Yard-Rake incompatibility

### DIFF
--- a/prawn.gemspec
+++ b/prawn.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency('pdf-inspector', '~> 1.2.1')
   spec.add_development_dependency('yard')
   spec.add_development_dependency('rspec', '~> 3.0')
-  spec.add_development_dependency('rake')
+  spec.add_development_dependency('rake', '< 11.0')
   spec.add_development_dependency('simplecov')
   spec.add_development_dependency('prawn-manual_builder', ">= 0.2.0")
   spec.add_development_dependency('pdf-reader', '~>1.2')


### PR DESCRIPTION
At the moment Yard has some problems with the latest Rake. Let's not break everybody's code because of that.

Hopefully the incompatibility (lsegal/yard#946) is going to be resolved by the time of next Prawn release and we will loosen the requirement.