### PR TITLE
Add line_widths to Prawn::Text::Formatted::Box

### DIFF
--- a/lib/prawn/text/formatted/box.rb
+++ b/lib/prawn/text/formatted/box.rb
@@ -130,6 +130,8 @@ module Prawn
         attr_reader :descender
         # The leading used during printing
         attr_reader :leading
+        # The width of each line
+        attr_reader :line_widths
 
         def line_gap
           line_height - (ascender + descender)
@@ -193,6 +195,8 @@ module Prawn
             size: options[:size],
             style: options[:style]
           }
+
+          @line_widths = []
 
           super(formatted_text, options)
         end

--- a/lib/prawn/text/formatted/wrap.rb
+++ b/lib/prawn/text/formatted/wrap.rb
@@ -106,6 +106,8 @@ module Prawn
             accumulated_width += fragment_this_line.width
           end
 
+          @line_widths.push(accumulated_width)
+
           @printed_lines << printed_fragments.map do |s|
             s.dup.force_encoding(::Encoding::UTF_8)
           end.join

--- a/spec/prawn/text/formatted/box_spec.rb
+++ b/spec/prawn/text/formatted/box_spec.rb
@@ -906,4 +906,52 @@ describe Prawn::Text::Formatted::Box do
       )
     end
   end
+
+  describe 'Text::Formatted::box#line_widths' do
+    it 'handles newlines' do
+      accented_char = win1252_string("\xE9"); # é in win-1252
+      array = [
+        {
+          text: "Oh hai t#{accented_char}xt rect.\nOh hai text rect thats longer.",
+          font: 'Times-Roman',
+          size: 12
+        }
+      ]
+
+      options = { document: pdf }
+      text_box = described_class.new(array, options)
+      text_box.render
+      expect(text_box.line_widths).to eq(
+        [
+          77.136,
+          135.804
+        ]
+      )
+    end
+
+    it 'handles fallback fonts' do
+      file = "#{Prawn::DATADIR}/fonts/gkai00mp.ttf"
+      pdf.font_families['Kai'] = {
+        normal: { file: file, font: 'Kai' }
+      }
+      array = [
+        {
+          text: "hello你好\n再见goodbye",
+          font: 'Times-Roman',
+          size: 12
+        }
+      ]
+
+      options = { document: pdf, fallback_fonts: ['Kai'] }
+      text_box = described_class.new(array, options)
+      text_box.render
+
+      expect(text_box.line_widths).to eq(
+        [
+          48.000,
+          65.328
+        ]
+      )
+    end
+  end
 end


### PR DESCRIPTION
Add line_widths to Prawn::Text::Formatted::Box, which holds an Array with the width of each line.  This is useful with the dry_run option to determine how wide text will be, so that, for example, one could calculate some layout before rendering the text.

Unlike Document#width_of, this goes through the whole rendering pipeline, so it handles things like fallback fonts.  It also handles multiple lines directly.
