### PR TITLE
Fix Rakefile so running rake without bundling gives a better error

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'bundler/setup'
 
 GEMSPEC = File.expand_path('prawn.gemspec', __dir__)

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'bundler/setup'
 
 GEMSPEC = File.expand_path('prawn.gemspec', __dir__)
 require 'prawn/dev/tasks'


### PR DESCRIPTION
I was trying to make some changes locally, and followed the README's direction to run `rake` to test. It failed though:

    ❯ rake
    rake aborted!
    LoadError: cannot load such file -- prawn/dev/tasks
    /Users/josh.nichols/workspace/prawn/Rakefile:4:in `<top (required)>'
    (See full trace by running task with --trace)

The fix is `bundle install`, but it would be nice to be directed to do that. This change uses `bundler/setup` to try to load bundled dependencies, and if something isn't met for some reason, it fails with a more instructive message:

    ❯ rake
    Could not find prawn-dev-0.3.0 in locally installed gems
    Run `bundle install` to install missing gems.