### PR TITLE
Reduce memory allocations and enhance performance

### DIFF
--- a/lib/prawn/font.rb
+++ b/lib/prawn/font.rb
@@ -12,6 +12,8 @@ module Prawn
   class Document
     # @group Stable API
 
+    DEFAULT_OPTS = {}.freeze
+
     # Without arguments, this returns the currently selected font. Otherwise,
     # it sets the current font. When a block is used, the font is applied
     # transactionally and is rolled back when the block exits.
@@ -45,7 +47,7 @@ module Prawn
     # font files.
     # See font_families for more information.
     #
-    def font(name = nil, options = {})
+    def font(name = nil, options = DEFAULT_OPTS)
       return((defined?(@font) && @font) || font('Helvetica')) if name.nil?
 
       if state.pages.empty? && !state.page.in_stamp_stream?
@@ -336,6 +338,7 @@ module Prawn
       @identifier = generate_unique_id
 
       @references = {}
+      @subset_name_cache = {}
     end
 
     # The size of the font ascender in PDF points
@@ -394,13 +397,11 @@ module Prawn
     #
     def add_to_current_page(subset)
       @references[subset] ||= register(subset)
-      @document.state.page.fonts.merge!(
-        identifier_for(subset) => @references[subset]
-      )
+      @document.state.page.fonts[identifier_for(subset)] = @references[subset]
     end
 
     def identifier_for(subset) #:nodoc:
-      "#{@identifier}.#{subset}".to_sym
+      @subset_name_cache[subset] ||= "#{@identifier}.#{subset}".to_sym
     end
 
     def inspect #:nodoc:


### PR DESCRIPTION
# Introduction

