### PR TITLE
Clean up document state before raising Prawn::Errors::CannotFit

### DIFF
--- a/lib/prawn/text/formatted/box.rb
+++ b/lib/prawn/text/formatted/box.rb
@@ -234,6 +234,9 @@ module Prawn
             end
           end
 
+          # Only raise CannotFit error after cleaning up document state
+          raise Errors::CannotFit if @line_wrap.cannot_fit
+
           unprinted_text.map do |e|
             e.merge(text: @document.font.to_utf8(e[:text]))
           end
@@ -548,18 +551,13 @@ module Prawn
         # size is reached
         def shrink_to_fit(text)
           loop do
-            if @disable_wrap_by_char && @font_size > @min_font_size
-              begin
-                wrap(text)
-              rescue Errors::CannotFit
-                # Ignore errors while we can still attempt smaller
-                # font sizes.
-              end
-            else
-              wrap(text)
-            end
+            wrap(text)
 
-            break if @everything_printed || @font_size <= @min_font_size
+            unless @disable_wrap_by_char && @font_size > @min_font_size
+              break if @everything_printed ||
+                @line_wrap.cannot_fit ||
+                @font_size <= @min_font_size
+            end
 
             @font_size = [@font_size - 0.5, @min_font_size].max
             @document.font_size = @font_size

--- a/lib/prawn/text/formatted/box.rb
+++ b/lib/prawn/text/formatted/box.rb
@@ -553,11 +553,8 @@ module Prawn
           loop do
             wrap(text)
 
-            unless @disable_wrap_by_char && @font_size > @min_font_size
-              break if @everything_printed ||
-                @line_wrap.cannot_fit ||
-                @font_size <= @min_font_size
-            end
+            break if @font_size <= @min_font_size
+            break if (@everything_printed || @line_wrap.cannot_fit) && !@disable_wrap_by_char
 
             @font_size = [@font_size - 0.5, @min_font_size].max
             @document.font_size = @font_size

--- a/lib/prawn/text/formatted/line_wrap.rb
+++ b/lib/prawn/text/formatted/line_wrap.rb
@@ -22,6 +22,11 @@ module Prawn
         # The number of spaces in the last wrapped line
         attr_reader :space_count
 
+        # This is set to true when there is not enough space.
+        # We then clean up the document state before raising
+        # the CannotFit error.
+        attr_accessor :cannot_fit
+
         # Whether this line is the last line in the paragraph
         def paragraph_finished?
           @newline_encountered || next_string_newline? || @arranger.finished?
@@ -221,6 +226,7 @@ module Prawn
 
           @newline_encountered = false
           @line_full = false
+          @cannot_fit = false
         end
 
         def fragment_finished(fragment)
@@ -245,7 +251,8 @@ module Prawn
             fragment.slice(@fragment_output.length..fragment.length)
           if line_finished? && line_empty? && @fragment_output.empty? &&
               !fragment.strip.empty?
-            raise Prawn::Errors::CannotFit
+            @cannot_fit = true
+            return
           end
 
           @arranger.update_last_string(

--- a/spec/prawn/text/formatted/line_wrap_spec.rb
+++ b/spec/prawn/text/formatted/line_wrap_spec.rb
@@ -36,6 +36,7 @@ describe Prawn::Text::Formatted::LineWrap do
       document: pdf
     )
     expect(line).to be_empty
+    expect(line_wrap.cannot_fit).to eq false
   end
 
   it 'tokenizes a string using the scan_pattern' do
@@ -76,21 +77,21 @@ describe Prawn::Text::Formatted::LineWrap do
         document: pdf
       )
       expect(string).to eq('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
+      expect(line_wrap.cannot_fit).to eq false
     end
 
-    it 'raise_errors CannotFit if a too-small width is given' do
+    it 'sets cannot_fit to true if a too-small width is given' do
       array = [
         { text: ' hello world, ' },
         { text: 'goodbye  ', style: [:bold] }
       ]
       arranger.format_array = array
-      expect do
-        line_wrap.wrap_line(
-          arranger: arranger,
-          width: 1,
-          document: pdf
-        )
-      end.to raise_error(Prawn::Errors::CannotFit)
+      line_wrap.wrap_line(
+        arranger: arranger,
+        width: 1,
+        document: pdf
+      )
+      expect(line_wrap.cannot_fit).to eq true
     end
 
     it 'breaks on space' do
@@ -102,6 +103,7 @@ describe Prawn::Text::Formatted::LineWrap do
         document: pdf
       )
       expect(string).to eq('hello')
+      expect(line_wrap.cannot_fit).to eq false
     end
 
     it 'breaks on zero-width space' do


### PR DESCRIPTION
Fixes #1073 

This is a rebased and rubocop-ed version of #1074   Thanks to @ndbroadbent for the original contribution.

I want to track down exactly what state is being cached (and not cleared) before this is merged, so I'm going to leave it as a draft PR for now.