### PR TITLE
fix: allow to use text and text_box in sequence with inline format flag

### DIFF
--- a/lib/prawn/text.rb
+++ b/lib/prawn/text.rb
@@ -159,7 +159,7 @@ module Prawn
       if p
         p = [] unless p.is_a?(Array)
         options.delete(:inline_format)
-        array = text_formatter.format(string, *p)
+        array = string.is_a?(Array) ? string : text_formatter.format(string, *p)
       else
         array = [{ text: string }]
       end

--- a/lib/prawn/text/box.rb
+++ b/lib/prawn/text/box.rb
@@ -111,7 +111,7 @@ module Prawn
         if options[:inline_format]
           p = options.delete(:inline_format)
           p = [] unless p.is_a?(Array)
-          array = text_formatter.format(string, *p)
+          array = string.is_a?(Array) ? string : text_formatter.format(string, *p)
           Text::Formatted::Box.new(array, options)
         else
           Text::Box.new(string, options)


### PR DESCRIPTION
- [x] !  allow to use text and text_box in sequence with inline format flag