### PR TITLE
Fix images.rb document

### DIFF
--- a/lib/prawn/images.rb
+++ b/lib/prawn/images.rb
@@ -58,7 +58,7 @@ module Prawn
     #   require "open-uri"
     #
     #   Prawn::Document.generate("remote_images.pdf") do
-    #     image open("http://prawnpdf.org/media/prawn_logo.png")
+    #     image URI.open("http://prawnpdf.org/media/prawn_logo.png")
     #   end
     #
     # This method returns an image info object which can be used to check the


### PR DESCRIPTION
https://github.com/prawnpdf/prawn/blob/30da9f40e5f308f69198879301d65cacca214b69/lib/prawn/images.rb#L58-L62

I ran the code with the above documentation and got the following error.

~~~ruby
require "open-uri"
image open("https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png")
~~~

~~~
No such file or directory @ rb_sysopen - https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png
~~~

Perhaps the  [Kernel.#open](https://docs.ruby-lang.org/en/3.1/Kernel.html#method-i-open) has been executed.

So I modified it as follows and it performed as expected.

~~~ruby
image URI.open("https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png")
~~~

If there is another way to solve this problem, I would appreciate it if you could let me know. Thank you.