### PR TITLE
Fix character_spacing effect on text width calculation.

### DIFF
--- a/lib/prawn/font_metric_cache.rb
+++ b/lib/prawn/font_metric_cache.rb
@@ -37,9 +37,12 @@ module Prawn
 
       length = @cache[key]
 
-      length +
-        (@document.character_spacing *
-         @document.font.character_count(encoded_string))
+      character_count = @document.font.character_count(encoded_string)
+      if character_count.positive?
+        length += @document.character_spacing * (character_count - 1)
+      end
+
+      length
     end
   end
 end

--- a/spec/prawn/font_spec.rb
+++ b/spec/prawn/font_spec.rb
@@ -41,7 +41,7 @@ describe Prawn::Font do
     it 'takes character spacing into account' do
       original_width = pdf.width_of('hello world')
       pdf.character_spacing(7) do
-        expect(pdf.width_of('hello world')).to eq(original_width + 11 * 7)
+        expect(pdf.width_of('hello world')).to eq(original_width + 10 * 7)
       end
     end
 

--- a/spec/prawn/text_spacing_spec.rb
+++ b/spec/prawn/text_spacing_spec.rb
@@ -52,8 +52,8 @@ describe Prawn::Text do
       end
 
       pdf.character_spacing(10) do
-        # the new width should include seven 10-pt character spaces.
-        expect(pdf.width_of(str)).to be_within(0.001).of(raw_width + (10 * 7))
+        # the new width should include six 10-pt character spaces.
+        expect(pdf.width_of(str)).to be_within(0.001).of(raw_width + (10 * 6))
       end
     end
   end

--- a/spec/prawn_manual_spec.rb
+++ b/spec/prawn_manual_spec.rb
@@ -6,11 +6,11 @@ require 'digest/sha2'
 MANUAL_HASH =
   case RUBY_ENGINE
   when 'ruby'
-    'cfc8c0335d96952ec9e06e8509ba6e80af20e4ff5e8a75143f1e78ca36ddb56f'\
-    'f861dd285c65b5b823845ae2b4d7a4f9d538c5fbf376f50c89bb87b7dd3c6b51'
+    '0b6348280c2bd694d32e687bbe8e04d1659f09624ab9787186a933f4e1274382'\
+    'a7d8eda06dd168da955a39d34ebafbf5a1c20a62f2a2a34281e4732beaba47a0'
   when 'jruby'
-    '30b10f71981d3dfbc087f18fe7aa98e67aaeaf5c0d97e30896b2edbda8de39e1'\
-    '1031f13905ec093cbc1afe4e6e00ef22d9dcf8a27b8febf76f02120c2ebf187a'
+    '1df4c83bc2dadb6368b755dfbed87f2730243023c8e7ceb8dc283eb9a485bf89'\
+    '644baf93e6e2f016f7c990a47dd001080904f0c60066025ef2204769b906d173'
   end
 
 RSpec.describe Prawn do


### PR DESCRIPTION
The value of `character_spacing` should be added to the length of the original string `(string.length - 1)` times instead of `string.length` times, since character_spacing only increases the space between
characters.

Incorrect text width calculation was causing `:center` and `:right` aligned text to be incorrectly positioned when using `character_spacing != 0` (see screenshots).

Note: this was briefly noticed/discussed in https://github.com/prawnpdf/prawn/issues/253.

**Screenshots - current behavior:**

| Alignment | Screenshot |
| --- | --- |
| left | <kbd><img src="https://user-images.githubusercontent.com/32585/57630052-328e1b80-759d-11e9-81fa-3735af8cbbf6.png"/></kbd> |
| center | <kbd><img src="https://user-images.githubusercontent.com/32585/57630090-40dc3780-759d-11e9-9bf4-ab9191c9d561.png"/></kbd> |
| right |<kbd><img src="https://user-images.githubusercontent.com/32585/57630112-489bdc00-759d-11e9-86ef-ac20b1548305.png"/></kbd> |

**Screenshots - with this patch:**

| Alignment | Screenshot |
| --- | --- |
| left | <kbd><img src="https://user-images.githubusercontent.com/32585/57630590-2ce50580-759e-11e9-85e9-e86b8555fc3b.png"/></kbd> |
| center | <kbd><img src="https://user-images.githubusercontent.com/32585/57630599-31112300-759e-11e9-976a-881bffdb1f59.png"/></kbd> |
| right |<kbd><img src="https://user-images.githubusercontent.com/32585/57630603-340c1380-759e-11e9-8d08-3dc31d139c99.png"/></kbd> |

