### PR TITLE
Fix bug when encrypted string contains \r

### DIFF
--- a/lib/prawn/security.rb
+++ b/lib/prawn/security.rb
@@ -229,14 +229,14 @@ module PDF
         obj =
           ByteString.new(
             Prawn::Document::Security.encrypt_string(obj, key, id, gen)
-          ).gsub(/[\\\n()]/) { |m| "\\#{m}" }
+          ).gsub(/[\\\r()]/) { |m| "\\#{m}" }
         "(#{obj})"
       when Time
         obj = "#{obj.strftime('D:%Y%m%d%H%M%S%z').chop.chop}'00'"
         obj =
           ByteString.new(
             Prawn::Document::Security.encrypt_string(obj, key, id, gen)
-          ).gsub(/[\\\n()]/) { |m| "\\#{m}" }
+          ).gsub(/[\\\r()]/) { |m| "\\#{m}" }
         "(#{obj})"
       when String
         pdf_object(

--- a/spec/prawn/document/security_spec.rb
+++ b/spec/prawn/document/security_spec.rb
@@ -127,13 +127,14 @@ describe Prawn::Document::Security do
           PDF::Core::LiteralString.new('foo'), '12345', 123, 0
         )
       ).to eq(bin_string("(J\xD6\xE3)"))
+
       expect(
         PDF::Core.encrypted_pdf_object(
-          PDF::Core::LiteralString.new('lhfbqg3do5u0satu3fjf'), nil, 123, 0
+          PDF::Core::LiteralString.new("\xAF\xC5fh\x9A\x14\x97,\xD3,\x06\x87\xCDSS"), nil, 123, 0
         )
       ).to eq(
         bin_string(
-          "(\xF1\x8B\\(\b\xBB\xE18S\x130~4*#\\(%\x87\xE7\x8E\\\n)"
+          "(2&\\(\x02P\x92\x9C\e\xAF\\)\\\r\x83\x94\x11\x0F)"
         )
       )
     end
@@ -141,12 +142,12 @@ describe Prawn::Document::Security do
     it 'encrypts time properly' do
       expect(
         PDF::Core.encrypted_pdf_object(
-          Time.utc(2050, 0o4, 26, 10, 17, 10), '12345', 123, 0
+          Time.utc(10_002, 0o4, 26, 10, 17, 10), '12345', 123, 0
         )
       ).to eq(
         bin_string(
-          "(h\x83\xBE\xDC\xEC\x99\x0F\xD7\\)%\x13\xD4$\xB8\xF0\x16\xB8\x80\xC5"\
-          "\xE91+\xCF)"
+          "(h\x83\xBD\xDC\xE9\x99\\\r\xD3/!\x14\xD5%\xBE\xF6\x17"\
+          "\xA3\x9B\xC5\xFE&+\xD8\x93)"
         )
       )
     end


### PR DESCRIPTION
Serialization of encrypted strings is separate from normal serialization. And here there is the problem that \n was escaped instead of \r. So using \r instead of \n yields the correct result.

Fixes #1229