### PR TITLE
Bump `prawn-dev` and fix RuboCop offenses

### DIFF
--- a/lib/prawn.rb
+++ b/lib/prawn.rb
@@ -37,7 +37,7 @@ module Prawn
   # @return [Boolean]
   attr_accessor :debug
 
-  module_function :debug, :debug=
+  module_function :debug, :debug= # rubocop:todo Style/AccessModifierDeclarations
 
   module_function
 

--- a/lib/prawn.rb
+++ b/lib/prawn.rb
@@ -37,7 +37,7 @@ module Prawn
   # @return [Boolean]
   attr_accessor :debug
 
-  module_function :debug, :debug= # rubocop:todo Style/AccessModifierDeclarations
+  module_function :debug, :debug= # rubocop:disable Style/AccessModifierDeclarations
 
   module_function
 

--- a/prawn.gemspec
+++ b/prawn.gemspec
@@ -53,6 +53,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency('pdf-inspector', '>= 1.2.1', '< 2.0.a')
   spec.add_development_dependency('pdf-reader', '~> 1.4', '>= 1.4.1')
-  spec.add_development_dependency('prawn-dev', '~> 0.4.0')
+  spec.add_development_dependency('prawn-dev', '~> 0.5.0')
   spec.add_development_dependency('prawn-manual_builder', '~> 0.4.0')
 end

--- a/spec/prawn/document/security_spec.rb
+++ b/spec/prawn/document/security_spec.rb
@@ -82,7 +82,7 @@ describe Prawn::Document::Security do
     let(:pdf) do
       Prawn::Document.new do |pdf|
         class << pdf
-          public :owner_password_hash, :user_password_hash, :user_encryption_key
+          public :owner_password_hash, :user_password_hash, :user_encryption_key # rubocop:todo Style/AccessModifierDeclarations
         end
         pdf.encrypt_document(
           user_password: 'foo',

--- a/spec/prawn/document/security_spec.rb
+++ b/spec/prawn/document/security_spec.rb
@@ -82,7 +82,7 @@ describe Prawn::Document::Security do
     let(:pdf) do
       Prawn::Document.new do |pdf|
         class << pdf
-          public :owner_password_hash, :user_password_hash, :user_encryption_key # rubocop:todo Style/AccessModifierDeclarations
+          public :owner_password_hash, :user_password_hash, :user_encryption_key # rubocop:disable Style/AccessModifierDeclarations
         end
         pdf.encrypt_document(
           user_password: 'foo',


### PR DESCRIPTION
- Following on from https://github.com/prawnpdf/prawn-dev/pull/2  like I said I would.
- Interestingly RuboCop didn’t complain about what I expected it to complain about (the non-parenthesized `puts`, for one) so I don’t know what I’m doing wrong?