### PR TITLE
README: Use SVG badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Prawn: Fast, Nimble PDF Generation For Ruby
 
-[![Gem Version](https://badge.fury.io/rb/prawn.png)](http://badge.fury.io/rb/prawn)
+[![Gem Version](https://badge.fury.io/rb/prawn.svg)](http://badge.fury.io/rb/prawn)
 [![Build Status](https://api.travis-ci.org/prawnpdf/prawn.svg?branch=master)](http://travis-ci.org/prawnpdf/prawn)
 [![Code Climate](https://codeclimate.com/github/prawnpdf/prawn/badges/gpa.svg)](https://codeclimate.com/github/prawnpdf/prawn)
-![Maintained: yes](https://img.shields.io/badge/maintained-yes-brightgreen.png)
+![Maintained: yes](https://img.shields.io/badge/maintained-yes-brightgreen.svg)
 
 Prawn is a pure Ruby PDF generation library that provides a lot of great
 functionality while trying to remain simple and reasonably performant. Here are


### PR DESCRIPTION
This PR makes all **build badges** in the README **use SVG**, which makes it easier to read.