### PR TITLE
Add data/images to gem package

### DIFF
--- a/prawn.gemspec
+++ b/prawn.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
     spec.signing_key = File.expand_path('~/.ssh/gem-private_key.pem')
   end
 
-  spec.files = Dir.glob('{examples,lib,spec,manual}/**/**/*') +
+  spec.files = Dir.glob('{lib,spec,manual,data/images}/**/**/*') +
     Dir.glob('data/fonts/{MustRead.html,*.afm}') +
     [
       'Rakefile', 'prawn.gemspec', 'Gemfile',


### PR DESCRIPTION
Images from `data/images` used in `prawn-table` specs.  (https://github.com/prawnpdf/prawn-table/blob/master/spec/cell_spec.rb#L595) and losted in latest release