### PR TITLE
Use default version of matrix

### DIFF
--- a/prawn.gemspec
+++ b/prawn.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   ]
   spec.licenses = %w[PRAWN GPL-2.0 GPL-3.0]
 
-  spec.add_dependency('matrix', '~> 0.4')
+  spec.add_dependency('matrix', '~> 0.4') if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.1')
   spec.add_dependency('pdf-core', '~> 0.9.0')
   spec.add_dependency('ttfunk', '~> 1.7')
 


### PR DESCRIPTION
Hi,

In ruby < 3.1, we do not need this gems (it is bundled by default).

Regards,


---------

Related to https://github.com/prawnpdf/prawn/issues/1303