### PR TITLE
Prawn::View#method_missing drops keyword arguments on Ruby 3.x

### DIFF
--- a/lib/prawn/view.rb
+++ b/lib/prawn/view.rb
@@ -69,10 +69,10 @@ module Prawn
 
     # Delegates all unhandled calls to object returned by +document+ method.
     # (which is an instance of Prawn::Document by default)
-    def method_missing(method_name, *arguments, &block)
+    def method_missing(method_name, *args, **kwargs, &block)
       return super unless document.respond_to?(method_name)
 
-      document.public_send(method_name, *arguments, &block)
+      document.public_send(method_name, *args, **kwargs, &block)
     end
 
     def respond_to_missing?(method_name, _include_all = false)

--- a/spec/prawn/view_spec.rb
+++ b/spec/prawn/view_spec.rb
@@ -11,13 +11,22 @@ describe Prawn::View do
 
   it 'delegates unhandled methods to object returned by document method' do
     doc = instance_double('Document')
+    allow(doc).to receive(:fill_gradient) do |*args, **kwargs, &block|
+      { args: args, kwargs: kwargs, block: block }
+    end
+
     allow(view_object).to receive(:document).and_return(doc)
 
-    allow(doc).to receive(:some_delegated_method)
+    block = proc {}
+    arguments = view_object.fill_gradient('positional', keyword: 'argument', &block)
 
-    view_object.some_delegated_method
-
-    expect(doc).to have_received(:some_delegated_method)
+    expect(arguments).to eq(
+      {
+        args: ['positional'],
+        kwargs: { keyword: 'argument' },
+        block: block
+      }
+    )
   end
 
   it 'allows a block-like DSL via the update method' do


### PR DESCRIPTION
Hi! This is my first message about this issue — I figured starting with a PR would make the issue more clear. I'm betting on CI running this code on older versions of Ruby to make sure this doesn't break anything by accident.

Ruby 3.x changes behavior of keyword arguments when used with single splat `*arguments`. `Prawn::View#method_missing` delegates missing methods to the document, but keyword arguments are dropped in the delegation in Ruby 3.

There aren't that many Prawn::Document methods that takes keyword arguments (I pretty much only found the gradient methods). We ran into this in our own code because we've added a few helper methods to Prawn::Document that _does_ take keyword arguments, and we noticed in our upgrade to Ruby 3.x we couldn't use those methods.

In our own code we've temporarily fixed this with a monkey patch:

```ruby
module Prawn::View
  ruby2_keywords :method_missing
end
```

Here's an example of behavior changed in Ruby 3.x vs 2.x:

```ruby
def original(*args, **kwargs)
  p({ args: args, kwargs: kwargs })
end

def forward(*args)
  original(*args)
end

forward(1, 2, x: "x", y: "y")
# Ruby 2.7: {:args=>[1, 2], :kwargs=>{:x=>"x", :y=>"y"}}
# Ruby 3.x: {:args=>[1, 2, {:x=>"x", :y=>"y"}], :kwargs=>{}}
```