### PR TITLE
Test against Ruby 2.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
+          - "2.4.0"
+          - "2.4"
           - "2.5.0"
           - "2.5"
           - "2.6.0"

--- a/prawn.gemspec
+++ b/prawn.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
       '.yardopts'
     ]
   spec.require_path = 'lib'
-  spec.required_ruby_version = '>= 2.5'
+  spec.required_ruby_version = '>= 2.4'
   spec.required_rubygems_version = '>= 1.3.6'
 
   spec.authors = [


### PR DESCRIPTION
Add Ruby 2.4 to the test matrix so we are sure to be able to deploy it