### PR TITLE
Fix reported Rubocop warnings

### DIFF
--- a/spec/prawn/document_grid_spec.rb
+++ b/spec/prawn/document_grid_spec.rb
@@ -26,6 +26,7 @@ describe Prawn::Document do
       let(:num_columns) { 5 }
       let(:num_rows) { 8 }
       let(:gutter) { 10.0 }
+
       before do
         pdf.define_grid(
           columns: num_columns,

--- a/spec/prawn/stamp_spec.rb
+++ b/spec/prawn/stamp_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe Prawn::Stamp do
   describe 'create_stamp before any page is added' do
     let(:pdf) { Prawn::Document.new(skip_page_creation: true) }
+
     it 'works with the font class' do
       # If anything goes wrong, Prawn::Errors::NotOnPage will be raised
       pdf.create_stamp('my_stamp') do

--- a/spec/prawn/text_spec.rb
+++ b/spec/prawn/text_spec.rb
@@ -66,7 +66,7 @@ describe Prawn::Text do
       pdf.text ' '
       text = PDF::Inspector::Text.analyze(pdf.render)
       # If anything is rendered to the page, it should be whitespace.
-      text.strings.each { |str| expect(str).to match(/\A\s*\z/) }
+      expect(text.strings).to all(match(/\A\s*\z/))
     end
 
     it 'ignores call when string is nil' do


### PR DESCRIPTION
There were two trivial whitespace issues and one would-prefer-this-approach issue in the specs. This fixes all three