### PR TITLE
Revise confusing 'valign' error message for text boxes

### DIFF
--- a/lib/prawn/text/formatted/box.rb
+++ b/lib/prawn/text/formatted/box.rb
@@ -589,7 +589,7 @@ module Prawn
             @at[1] -= (@height - height)
           else
             raise ArgumentError,
-              'valign must be one of :left, :right or :center symbols'
+              'valign must be one of :top, :bottom or :center symbols'
           end
 
           @height = height

--- a/spec/prawn/text/formatted/box_spec.rb
+++ b/spec/prawn/text/formatted/box_spec.rb
@@ -859,7 +859,7 @@ describe Prawn::Text::Formatted::Box do
       text_box = described_class.new(array, options)
       expect { text_box.render }.to raise_error(
         ArgumentError,
-        'valign must be one of :left, :right or :center symbols',
+        'valign must be one of :top, :bottom or :center symbols',
       )
     end
 

--- a/spec/prawn/text/formatted/box_spec.rb
+++ b/spec/prawn/text/formatted/box_spec.rb
@@ -869,7 +869,7 @@ describe Prawn::Text::Formatted::Box do
       text_box = described_class.new(array, options)
       expect { text_box.render }.to raise_error(
         ArgumentError,
-        'valign must be one of :left, :right or :center symbols',
+        'valign must be one of :top, :bottom or :center symbols',
       )
     end
   end


### PR DESCRIPTION
Problem:
Using an unsupported symbol for the value of 'valign' on a text box throws a misleading error message. 

Solution:
This adjusts the error message to match the actual values supported by the code.