### PR TITLE
Add Font#font_style and Font#font_family

### DIFF
--- a/lib/prawn/document.rb
+++ b/lib/prawn/document.rb
@@ -218,6 +218,7 @@ module Prawn
 
       @background = options[:background]
       @background_scale = options[:background_scale] || 1
+      @font = nil
       @font_size = 12
 
       @bounding_box = nil

--- a/lib/prawn/fonts/afm.rb
+++ b/lib/prawn/fonts/afm.rb
@@ -72,6 +72,7 @@ module Prawn
         @kern_pair_table = font_data[:kern_pair_table]
         @attributes = font_data[:attributes]
 
+        @family ||= @attributes['familyname']
         @ascender = @attributes['ascender'].to_i
         @descender = @attributes['descender'].to_i
         @line_gap = Float(bbox[3] - bbox[1]) - (@ascender - @descender)

--- a/lib/prawn/fonts/ttf.rb
+++ b/lib/prawn/fonts/ttf.rb
@@ -47,6 +47,7 @@ module Prawn
         super
 
         @ttf = read_ttf_file
+        @family ||= @ttf.name.font_family.first
         @subsets = TTFunk::SubsetCollection.new(@ttf)
         @italic_angle = nil
 

--- a/manual/text/font.rb
+++ b/manual/text/font.rb
@@ -5,11 +5,12 @@
 # If we don't pass it any arguments it will return the current font being used
 # to render text.
 #
-# If we just pass it a font name it will use that font for rendering text
-# through the rest of the document.
+# If we just pass it a font name and an options hash, it will use that font for
+# rendering text through the rest of the document. Both the font name and
+# the options can be omitted. Valid option keys are :style and :size.
 #
-# It can also be used by passing a font name and a block. In this case the
-# specified font will only be used to render text inside the block.
+# It can also be used by passing a font name, an options hash and a block. In this
+# case the specified font will only be used to render text inside the block.
 #
 # The default font is Helvetica.
 
@@ -18,6 +19,7 @@ require_relative '../example_helper'
 filename = File.basename(__FILE__).gsub('.rb', '.pdf')
 Prawn::ManualBuilder::Example.generate(filename) do
   text "Let's see which font we are using: #{font.inspect}"
+  text "Family is #{font_family}, style is #{font_style}, and size is #{font_size}"
 
   move_down 20
   font 'Times-Roman'
@@ -30,6 +32,11 @@ Prawn::ManualBuilder::Example.generate(filename) do
 
   move_down 20
   text 'Written in Times again as we left the previous block.'
+
+  move_down 20
+  font nil, size: 16, style: :bold do
+    text 'Written in 16pt bold, still Times.'
+  end
 
   move_down 20
   text "Let's see which font we are using again: #{font.inspect}"

--- a/manual/text/font_style.rb
+++ b/manual/text/font_style.rb
@@ -1,11 +1,16 @@
 # frozen_string_literal: true
 
+# The <code>font_style</code> method works just like the <code>font</code>
+# method.
+#
+# In fact we can even use <code>font</code> with the <code>:style</code> option
+# to declare which size we want.
+#
+# Another way to change the font size is by supplying the <code>:style</code>
+# option to the text methods.
+#
 # Most font families come with some styles other than normal. Most common are
 # <code>bold</code>, <code>italic</code> and <code>bold_italic</code>.
-#
-# The style can be set the using the <code>:style</code> option, with either the
-# <code>font</code> method which will set the font and style for rest of the
-# document, or with the inline text methods.
 
 require_relative '../example_helper'
 
@@ -20,6 +25,11 @@ Prawn::ManualBuilder::Example.generate(filename) do
     styles.each do |style|
       font example_font, style: style
       text "I'm writing in #{example_font} (#{style})"
+
+      font_style style
+      text "This is also #{style}"
+
+      text "And this is also #{style}", style: style
     end
   end
 end


### PR DESCRIPTION
Just like you can use `font_size` to adjust the size without passing the current font name, add `font_style` to allow changing the style while preserving the font size and family.