### PR TITLE
Remove superfluous pdf-core requires

### DIFF
--- a/lib/prawn/security.rb
+++ b/lib/prawn/security.rb
@@ -6,8 +6,6 @@
 
 require 'digest/md5'
 
-require 'pdf/core/byte_string'
-
 require_relative 'security/arcfour'
 
 module Prawn

--- a/lib/prawn/text.rb
+++ b/lib/prawn/text.rb
@@ -6,8 +6,6 @@
 
 require 'zlib'
 
-require 'pdf/core/text'
-
 require_relative 'text/formatted'
 require_relative 'text/box'
 


### PR DESCRIPTION
We require `pdf/core` in `lib/prawn.rb`, and were requiring
`pdf/core/text` and `pdf/core/byte_string` in `lib/prawn/text.rb` and
`lib/prawn/security.rb` respectively.

Those second requires were causing double-loads and warnings under
certain circumstances because of a bug in Ruby
(https://bugs.ruby-lang.org/issues/10222).

We use objects under the `PDF::Core` namespace freely throught Prawn and
those two requires seem to be both out of character (in the rest of the
codebase it's assumed that `PDF::Core` has already been required), and
overkill (`pdf-core`'s codebase itself generally assumes that all the
objects under its namespace are already required).

I think it's safe to just remove these requires deeper into `pdf-core` -
it makes these double-load problems go away and is more in keeping with
the way the code is structured.

There is the larger question of the architecture of `pdf-core` – whether
it's a grab-bag of objects and modules to be picked-and-chosen from, or
a single entity that should be used complete. I don't think there's a
significant impact to that process from this approach to removing the
warnings.

Fixes #1024 
Obsoletes #1026 