### PR TITLE
Exposed current_column in ColumnBox

### DIFF
--- a/lib/prawn/document/column_box.rb
+++ b/lib/prawn/document/column_box.rb
@@ -50,6 +50,8 @@ module Prawn
     # work.
     #
     class ColumnBox < BoundingBox
+      attr_reader :current_column
+
       def initialize(document, parent, point, options = {}) #:nodoc:
         super
         @columns = options[:columns] || 3


### PR DESCRIPTION
I need this for the following use-case:

`pdf.bounds.move_past_bottom if pdf.bounds.current_column == 0`

