### PR TITLE
fix font widths discrepancy

### DIFF
--- a/lib/prawn/font.rb
+++ b/lib/prawn/font.rb
@@ -362,6 +362,10 @@ module Prawn
     # @return [Hash]
     attr_reader :options
 
+    # Whether the font is a full embedding.
+    # @return [Boolean]
+    attr_reader :full_font_embedding
+
     # Shortcut interface for constructing a font object. Filenames of the form
     # `*.ttf` will call {Fonts::TTF#initialize TTF.new}, `*.otf` calls
     # {Fonts::OTF#initialize OTF.new}, `*.dfont` calls {Fonts::DFont#initialize
@@ -535,8 +539,6 @@ module Prawn
     end
 
     private
-
-    attr_reader :full_font_embedding
 
     # generate a font identifier that hasn't been used on the current page yet
     #

--- a/lib/prawn/fonts/ttf.rb
+++ b/lib/prawn/fonts/ttf.rb
@@ -522,7 +522,7 @@ module Prawn
 
       def embed_composite_font(reference, font)
         if font_type(font) == :unknown
-          raise Error, %(Composite font embedding is not uspported for font "#{font.name}.")
+          raise Error, %(Composite font embedding is not supported for font "#{font.name}.")
         end
 
         true_type = font_type(font) == :true_type
@@ -565,7 +565,7 @@ module Prawn
         to_unicode.stream.compress! if @document.compression_enabled?
 
         widths =
-          font.horizontal_metrics.widths.map { |w| (w * scale_factor).round }
+          font.horizontal_metrics.widths.map { |w| Integer(w * scale_factor) }
 
         child_font = @document.ref!(
           Type: :Font,


### PR DESCRIPTION
There was a discrepancy where `embed_simple_font` was truncating widths, but `embed_composite_font` was rounding them.  This produced a visual difference when embedding a font with `subset: true` vs. `subset: false`.  This PR fixes that.

I am also making the `full_font_embedding` attribute public, because I need it for [this PR](https://github.com/prawnpdf/pdf-core/pull/64) to pdf-core.