### PR TITLE
Fix transformation stack not being popped

### DIFF
--- a/lib/prawn/document/internals.rb
+++ b/lib/prawn/document/internals.rb
@@ -31,6 +31,7 @@ module Prawn
       def save_graphics_state(state = nil, &block)
         save_transformation_stack
         renderer.save_graphics_state(state, &block)
+        restore_transformation_stack if block
       end
 
       def restore_graphics_state

--- a/spec/prawn/graphics_spec.rb
+++ b/spec/prawn/graphics_spec.rb
@@ -670,6 +670,36 @@ describe Prawn::Graphics do
         expect(new_state.public_send(attr)).to_not equal(pdf.graphic_state.public_send(attr))
       end
     end
+
+    it 'saves the transformation stack on graphics state save' do
+      allow(pdf).to receive(:save_transformation_stack)
+      allow(pdf).to receive(:restore_transformation_stack)
+
+      pdf.save_graphics_state
+
+      expect(pdf).to have_received(:save_transformation_stack)
+      expect(pdf).to_not have_received(:restore_transformation_stack)
+    end
+
+    it 'saves and restores the transformation stack when save graphics state ' \
+      'used in block form' do
+      allow(pdf).to receive(:save_transformation_stack)
+      allow(pdf).to receive(:restore_transformation_stack)
+
+      pdf.save_graphics_state do
+      end
+
+      expect(pdf).to have_received(:save_transformation_stack)
+      expect(pdf).to have_received(:restore_transformation_stack)
+    end
+
+    it 'restores the transformation stack on graphics state restore' do
+      allow(pdf).to receive(:restore_transformation_stack)
+
+      pdf.restore_graphics_state
+
+      expect(pdf).to have_received(:restore_transformation_stack)
+    end
   end
 
   describe 'When using transformation matrix' do


### PR DESCRIPTION
save_graphics_state can take a block form which automatically restores
the graphics state when the block completes.  However, the
transformation stack was not being popped in this case.

This fix pops the transformation stack after save_graphics_state is
used in block form.