### PR TITLE
Adiciona tag <p> no parse para renderizar relatório

### DIFF
--- a/lib/prawn/document.rb
+++ b/lib/prawn/document.rb
@@ -683,21 +683,17 @@ module Prawn
     end
 
     def apply_margin_options(options)
-      if options[:margin]
-        # Treat :margin as CSS shorthand with 1-4 values.
-        margin = Array(options[:margin])
-        positions = { 4 => [0, 1, 2, 3], 3 => [0, 1, 2, 1],
-                      2 => [0, 1, 0, 1], 1 => [0, 0, 0, 0] }[margin.length]
+      sides = [:top, :right, :bottom, :left]
+      margin = Array(options[:margin])
 
-        [:top, :right, :bottom, :left].zip(positions).each do |p, i|
-          options[:"#{p}_margin"] ||= margin[i]
-        end
-      end
+      # Treat :margin as CSS shorthand with 1-4 values.
+      positions = { 4 => [0, 1, 2, 3], 3 => [0, 1, 2, 1],
+                    2 => [0, 1, 0, 1], 1 => [0, 0, 0, 0],
+                    0 => [] }[margin.length]
 
-      [:left, :right, :top, :bottom].each do |side|
-        if margin = options[:"#{side}_margin"]
-          state.page.margins[side] = margin
-        end
+      sides.zip(positions).each do |side, pos|
+        new_margin = options["#{side}_margin"] || (margin[pos] if pos)
+        state.page.margins[side] = new_margin if new_margin
       end
     end
 

--- a/lib/prawn/document.rb
+++ b/lib/prawn/document.rb
@@ -683,17 +683,21 @@ module Prawn
     end
 
     def apply_margin_options(options)
-      sides = [:top, :right, :bottom, :left]
-      margin = Array(options[:margin])
+      if options[:margin]
+        # Treat :margin as CSS shorthand with 1-4 values.
+        margin = Array(options[:margin])
+        positions = { 4 => [0, 1, 2, 3], 3 => [0, 1, 2, 1],
+                      2 => [0, 1, 0, 1], 1 => [0, 0, 0, 0] }[margin.length]
 
-      # Treat :margin as CSS shorthand with 1-4 values.
-      positions = { 4 => [0, 1, 2, 3], 3 => [0, 1, 2, 1],
-                    2 => [0, 1, 0, 1], 1 => [0, 0, 0, 0],
-                    0 => [] }[margin.length]
+        [:top, :right, :bottom, :left].zip(positions).each do |p, i|
+          options[:"#{p}_margin"] ||= margin[i]
+        end
+      end
 
-      sides.zip(positions).each do |side, pos|
-        new_margin = options["#{side}_margin"] || (margin[pos] if pos)
-        state.page.margins[side] = new_margin if new_margin
+      [:left, :right, :top, :bottom].each do |side|
+        if margin = options[:"#{side}_margin"]
+          state.page.margins[side] = margin
+        end
       end
     end
 

--- a/lib/prawn/font/afm.rb
+++ b/lib/prawn/font/afm.rb
@@ -99,6 +99,7 @@ module Prawn
       # is replaced with a string in WinAnsi encoding.
       #
       def normalize_encoding(text)
+        text = remove_not_encodable_chars(text)
         text.encode("windows-1252")
       rescue ::Encoding::InvalidByteSequenceError,
              ::Encoding::UndefinedConversionError
@@ -141,6 +142,20 @@ module Prawn
       end
 
       private
+
+      # Remove characters that can not be encoded, replacing with "?"
+      def remove_not_encodable_chars(text)
+        new_text = ""
+        text.each_char do |char|
+          begin
+            new_char = char.encode("windows-1252")
+          rescue Exception
+            new_char = "?"
+          end
+          new_text += new_char
+        end
+        new_text
+      end
 
       def register(subset)
         font_dict = {

--- a/lib/prawn/text/formatted/parser.rb
+++ b/lib/prawn/text/formatted/parser.rb
@@ -19,6 +19,7 @@ module Prawn
                          "<b>|</b>|" \
                          "<i>|</i>|" \
                          "<u>|</u>|" \
+                         "<p>|</p>|" \
                          "<strikethrough>|</strikethrough>|" \
                          "<sub>|</sub>|" \
                          "<sup>|</sup>|" \
@@ -41,12 +42,14 @@ module Prawn
           prefixes = { :bold => "<b>",
                        :italic => "<i>",
                        :underline => "<u>",
+                       :paragraph => "<p>",
                        :strikethrough => "<strikethrough>",
                        :subscript => "<sub>",
                        :superscript => "<sup>" }
           suffixes = { :bold => "</b>",
                        :italic => "</i>",
                        :underline => "</u>",
+                       :paragraph => "</p>",
                        :strikethrough => "</strikethrough>",
                        :subscript => "</sub>",
                        :superscript => "</sup>" }
@@ -136,6 +139,8 @@ module Prawn
               styles << :italic
             when "<u>"
               styles << :underline
+            when "<p>"
+              styles << :paragraph
             when "<strikethrough>"
               styles << :strikethrough
             when "<sub>"
@@ -148,6 +153,8 @@ module Prawn
               styles.delete(:italic)
             when "</u>"
               styles.delete(:underline)
+            when "</p>"
+              styles.delete(:paragraph)
             when "</strikethrough>"
               styles.delete(:strikethrough)
             when "</sub>"

--- a/spec/document_spec.rb
+++ b/spec/document_spec.rb
@@ -151,6 +151,14 @@ describe "Prawn::Document#float" do
   end
 end
 
+describe "Prawn::Document#start_new_page" do
+  it "doesn't modify the options hash" do
+    expect {
+      Prawn::Document.new.start_new_page({ margin: 0 }.freeze)
+    }.not_to raise_error
+  end
+end
+
 describe "The page_number method" do
   it "should be 1 for a new document" do
     pdf = Prawn::Document.new

--- a/spec/document_spec.rb
+++ b/spec/document_spec.rb
@@ -151,14 +151,6 @@ describe "Prawn::Document#float" do
   end
 end
 
-describe "Prawn::Document#start_new_page" do
-  it "doesn't modify the options hash" do
-    expect {
-      Prawn::Document.new.start_new_page({ margin: 0 }.freeze)
-    }.not_to raise_error
-  end
-end
-
 describe "The page_number method" do
   it "should be 1 for a new document" do
     pdf = Prawn::Document.new


### PR DESCRIPTION
## Contexto
Estava sendo renderizado tag html nos relatórios onde o editor de texto summernote foi adicionado.

## Solução
Foi adicionado uma nova tag html `<p>` para que o relatório pudesse ser renderizado sem a mostra da tag no campo de texto