I regularly run the [HexaPDF benchmarks](https://hexapdf.gettalong.org/documentation/benchmarks/) to verify that HexaPDF gets only faster. Two benchmarks, "raw_text" and "line_wrapping" also use Prawn to evaluate the relative performance.

When updating to the latest releases I noticed that Prawn seemed to be slower than usual. Therefore I looked at the code to see if I could find some low hanging fruit to optimize. I **did** find some spots that made Prawn faster again although it seems that Prawn generally got a bit slower over time.

**By applying this PR and the other one for `pdf-core` in https://github.com/prawnpdf/pdf-core/pull/45 we will roughly get the performance of Prawn 2.2.0 back**.

Everything was run with Ruby 3.0.0 and using the latest release of Prawn, 2.4.0. Results are presented first, then how they can be reproduced.

# Results

## Memory allocations

Prawn 2.4.0: *9,070,447*
This PR: *4,097,068*
So about **55% less allocated objects**.

## Run time

Prawn 2.4.0: *7.50 seconds*
This PR: *5.24 seconds*
So about **30% faster**.

## raw_text Benchmark for different Prawn releases

~~~
|--------------------------------------------------------------------|
|                              ||    Time |     Memory |   File size |
|--------------------------------------------------------------------|
| prawn 2.1.0 | 1x             |    930ms |  31.560KiB |     585.793 |
| prawn 2.2.0 | 1x             |    791ms |  32.024KiB |     616.765 |
| prawn 2.3.0 | 1x             |    874ms |  32.036KiB |     616.765 |
| prawn       | 1x             |  1.068ms |  32.120KiB |     616.765 |
| prawn-dev   | 1x             |    811ms |  32.608KiB |     616.765 |
|--------------------------------------------------------------------|
| prawn 2.1.0 | 5x             |  2.534ms |  49.804KiB |   2.929.789 |
| prawn 2.2.0 | 5x             |  2.552ms |  51.280KiB |   3.084.301 |
| prawn 2.3.0 | 5x             |  2.967ms |  51.532KiB |   3.084.301 |
| prawn       | 5x             |  3.759ms |  51.972KiB |   3.084.301 |
| prawn-dev   | 5x             |  2.580ms |  53.332KiB |   3.084.301 |
|--------------------------------------------------------------------|
| prawn 2.1.0 | 10x            |  4.520ms |  71.804KiB |   5.861.065 ||
| prawn 2.2.0 | 10x            |  4.542ms |  76.392KiB |   6.170.089 |
| prawn 2.3.0 | 10x            |  5.768ms |  74.296KiB |   6.170.089 |
| prawn       | 10x            |  7.677ms |  74.988KiB |   6.170.089 |
| prawn-dev   | 10x            |  5.212ms |  77.328KiB |   6.170.089 |
|--------------------------------------------------------------------|
| prawn 2.1.0 | 1x ttf         |  1.624ms |  33.900KiB |     605.210 |
| prawn 2.2.0 | 1x ttf         |  2.922ms |  34.840KiB |     636.143 |
| prawn 2.3.0 | 1x ttf         |  3.012ms |  34.852KiB |     636.141 |
| prawn       | 1x ttf         |  3.267ms |  35.192KiB |     636.141 |
| prawn-dev   | 1x ttf         |  2.991ms |  35.632KiB |     636.141 |
|--------------------------------------------------------------------|
| prawn 2.1.0 | 5x ttf         |  6.429ms |  50.896KiB |   2.943.696 |
| prawn 2.2.0 | 5x ttf         | 12.791ms |  53.952KiB |   3.098.169 |
| prawn 2.3.0 | 5x ttf         | 14.126ms |  54.356KiB |   3.098.167 |
| prawn       | 5x ttf         | 14.448ms |  54.392KiB |   3.098.167 |
| prawn-dev   | 5x ttf         | 12.870ms |  56.648KiB |   3.098.167 |
|--------------------------------------------------------------------|
| prawn 2.1.0 | 5x ttf         |  6.429ms |  50.896KiB |   2.943.696 ||
| prawn 2.2.0 | 10x ttf        | 25.504ms |  77.552KiB |   6.177.034 |
| prawn 2.3.0 | 10x ttf        | 26.662ms |  77.404KiB |   6.177.032 |
| prawn       | 10x ttf        | 28.216ms |  77.636KiB |   6.177.032 |
| prawn-dev   | 10x ttf        | 25.923ms |  80.368KiB |   6.177.032 |
|--------------------------------------------------------------------|
~~~

# How the benchmarks are done

Checkout the [HexaPDF repository](https://github.com/gettalong/hexapdf). Then change into `benchmarks/raw_text` and run `./script.sh -b hexapdf`. You can stop the script one the first benchmark line is run. This will create the `/tmp/10odyssey.txt` file.

The runtime was gotten with the following command:

~~~
time ruby benchmark/raw_text/prawn.rb /tmp/10odyssey.txt /tmp/out.pdf
~~~

The memory allocations were gotten using the following helper script `prof_alloc.rb`:

~~~ ruby
BEGIN {
require 'set'
require 'forwardable'
require 'allocation_tracer'

ObjectSpace::AllocationTracer.setup(%i{path line type})
ObjectSpace::AllocationTracer.trace
}


END {
begin
  results = ObjectSpace::AllocationTracer.stop
  #results.reject! {|k, v| k.first !~ /hexapdf/}
  results.reject {|k, v| v[0] < 10}.sort_by{|k, v| [v[0], k[0]]}.each do |k, v|
    $stderr.puts "#{k[0]}:#{k[1]} - #{k[2]} - #{v[0]}"
  end
  $stderr.puts "Sum: " + results.inject(0) {|sum, (k,v)| sum + v[0]}.to_s
  pp ObjectSpace::AllocationTracer.allocated_count_table
  pp :total => ObjectSpace::AllocationTracer.allocated_count_table.values.inject(:+)
rescue
end
}
~~~

This needs the `allocation_tracer` gem installed. Then run the following command:

~~~
time ruby -I. -r prof_alloc benchmark/raw_text/prawn.rb /tmp/10odyssey.txt /tmp/out.pdf
~~~

The last line shows the total amount of allocated objects.