### PR TITLE
Turn on RSpec color output on CI

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,7 +26,7 @@ RSpec.configure do |config|
   config.include EncodingHelpers
 
   # force colors on during CI for better readability, since GitHub Actions supports it
-  config.color_enabled = true if ENV['CI']
+  config.color_mode = :on if ENV['CI']
 end
 
 def create_pdf(klass = Prawn::Document, &block)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,6 +24,9 @@ Dir[File.join(__dir__, 'extensions', '**', '*.rb')].sort.each { |f| require f }
 
 RSpec.configure do |config|
   config.include EncodingHelpers
+
+  # force colors on during CI for better readability, since GitHub Actions supports it
+  config.color_enabled = true if ENV['CI']
 end
 
 def create_pdf(klass = Prawn::Document, &block)


### PR DESCRIPTION
I've found color output super useful reading CI output to spot what failed. `.rspec` has `--color`, but this will only turn on color if it can detect that the terminal supports it. Unfortunately, it determines this by checking if it's a TTY, which GitHub Actions would not be.

This explicitly turns on color when the CI environment variable is present.

References:

- CI environment variable: https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
- Color support: https://github.blog/2020-09-23-a-better-logs-experience-with-github-actions/