### PR TITLE
Add TruffleRuby in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
           - "3.0.0"
           - ruby-head
           - jruby-9.2
+          - truffleruby-head
     steps:
       - uses: actions/checkout@v1
       - name: Set up Ruby

--- a/spec/prawn_manual_spec.rb
+++ b/spec/prawn_manual_spec.rb
@@ -5,7 +5,7 @@ require 'digest/sha2'
 
 MANUAL_HASH =
   case RUBY_ENGINE
-  when 'ruby'
+  when 'ruby', 'truffleruby'
     'de26db4fe63e024231c0a332203b41305103d877b584a2e98dbd0561bced39f2c066b5c0c96a4686e586a9deb347f099dac4c646446dadb1521a7d4a674ae6fb'
   when 'jruby'
     'c002ffaf6fe4b2877bd2244735e99c04a4b28b06bc365f343411af052d491660e0d858a956a757ad15a4ed16d6808fc8d726fd683d524f5a3f7c0c8b9566b683'


### PR DESCRIPTION
I marked as a Draft PR because there is some spec failing with OutOfMemoryError on TruffleRuby.