### PR TITLE
Check if image responds to :read

### DIFF
--- a/lib/prawn/images.rb
+++ b/lib/prawn/images.rb
@@ -137,11 +137,11 @@ module Prawn
 
     def verify_and_open_image(io_or_path)
       # File or IO
-      if io_or_path.respond_to?(:rewind)
+      if io_or_path.respond_to?(:read)
         io = io_or_path
         # Rewind if the object we're passed is an IO, so that multiple embeds of
         # the same IO object will work
-        io.rewind
+        io.rewind if io.respond_to?(:rewind)
         # read the file as binary so the size is calculated correctly
         # guard binmode because some objects acting io-like don't implement it
         io.binmode if io.respond_to?(:binmode)


### PR DESCRIPTION
Hi! This update allows to source image from "alternate" file implementations like `CarrierWave::Storage::Fog::File` and `CarrierWave::SanitizedFile`.

Very convenient when you're working with images stored remotely.