### PR TITLE
Clean up document state before raising Prawn::Errors::CannotFit

### DIFF
--- a/lib/prawn/text/formatted/line_wrap.rb
+++ b/lib/prawn/text/formatted/line_wrap.rb
@@ -22,6 +22,11 @@ module Prawn
         # The number of spaces in the last wrapped line
         attr_reader :space_count
 
+        # This is set to true when there is not enough space.
+        # We then clean up the document state before raising
+        # the CannotFit error.
+        attr_accessor :cannot_fit
+
         # Whether this line is the last line in the paragraph
         def paragraph_finished?
           @newline_encountered || next_string_newline? || @arranger.finished?
@@ -218,6 +223,7 @@ module Prawn
 
           @newline_encountered = false
           @line_full = false
+          @cannot_fit = false
         end
 
         def fragment_finished(fragment)
@@ -242,7 +248,8 @@ module Prawn
             fragment.slice(@fragment_output.length..fragment.length)
           if line_finished? && line_empty? && @fragment_output.empty? &&
               !fragment.strip.empty?
-            raise Prawn::Errors::CannotFit
+            @cannot_fit = true
+            return
           end
           @arranger.update_last_string(
             @fragment_output,

--- a/spec/prawn/text/formatted/line_wrap_spec.rb
+++ b/spec/prawn/text/formatted/line_wrap_spec.rb
@@ -36,6 +36,7 @@ describe Prawn::Text::Formatted::LineWrap do
       document: pdf
     )
     expect(line).to be_empty
+    expect(line_wrap.cannot_fit).to eq false
   end
 
   it 'tokenizes a string using the scan_pattern' do
@@ -76,20 +77,20 @@ describe Prawn::Text::Formatted::LineWrap do
         document: pdf
       )
       expect(string).to eq('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
+      expect(line_wrap.cannot_fit).to eq false
     end
-    it 'raise_errors CannotFit if a too-small width is given' do
+    it 'sets cannot_fit to true if a too-small width is given' do
       array = [
         { text: ' hello world, ' },
         { text: 'goodbye  ', style: [:bold] }
       ]
       arranger.format_array = array
-      expect do
-        line_wrap.wrap_line(
-          arranger: arranger,
-          width: 1,
-          document: pdf
-        )
-      end.to raise_error(Prawn::Errors::CannotFit)
+      line_wrap.wrap_line(
+        arranger: arranger,
+        width: 1,
+        document: pdf
+      )
+      expect(line_wrap.cannot_fit).to eq true
     end
 
     it 'breaks on space' do
@@ -101,6 +102,7 @@ describe Prawn::Text::Formatted::LineWrap do
         document: pdf
       )
       expect(string).to eq('hello')
+      expect(line_wrap.cannot_fit).to eq false
     end
 
     it 'breaks on zero-width space' do


### PR DESCRIPTION
Fixes a strange `character_spacing` issue that I was experiencing in #1073. All the specs are passing, and this change fixes my POC, but I might have missed something.