### PR TITLE
Fix typo in images function docs

### DIFF
--- a/lib/prawn/images.rb
+++ b/lib/prawn/images.rb
@@ -35,7 +35,7 @@ module Prawn
     #   not be changed.
     # @option options :position [:left, :center, :right, Number]
     #   Horizontal position relative to the current bounding box.
-    # @option options :vposition [:topm :center, :bottom, Number]
+    # @option options :vposition [:top, :center, :bottom, Number]
     #   Vertical position relative to the current bounding box.
     # @option options :height [Number] (actual height of the image)
     #   The height of the image.


### PR DESCRIPTION
There is a typo in the images function docs that shows a nonexistent option `topm`.