### PR TITLE
Don't mutate options hash in Document#start_new_page

### DIFF
--- a/lib/prawn/document.rb
+++ b/lib/prawn/document.rb
@@ -683,6 +683,8 @@ module Prawn
     end
 
     def apply_margin_options(options)
+      options = options.dup
+      
       if options[:margin]
         # Treat :margin as CSS shorthand with 1-4 values.
         margin = Array(options[:margin])

--- a/lib/prawn/document.rb
+++ b/lib/prawn/document.rb
@@ -692,11 +692,8 @@ module Prawn
                     0 => [] }[margin.length]
 
       sides.zip(positions).each do |side, pos|
-        state.page.margins[side] = margin[pos] if pos
-
-        # side-specific margin options take precedence over :margin
-        specific = options["#{side}_margin"]
-        state.page.margins[side] = specific if specific
+        new_margin = options["#{side}_margin"] || (margin[pos] if pos)
+        state.page.margins[side] = new_margin if new_margin
       end
     end
 

--- a/lib/prawn/document.rb
+++ b/lib/prawn/document.rb
@@ -684,7 +684,7 @@ module Prawn
 
     def apply_margin_options(options)
       options = options.dup
-      
+
       if options[:margin]
         # Treat :margin as CSS shorthand with 1-4 values.
         margin = Array(options[:margin])

--- a/lib/prawn/document.rb
+++ b/lib/prawn/document.rb
@@ -683,23 +683,20 @@ module Prawn
     end
 
     def apply_margin_options(options)
-      options = options.dup
+      sides = [:top, :right, :bottom, :left]
+      margin = Array(options[:margin])
 
-      if options[:margin]
-        # Treat :margin as CSS shorthand with 1-4 values.
-        margin = Array(options[:margin])
-        positions = { 4 => [0, 1, 2, 3], 3 => [0, 1, 2, 1],
-                      2 => [0, 1, 0, 1], 1 => [0, 0, 0, 0] }[margin.length]
+      # Treat :margin as CSS shorthand with 1-4 values.
+      positions = { 4 => [0, 1, 2, 3], 3 => [0, 1, 2, 1],
+                    2 => [0, 1, 0, 1], 1 => [0, 0, 0, 0],
+                    0 => [] }[margin.length]
 
-        [:top, :right, :bottom, :left].zip(positions).each do |p, i|
-          options[:"#{p}_margin"] ||= margin[i]
-        end
-      end
+      sides.zip(positions).each do |side, pos|
+        state.page.margins[side] = margin[pos] if pos
 
-      [:left, :right, :top, :bottom].each do |side|
-        if margin = options[:"#{side}_margin"]
-          state.page.margins[side] = margin
-        end
+        # side-specific margin options take precedence over :margin
+        specific = options["#{side}_margin"]
+        state.page.margins[side] = specific if specific
       end
     end
 

--- a/spec/document_spec.rb
+++ b/spec/document_spec.rb
@@ -154,7 +154,7 @@ end
 describe "Prawn::Document#start_new_page" do
   it "doesn't modify the options hash" do
     expect {
-      Prawn::Document.new.start_new_page({margin: 0}.freeze)
+      Prawn::Document.new.start_new_page({ margin: 0 }.freeze)
     }.not_to raise_error
   end
 end

--- a/spec/document_spec.rb
+++ b/spec/document_spec.rb
@@ -151,6 +151,14 @@ describe "Prawn::Document#float" do
   end
 end
 
+describe "Prawn::Document#start_new_page" do
+  it "doesn't modify the options hash" do
+    expect {
+      Prawn::Document.new.start_new_page({margin: 0}.freeze)
+    }.not_to raise_error
+  end
+end
+
 describe "The page_number method" do
   it "should be 1 for a new document" do
     pdf = Prawn::Document.new


### PR DESCRIPTION
Currently, usage like this:

```ruby
Prawn::Document.new.start_new_page({margin: 0}.freeze)
```

will raise:

```ruby
RuntimeError: can't modify frozen Hash
```

The mutation happens in `apply_margin_options`, and only when the `:margin` key is present. This PR refactors that method so that it doesn't need the options hash for temporary storage.

See more details here: https://github.com/prawnpdf/prawn/issues/962

