### PR TITLE
Adjust to allow not encodable chars;

### DIFF
--- a/lib/prawn/font/afm.rb
+++ b/lib/prawn/font/afm.rb
@@ -99,6 +99,7 @@ module Prawn
       # is replaced with a string in WinAnsi encoding.
       #
       def normalize_encoding(text)
+        text = remove_not_encodable_chars(text)
         text.encode("windows-1252")
       rescue ::Encoding::InvalidByteSequenceError,
              ::Encoding::UndefinedConversionError
@@ -141,6 +142,20 @@ module Prawn
       end
 
       private
+
+      # Remove characters that can not be encoded, replacing with "?"
+      def remove_not_encodable_chars(text)
+        new_text = ""
+        text.each_char do |char|
+          begin
+            new_char = char.encode("windows-1252")
+          rescue Exception
+            new_char = "?"
+          end
+          new_text += new_char
+        end
+        new_text
+      end
 
       def register(subset)
         font_dict = {


### PR DESCRIPTION
Instead of a error, i think that it's better to replace unknown chars with "?" ...

What you guys think?