### PR TITLE
Fixed wrong arguments for Prawn::View on respond_to_missing? call.

### DIFF
--- a/lib/prawn/view.rb
+++ b/lib/prawn/view.rb
@@ -67,8 +67,8 @@ module Prawn
       document.send(m, *a, &b)
     end
 
-    def respond_to_missing?
-      document.respond_to?(m)
+    def respond_to_missing?(method_name, include_private = false)
+      document.respond_to?(method_name, include_private)
     end
 
     # Syntactic sugar that uses +instance_eval+ under the hood to provide


### PR DESCRIPTION
Fix error:

ArgumentError: wrong number of arguments (given 2, expected 0)
prawn/view.rb:70:in `respond_to_missing?'

on ruby 2.3.1