### PR TITLE
Add documentation about document configuration

### DIFF
--- a/lib/prawn/view.rb
+++ b/lib/prawn/view.rb
@@ -11,6 +11,12 @@ module Prawn
   #     class Greeter
   #       include Prawn::View
   #
+  #       # Optional override: allows you to set document options or even use
+  #       # a custom document class
+  #       def document
+  #         @document ||= Prawn::Document.new(page_size: 'A4')
+  #       end
+  #
   #       def initialize(name)
   #         @name = name
   #       end


### PR DESCRIPTION
Echoes https://github.com/prawnpdf/prawn/issues/802.

I had seen the greeter example in the docs but missed the comment on the document method. I thought it might be helpful to include it in the example as well.