### PR TITLE
Fix transformation matrix serialization

### DIFF
--- a/lib/prawn/graphics/transformation.rb
+++ b/lib/prawn/graphics/transformation.rb
@@ -149,11 +149,11 @@ module Prawn
           raise ArgumentError,
             'Transformation matrix must have exacty 6 elements'
         end
-        values = matrix.map { |x| x.to_f.round(5) }.join(' ')
         save_graphics_state if block_given?
 
         add_to_transformation_stack(*matrix)
 
+        values = PDF::Core.real_params(matrix)
         renderer.add_content "#{values} cm"
         if block_given?
           yield

--- a/spec/prawn/graphics_spec.rb
+++ b/spec/prawn/graphics_spec.rb
@@ -707,6 +707,16 @@ describe Prawn::Graphics do
       expect(pdf).to have_received(:restore_graphics_state).with(no_args)
         .ordered
     end
+
+    it 'properly serializes the matrix', issue: 1178 do
+      pdf.transformation_matrix 1, 0, 0, 1, 0.0, 1.8977874316715393e-05
+      rendered_document = pdf.render
+
+      expect(rendered_document).to_not include('2.0e-05')
+
+      matrices = PDF::Inspector::Graphics::Matrix.analyze(rendered_document)
+      expect(matrices.matrices).to eq([[1, 0, 0, 1, 0.0, 0.00002]])
+    end
   end
 
   describe 'When using transformations shortcuts' do

--- a/spec/prawn_manual_spec.rb
+++ b/spec/prawn_manual_spec.rb
@@ -6,11 +6,11 @@ require 'digest/sha2'
 MANUAL_HASH =
   case RUBY_ENGINE
   when 'ruby'
-    '59c0acffd3c75588de2f1df60bb6af857a7c8b50c9e551bdc930af32e6a4eee6'\
-    '061561812a17384a5345f06ff770d7022d1f1d1f1da7d9ac0d01e805532c1287'
+    'bcba28d39698ac349a626e1bc3d6a354d20bd7da340190bc8843cec1be3caefb'\
+    '88fc9591edba9cf21d7f2e08faf40a40d269b26b5c5ac6afb8c7fb61cba8c544'
   when 'jruby'
-    'f4e45385bfebe797d97c46046ea585434d45de3e70e7f6a2f9d77445daadf5be'\
-    'aaa3c6bf52664280334356e01bfa275b0184a7bb18d2f2499286b00c99df2741'
+    'fc28a61d956326664aba40e2fa41bda2ffc112ce95c6b689be01f5e909038b09'\
+    '6b93f6445cf4b324b2d13dc794edc88ee2116db556dd6ae5c7d350e963d1f45a'
   end
 
 RSpec.describe Prawn do


### PR DESCRIPTION
We have proper number serialization routines provide by PDF::Core but we didn't use them in this case.

Fixes #1178 