### PR TITLE
CI: Add Ruby 3.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
           - "3.2"
           - "3.3.0"
           - "3.3"
+          - "3.4"
           - "head"
           - "jruby-9.4"
         dependencies:


### PR DESCRIPTION
This PR adds the latest generally-available Ruby to the CI build matrix.

Glad to see it 🟢 !