### PR TITLE
replace require_relative in spec helper

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,7 +9,7 @@ if ENV['COVERAGE']
   end
 end
 
-require_relative '../lib/prawn'
+require 'prawn'
 
 Prawn.debug = true
 Prawn::Fonts::AFM.hide_m17n_warning = true


### PR DESCRIPTION
Hi,
according to the following document,
https://github.com/rubocop-hq/packaging-style-guide#using-require-relative-from-test-to-lib
it is considered a good practive to not use require_relative to code in lib from the spec.
This would help running the tests of the gem in distributions providing packaged versions of prawn, like Debian.
Thanks in advance for considering this change.