### PR TITLE
Set stroke color correctly

### DIFF
--- a/lib/prawn/graphics/color.rb
+++ b/lib/prawn/graphics/color.rb
@@ -219,7 +219,7 @@ module Prawn
       end
 
       def write_stroke_color
-        write_color(current_fill_color, 'SCN')
+        write_color(current_stroke_color, 'SCN')
       end
 
       def write_color(color, operator)


### PR DESCRIPTION
Currently the `write_stroke_color` method actually sets the fill color, not the stroke color as it should.
