### PR TITLE
Extract escape and unescape methods in Text::Formatted::Parser module

### DIFF
--- a/lib/prawn/text/formatted/parser.rb
+++ b/lib/prawn/text/formatted/parser.rb
@@ -33,6 +33,14 @@ module Prawn
             Regexp.new(regex_string, Regexp::MULTILINE)
           end
 
+        ESCAPE_CHARS = {
+          '&' => '&amp;',
+          '>' => '&gt;',
+          '<' => '&lt;'
+        }.freeze
+
+        UNESCAPE_CHARS = ESCAPE_CHARS.invert.freeze
+
         def self.format(string, *_args)
           tokens = string.gsub(%r{<br\s*/?>}, "\n").scan(PARSER_REGEX)
           array_from_tokens(tokens)
@@ -94,8 +102,7 @@ module Prawn
               suffix = '</color>'
             end
 
-            string = hash[:text].gsub('&', '&amp;').gsub('>', '&gt;')
-              .gsub('<', '&lt;')
+            string = escape(hash[:text])
             prefix + string + suffix
           end.join
         end
@@ -221,8 +228,7 @@ module Prawn
                 /character_spacing='([^']*)'/.match(token)
               character_spacings << matches[1].to_f unless matches.nil?
             else
-              string = token.gsub('&lt;', '<').gsub('&gt;', '>')
-                .gsub('&amp;', '&')
+              string = unescape(token)
               array << {
                 text: string,
                 styles: styles.dup,
@@ -237,6 +243,14 @@ module Prawn
             end
           end
           array
+        end
+
+        def self.escape(text)
+          text.gsub(Regexp.union(ESCAPE_CHARS.keys), ESCAPE_CHARS)
+        end
+
+        def self.unescape(text)
+          text.gsub(Regexp.union(UNESCAPE_CHARS.keys), UNESCAPE_CHARS)
         end
       end
     end

--- a/spec/prawn/text/formatted/parser_spec.rb
+++ b/spec/prawn/text/formatted/parser_spec.rb
@@ -712,4 +712,22 @@ describe Prawn::Text::Formatted::Parser do
       expect(described_class.array_paragraphs(array)).to eq(target)
     end
   end
+
+  describe '#escape' do
+    it 'escapes < > & chars' do
+      string = "&gt; < gt; hello &lt > &lt; world &amp & &amp; \" ' \n &nbsp;"
+      value = described_class.escape(string)
+      exp = '&amp;gt; &lt; gt; hello &amp;lt &gt; &amp;lt; world'\
+        " &amp;amp &amp; &amp;amp; \" ' \n &amp;nbsp;"
+      expect(value).to eq(exp)
+    end
+  end
+
+  describe '#unescape' do
+    it 'unescapes &gt; &lt; &amp; chars' do
+      string = "&gt; < gt; hello &lt > &lt; world &amp & &amp; \" ' \n &nbsp;"
+      value = described_class.unescape(string)
+      expect(value).to eq("> < gt; hello &lt > < world &amp & & \" ' \n &nbsp;")
+    end
+  end
 end


### PR DESCRIPTION
This PR exposes the escape and unescape logic for Prawn HTML.

This is a rebased version of the change in #889 .  Thanks to @johnnyshields for the original submission.

@pointlessone this can be merged.