### PR TITLE
feat: Pixels to Points

### DIFF
--- a/lib/prawn/measurement_extensions.rb
+++ b/lib/prawn/measurement_extensions.rb
@@ -79,4 +79,11 @@ class Numeric
   def pt
     pt2pt(self)
   end
+
+  # Convert from pixels to points.
+  #
+  # @return [Number]
+  def px
+    px2pt(self)
+  end
 end

--- a/lib/prawn/measurements.rb
+++ b/lib/prawn/measurements.rb
@@ -124,6 +124,14 @@ module Prawn
     def pt2mm(pt)
       pt * 1 / mm2pt(1) # (25.4 / 72)
     end
+
+    # Convert pixels to points.
+    #
+    # @param px [Number]
+    # @return [Number]
+    def px2pt(px)
+      px * 72 / 96.0
+    end
   end
 end
 # rubocop: enable Naming/MethodParameterName

--- a/spec/prawn/measurements_extensions_spec.rb
+++ b/spec/prawn/measurements_extensions_spec.rb
@@ -19,6 +19,7 @@ describe Prawn::Measurements do
       expect(1.ft).to eq(72 * 12)
       expect(1.yd).to eq(72 * 12 * 3)
       expect(1.pt).to eq(1)
+      expect(1.px).to eq(0.75)
     end
   end
 end


### PR DESCRIPTION
### Motivation
Convert pixels to points.
Useful when you are working with images.

Example:
```ruby
1.px
=> 0.75 # points

800.px
=> 600.0 # points
```