### PR TITLE
resolves #1022 provide more information about missing font

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## PrawnPDF master branch
 
+### Unknown font message
+
+Provide more detail in error message about unknown font.
+
+(Dan Allen, [#1022](https://github.com/prawnpdf/prawn/pull/1022))
+
 ## PrawnPDF 2.2.2
 
 Relax pdf-inspector depspec.

--- a/lib/prawn/font/afm.rb
+++ b/lib/prawn/font/afm.rb
@@ -49,8 +49,10 @@ module Prawn
       end
 
       def initialize(document, name, options = {}) #:nodoc:
+        name ||= options[:family]
         unless BUILT_INS.include?(name)
-          raise Prawn::Errors::UnknownFont, "#{name} is not a known font."
+          raise Prawn::Errors::UnknownFont,
+            "#{name} (#{options[:style] || 'normal'}) is not a known font."
         end
 
         super

--- a/spec/prawn/font_spec.rb
+++ b/spec/prawn/font_spec.rb
@@ -69,6 +69,14 @@ describe Prawn::Font do
       end
     end
 
+    it 'reports missing font with style' do
+      expect do
+        pdf.font('Nada', style: :bold) do
+          pdf.width_of('hello')
+        end
+      end.to raise_error(Prawn::Errors::UnknownFont, /Nada \(bold\)/)
+    end
+
     it 'calculates styled widths correctly using TTFs' do
       pdf.font_families.update(
         'DejaVu Sans' => {


### PR DESCRIPTION
- when an afm font is missing, provide more information to the user
- look for font name in family option in case of missing TTF