### PR TITLE
Raise exception for unrecognized join styles

### DIFF
--- a/lib/prawn/errors.rb
+++ b/lib/prawn/errors.rb
@@ -75,5 +75,8 @@ module Prawn
     # Raised when unrecognized content is provided for a table cell.
     #
     UnrecognizedTableContent = Class.new(StandardError)
+
+    # This error is raised when an incompatible join style is specified
+    InvalidJoinStyle = Class.new(StandardError)
   end
 end

--- a/lib/prawn/graphics/join_style.rb
+++ b/lib/prawn/graphics/join_style.rb
@@ -25,6 +25,11 @@ module Prawn
 
         self.current_join_style = style
 
+        unless JOIN_STYLES.key?(current_join_style)
+          raise Prawn::Errors::InvalidJoinStyle,
+                "#{style} is not a recognized join style. Valid styles are #{JOIN_STYLES.keys.join(", ")}"
+        end
+
         write_stroke_join_style
       end
 

--- a/spec/stroke_styles_spec.rb
+++ b/spec/stroke_styles_spec.rb
@@ -97,6 +97,12 @@ describe "Join styles" do
     expect(join_styles.join_style_count).to eq(2)
     expect(join_styles.join_style).to eq(1)
   end
+
+  context "with invalid arguments" do
+    it "should raise an exception" do
+      expect{ @pdf.join_style(:mitre) }.to raise_error(Prawn::Errors::InvalidJoinStyle)
+    end
+  end
 end
 
 describe "Dashes" do


### PR DESCRIPTION
Hey, guys. I wasn't sure how you'd want to handle #988, raise, coalesce to :miter, &c. Right now this raises, but I'm happy to make the change if there's some way you'd rather see this done. 

Cheers!
