### PR TITLE
implement respond_to_missing? method for Prawn::View module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## PrawnPDF master branch
 
+### Implemented `respond_to_missing?` method for Prawn::View
+
+Prawn::View objects now properly returns if it responds to a method or not.
+
+(Rodrigo Ra, [#971](https://github.com/prawnpdf/prawn/pull/971);
+
 ## PrawnPDF 2.1.0 -- 2016-02-29
 
 ### Added support for PNG images with indexed transparency

--- a/lib/prawn/view.rb
+++ b/lib/prawn/view.rb
@@ -69,6 +69,17 @@ module Prawn
       document.send(m, *a, &b)
     end
 
+    # Checks if +document+ respond_to +method_name+.
+    #
+    # This will correctly returns if Prawn::View object respond or not to a
+    # method:
+    #
+    #   view = Prawn::View.new
+    #   view.respond_to?(:cursor)  # => true
+    def respond_to_missing?(method_name, include_private = false)
+      document.respond_to?(method_name) || super
+    end
+
     # Syntactic sugar that uses +instance_eval+ under the hood to provide
     # a block-based DSL.
     #

--- a/spec/view_spec.rb
+++ b/spec/view_spec.rb
@@ -18,6 +18,14 @@ describe "Prawn::View" do
     view_object.some_delegated_method
   end
 
+  it "correctly returns if view object responds_to? methods" do
+    expect(view_object).to respond_to(:cursor)
+  end
+
+  it "returns false for methods the view object does not respond to" do
+    expect(view_object).to_not respond_to(:nonexistant_method)
+  end
+
   it "allows a block-like DSL via the update method" do
     doc = double("Document")
     allow(view_object).to receive(:document).and_return(doc)


### PR DESCRIPTION
Hey guys.

first thank you for this awesome gem.

I'm building a library on top of prawn that forwards all `Prawn::Document` methods to `@document` taking advantage of `Prawn::View` module.

My code look like this:

``` ruby

class PdfReport
  include Prawn::View
  # ....
end

report = PdfReport.new

# here is the problem
report.respond_to?(:text)  # => returns false
report.text('Hi there')    # => works
```

The `report` should return `true` since it forwards the `text` method to `@document`. More info: [https://robots.thoughtbot.com/always-define-respond-to-missing-when-overriding](https://robots.thoughtbot.com/always-define-respond-to-missing-when-overriding)

In this PR I implemented the `respond_to_missing` method for `Prawn::View` module.

Please review and LMK if you agree with this change.
And, however this is a simple change, it may break some codes. I think this should be included in a major version.

Thank you for reviewing it.
