### PR TITLE
Fixes circular require warning

### DIFF
--- a/lib/prawn/fonts.rb
+++ b/lib/prawn/fonts.rb
@@ -6,7 +6,6 @@ module Prawn
   end
 end
 
-require_relative 'font'
 require_relative 'fonts/afm'
 require_relative 'fonts/ttf'
 require_relative 'fonts/dfont'


### PR DESCRIPTION
fixes:

```
warning: lib/prawn/fonts.rb:9: warning: loading in progress, circular require considered harmful - lib/prawn/font.rb
```