### PR TITLE
Improve color regex

### DIFF
--- a/lib/prawn/graphics/color.rb
+++ b/lib/prawn/graphics/color.rb
@@ -94,7 +94,7 @@ module Prawn
       def color_type(color)
         case color
         when String
-          if color =~ /\A[0-F]{6}\z/i
+          if color =~ /\A[0-9a-fA-F]{6}\z/
             :RGB
           else
             raise ArgumentError, "Unknown type of color: #{color.inspect}"

--- a/spec/prawn/document_grid_spec.rb
+++ b/spec/prawn/document_grid_spec.rb
@@ -26,6 +26,7 @@ describe Prawn::Document do
       let(:num_columns) { 5 }
       let(:num_rows) { 8 }
       let(:gutter) { 10.0 }
+
       before do
         pdf.define_grid(
           columns: num_columns,

--- a/spec/prawn/graphics_spec.rb
+++ b/spec/prawn/graphics_spec.rb
@@ -245,6 +245,10 @@ describe Prawn::Graphics do
       expect { pdf.fill_color 'zcff00' }.to raise_error(ArgumentError)
     end
 
+    it 'raises an error for a color string with invalid characters' do
+      expect { pdf.fill_color 'f0f0f?' }.to raise_error(ArgumentError)
+    end
+
     it 'resets the colors on each new page if they have been defined' do
       pdf.fill_color 'ccff00'
 

--- a/spec/prawn/stamp_spec.rb
+++ b/spec/prawn/stamp_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe Prawn::Stamp do
   describe 'create_stamp before any page is added' do
     let(:pdf) { Prawn::Document.new(skip_page_creation: true) }
+
     it 'works with the font class' do
       # If anything goes wrong, Prawn::Errors::NotOnPage will be raised
       pdf.create_stamp('my_stamp') do

--- a/spec/prawn/text_spec.rb
+++ b/spec/prawn/text_spec.rb
@@ -66,7 +66,7 @@ describe Prawn::Text do
       pdf.text ' '
       text = PDF::Inspector::Text.analyze(pdf.render)
       # If anything is rendered to the page, it should be whitespace.
-      text.strings.each { |str| expect(str).to match(/\A\s*\z/) }
+      expect(text.strings).to all match(/\A\s*\z/)
     end
 
     it 'ignores call when string is nil' do


### PR DESCRIPTION
The [current color regex](https://github.com/prawnpdf/prawn/blob/master/lib/prawn/graphics/color.rb#L97) uses `[0-F]` which allows all characters with a char code between 48-70. This would allow a user to pass in any of ``: ; < = > ? ` `` into their hex.