### PR TITLE
Look for glyph in correct font when fallback fonts are enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## PrawnPDF master branch
 
+## Unreleased
+
+### Look for glyph in correct font
+
+Take the font style into account when looking for a glyph and fallback fonts are enabled.
+
+(Dan Allen, [#1147](https://github.com/prawnpdf/prawn/issues/1147))
+
 ## PrawnPDF 2.4.0
 
 ### Added support for Ruby 3

--- a/lib/prawn/text/formatted/box.rb
+++ b/lib/prawn/text/formatted/box.rb
@@ -419,6 +419,8 @@ module Prawn
 
           original_font = @document.font.family
           fragment_font = hash[:font] || original_font
+          fragment_font_options =
+            (fragment_font_style = font_style(hash[:styles])) == :normal ? {} : { style: fragment_font_style }
 
           fallback_fonts = @fallback_fonts.dup
           # always default back to the current font if the glyph is missing from
@@ -431,7 +433,8 @@ module Prawn
                 find_font_for_this_glyph(
                   char,
                   fragment_font,
-                  fallback_fonts.dup
+                  fallback_fonts.dup,
+                  fragment_font_options
                 ),
                 char
               ]
@@ -448,12 +451,26 @@ module Prawn
           form_fragments_from_like_font_glyph_pairs(font_glyph_pairs, hash)
         end
 
-        def find_font_for_this_glyph(char, current_font, fallback_fonts)
-          @document.font(current_font)
+        def font_style(styles)
+          if styles
+            if styles.include?(:bold)
+              styles.include?(:italic) ? :bold_italic : :bold
+            elsif styles.include?(:italic)
+              :italic
+            else
+              :normal
+            end
+          else
+            :normal
+          end
+        end
+
+        def find_font_for_this_glyph(char, current_font, fallback_fonts, current_font_options = {})
+          @document.font(current_font, current_font_options)
           if fallback_fonts.empty? || @document.font.glyph_present?(char)
             current_font
           else
-            find_font_for_this_glyph(char, fallback_fonts.shift, fallback_fonts)
+            find_font_for_this_glyph(char, fallback_fonts.shift, fallback_fonts, current_font_options)
           end
         end
 

--- a/spec/prawn/text/formatted/box_spec.rb
+++ b/spec/prawn/text/formatted/box_spec.rb
@@ -218,6 +218,32 @@ describe Prawn::Text::Formatted::Box do
       expect(text.strings[2]).to eq('再见')
       expect(text.strings[3]).to eq('goodbye')
     end
+
+    it 'considers style when looking for glyph in font' do
+      dustismo_file = "#{Prawn::DATADIR}/fonts/Dustismo_Roman.ttf"
+      dejavu_sans_file = "#{Prawn::DATADIR}/fonts/DejaVuSans.ttf"
+      dejavu_sans_bold_file = "#{Prawn::DATADIR}/fonts/DejaVuSans-Bold.ttf"
+
+      pdf.font_families['Dustismo'] = {
+        normal: { file: dustismo_file },
+        bold: { file: dejavu_sans_bold_file }
+      }
+
+      pdf.font_families['Fallback'] = {
+        normal: { file: dejavu_sans_file },
+        bold: { file: dejavu_sans_file }
+      }
+
+      formatted_text = [{ text: ?\u203b, styles: [:bold], font: 'Dustismo' }]
+      pdf.formatted_text_box(formatted_text, fallback_fonts: ['Fallback'])
+
+      text = PDF::Inspector::Text.analyze(pdf.render)
+
+      fonts_used = text.font_settings.map { |e| e[:name] }
+      expect(fonts_used.length).to eq(1)
+      expect(fonts_used[0].to_s).to match(/DejaVuSans-Bold/)
+      expect(text.strings[0]).to eq(?\u203b)
+    end
   end
 
   describe 'Text::Formatted::Box' do


### PR DESCRIPTION
note that this patch adds an optional fourth argument to find_font_for_this_glyph

resolves #1147