### PR TITLE
Remove unnecessary color methods

### DIFF
--- a/lib/prawn/graphics/color.rb
+++ b/lib/prawn/graphics/color.rb
@@ -215,14 +215,6 @@ module Prawn
         graphic_state.stroke_color = color
       end
 
-      def write_fill_color
-        write_color(current_fill_color, 'scn')
-      end
-
-      def write_stroke_color
-        write_color(current_fill_color, 'SCN')
-      end
-
       def write_color(color, operator)
         renderer.add_content "#{color} #{operator}"
       end


### PR DESCRIPTION
Picking up stale work from #978 

As noted in that PR, `write_fill_color` and `write_stroke_color` are private methods aren't used anywhere in this project. Removing these because of that and then we can close that PR as well. 

Didn't add any specs, we just use the lower-level `write_color` inside of `set_color`. We do test the public [`stroke_color`](https://github.com/prawnpdf/prawn/blob/master/spec/prawn/graphics_spec.rb#L227) and [`fill_color`](https://github.com/prawnpdf/prawn/blob/master/spec/prawn/graphics_spec.rb#L234) methods so we know that color assignment hasn't been affected.