### PR TITLE
Update ruby_version requirement to allow ruby 3.0

### DIFF
--- a/prawn.gemspec
+++ b/prawn.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
       '.yardopts'
     ]
   spec.require_path = 'lib'
-  spec.required_ruby_version = '~> 2.5'
+  spec.required_ruby_version = '>= 2.5'
   spec.required_rubygems_version = '>= 1.3.6'
 
   spec.authors = [


### PR DESCRIPTION
Ruby master branch recently bumped the version number to 3.0: https://github.com/ruby/ruby/commit/21c62fb670b1646c5051a46d29081523cd782f11

This is breaking our ruby-head CI.