### PR TITLE
Really fix encryption issue

### DIFF
--- a/lib/prawn/security.rb
+++ b/lib/prawn/security.rb
@@ -229,14 +229,14 @@ module PDF
         obj =
           ByteString.new(
             Prawn::Document::Security.encrypt_string(obj, key, id, gen)
-          ).gsub(/[\\\r()]/) { |m| "\\#{m}" }
+          ).gsub(/[\\\r()]/, STRING_ESCAPE_MAP)
         "(#{obj})"
       when Time
         obj = "#{obj.strftime('D:%Y%m%d%H%M%S%z').chop.chop}'00'"
         obj =
           ByteString.new(
             Prawn::Document::Security.encrypt_string(obj, key, id, gen)
-          ).gsub(/[\\\r()]/) { |m| "\\#{m}" }
+          ).gsub(/[\\\r()]/, STRING_ESCAPE_MAP)
         "(#{obj})"
       when String
         pdf_object(

--- a/spec/prawn/document/security_spec.rb
+++ b/spec/prawn/document/security_spec.rb
@@ -134,7 +134,7 @@ describe Prawn::Document::Security do
         )
       ).to eq(
         bin_string(
-          "(2&\\(\x02P\x92\x9C\e\xAF\\)\\\r\x83\x94\x11\x0F)"
+          "(2&\\(\x02P\x92\x9C\e\xAF\\)\\r\x83\x94\x11\x0F)"
         )
       )
     end
@@ -146,7 +146,7 @@ describe Prawn::Document::Security do
         )
       ).to eq(
         bin_string(
-          "(h\x83\xBD\xDC\xE9\x99\\\r\xD3/!\x14\xD5%\xBE\xF6\x17"\
+          "(h\x83\xBD\xDC\xE9\x99\\r\xD3/!\x14\xD5%\xBE\xF6\x17"\
           "\xA3\x9B\xC5\xFE&+\xD8\x93)"
         )
       )


### PR DESCRIPTION
The previous fix incorrectly escaped "\r" as "\\\r". However, it needs
to be escaped as "\\r" (so backslash followed by letter r).

This pull request needs https://github.com/prawnpdf/pdf-core/pull/55 to work since there the needed constant is defined.