### PR TITLE
Add Ruby 3.1.0 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.0.0
+          ruby-version: 3.1.0
       - name: Gems cache
         uses: actions/cache@v2
         with:
@@ -44,6 +44,8 @@ jobs:
           - "2.7"
           - "3.0.0"
           - "3.0"
+          - "3.1.0"
+          - "3.1"
           - ruby-head
           - jruby-9.2
     steps:


### PR DESCRIPTION
Since [Ruby 3.1.0 is out](https://www.ruby-lang.org/en/news/2021/12/25/ruby-3-1-0-released/), we should add it to the CI workflow.

@pointlessone Can you release a new version? `prawn` 2.4.0 fail with Ruby 3.1.0 without adding `matrix` gem to the Gemfile.