### PR TITLE
Fix TypeError in Grid#apply_gutter when gutter is not specified

### DIFF
--- a/lib/prawn/grid.rb
+++ b/lib/prawn/grid.rb
@@ -149,8 +149,8 @@ module Prawn
           @row_gutter = @gutter
           @column_gutter = @gutter
         else
-          @row_gutter = Float(options[:row_gutter])
-          @column_gutter = Float(options[:column_gutter])
+          @row_gutter = Float(options.fetch(:row_gutter, 0))
+          @column_gutter = Float(options.fetch(:column_gutter, 0))
           @gutter = 0
         end
       end

--- a/spec/prawn/document_grid_spec.rb
+++ b/spec/prawn/document_grid_spec.rb
@@ -24,6 +24,27 @@ describe Prawn::Document do
       expect(pdf.grid.gutter).to eq(0.1)
     end
 
+    it 'defaults to zero gutter when no gutter is defined' do
+      pdf.define_grid(columns: 5, rows: 8)
+      expect(pdf.grid.gutter).to eq(0)
+      expect(pdf.grid.row_gutter).to eq(0)
+      expect(pdf.grid.column_gutter).to eq(0)
+    end
+
+    it 'defaults column_gutter to zero when only row_gutter is given' do
+      pdf.define_grid(columns: 5, rows: 8, row_gutter: 10)
+      expect(pdf.grid.row_gutter).to eq(10)
+      expect(pdf.grid.column_gutter).to eq(0)
+      expect(pdf.grid.gutter).to eq(0)
+    end
+
+    it 'defaults row_gutter to zero when only column_gutter is given' do
+      pdf.define_grid(columns: 5, rows: 8, column_gutter: 10)
+      expect(pdf.grid.row_gutter).to eq(0)
+      expect(pdf.grid.column_gutter).to eq(10)
+      expect(pdf.grid.gutter).to eq(0)
+    end
+
     describe 'when a grid is defined' do
       let(:num_columns) { 5 }
       let(:num_rows) { 8 }


### PR DESCRIPTION
Closes #1343
Closes #1344

## Problem

Since commit be66ddd ("Update code style"), `define_grid` raises a `TypeError` when called without gutter options:

```ruby
define_grid(columns: 5, rows: 8)
# => TypeError: can't convert nil into Float
```

The same error occurs when only one of `row_gutter` or `column_gutter` is specified:

```ruby
define_grid(columns: 5, rows: 8, row_gutter: 10)
# => TypeError: can't convert nil into Float (from column_gutter)
```

The cause is that `apply_gutter` was changed from `options[:row_gutter].to_f` (which returns `0.0` for `nil`) to `Float(options[:row_gutter])` (which raises `TypeError` for `nil`).

## Solution

Use `Hash#fetch` with a default value of `0`:

```ruby
@row_gutter = Float(options.fetch(:row_gutter, 0))
@column_gutter = Float(options.fetch(:column_gutter, 0))
```

This preserves the stricter `Float()` conversion for invalid values while defaulting to zero when options are omitted.

## Tests

Added three test cases covering:

- No gutter options specified at all
- Only `row_gutter` specified (`column_gutter` defaults to 0)
- Only `column_gutter` specified (`row_gutter` defaults to 0)

## Note

@afdev82 previously addressed this in their fork ([adnotam/prawn@327de7e](https://github.com/adnotam/prawn/commit/327de7e)) but a PR was not opened against upstream. This PR follows a similar approach.
