### PR TITLE
Fix font metric caching on Ruby 2.7+

### DIFF
--- a/lib/prawn/font.rb
+++ b/lib/prawn/font.rb
@@ -413,7 +413,7 @@ module Prawn
     # Prawn::Table::Text#styled_with_of_single_character)
     #
     def hash #:nodoc:
-      [self.class, name, family, size].hash
+      [self.class, name, family].hash
     end
 
     # Compliments the #hash implementation above

--- a/lib/prawn/font_metric_cache.rb
+++ b/lib/prawn/font_metric_cache.rb
@@ -13,7 +13,7 @@ module Prawn
   #
   # @private
   class FontMetricCache
-    CacheEntry = Struct.new(:font, :options, :string)
+    CacheEntry = Struct.new(:font, :font_size, :options, :string)
 
     def initialize(document)
       @document = document
@@ -32,7 +32,7 @@ module Prawn
 
       encoded_string = f.normalize_encoding(string)
 
-      key = CacheEntry.new(f, options, encoded_string)
+      key = CacheEntry.new(f, @document.font_size, options, encoded_string)
 
       @cache[key] ||= f.compute_width_of(encoded_string, options)
 

--- a/spec/prawn/font_metric_cache_spec.rb
+++ b/spec/prawn/font_metric_cache_spec.rb
@@ -51,4 +51,20 @@ describe Prawn::FontMetricCache do
     expect(font_metric_cache.instance_variable_get(:@cache).entries.size)
       .to eq 2
   end
+
+  it 'does not use the cached width of a different font size' do
+    pdf = Prawn::Document.new do
+      font('Helvetica', size: 42, style: :bold) do
+        text 'First part M'
+      end
+      font('Helvetica', size: 12) do
+        text '<strong>First part M</strong> second part', inline_format: true
+        text '<strong>First part W</strong> second part.', inline_format: true
+      end
+    end
+
+    x_positions = PDF::Inspector::Text.analyze(pdf.render).positions.map(&:first)
+
+    expect(x_positions[2]).to be_within(3.0).of(x_positions[4])
+  end
 end


### PR DESCRIPTION
This is a proposed fix for #1140 

Since font size is mutable and derived from Prawn::Document, I think it makes the most sense to explicitly include it in the cache key. 